### PR TITLE
Multiple vectors per item

### DIFF
--- a/botnim/benchmark/evaluate_queries.py
+++ b/botnim/benchmark/evaluate_queries.py
@@ -32,7 +32,11 @@ class QueryEvaluation:
 
 def normalize_path(path: str) -> str:
     """Extract and normalize just the document name from a path."""
-    return os.path.basename(str(path).strip())
+    filename = os.path.basename(str(path).strip())
+    # Remove leading underscore if present
+    if filename.startswith('_'):
+        filename = filename[1:]
+    return filename
 
 def parse_store_id(store_id: str) -> Tuple[str, str, str]:
     """Parse store_id into bot name, context, and environment."""

--- a/botnim/cli.py
+++ b/botnim/cli.py
@@ -64,12 +64,19 @@ def reverse_lines(text: str) -> str:
 @click.option('--num-results', type=int, default=7, help='Number of results to return')
 @click.option('--full', '-f', is_flag=True, help='Show full content of results')
 @click.option('--rtl', is_flag=True, help='Display results in right-to-left order')
-def search(environment: str, bot: str, context: str, query_text: str, num_results: int, full: bool, rtl: bool):
+@click.option('--explain', is_flag=True, help='Show detailed scoring explanation for results')
+def search(environment: str, bot: str, context: str, query_text: str, num_results: int, full: bool, rtl: bool, explain: bool):
     """Search the vector store with the given query."""
     logger.info(f"Searching {bot}/{context} in {environment} with query: '{query_text}', num_results: {num_results}")
     try:
         vector_store_id = VectorStoreES.encode_index_name(bot, context, is_production(environment))
-        search_results = run_query(store_id=vector_store_id, query_text=query_text, num_results=num_results, format="text")
+        search_results = run_query(
+            store_id=vector_store_id, 
+            query_text=query_text, 
+            num_results=num_results, 
+            format="text",
+            explain=explain
+        )
         if rtl:
             search_results = reverse_lines(mirror_brackets(search_results))
         click.echo(search_results)

--- a/botnim/vector_store/vector_score_explainer.py
+++ b/botnim/vector_store/vector_score_explainer.py
@@ -1,0 +1,94 @@
+"""Helper functions for explaining vector similarity scores"""
+
+import numpy as np
+from typing import List, Dict, Any, Optional
+from ..config import get_logger
+
+logger = get_logger(__name__)
+
+def cosine_similarity(vec1: List[float], vec2: List[float]) -> float:
+    """Calculate cosine similarity between two vectors"""
+    vec1_np = np.array(vec1)
+    vec2_np = np.array(vec2)
+    similarity = float(np.dot(vec1_np, vec2_np) / (np.linalg.norm(vec1_np) * np.linalg.norm(vec2_np)))
+    logger.debug(f"Calculated cosine similarity: {similarity:.4f}")
+    return similarity
+
+def explain_vector_scores(query_vector: List[float], doc_vectors: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Calculate and explain vector similarity scores for document vectors
+    
+    Args:
+        query_vector: Query embedding vector
+        doc_vectors: List of document vectors with source field
+        
+    Returns:
+        Dict with vector similarity explanations
+    """
+    logger.info(f"Processing {len(doc_vectors)} document vectors")
+    logger.debug(f"Vector sources: {[vec.get('source', 'unknown') for vec in doc_vectors]}")
+    
+    vector_scores = []
+    
+    for vec in doc_vectors:
+        source = vec.get("source", "unknown")
+        logger.debug(f"Processing vector from source: {source}")
+        score = cosine_similarity(query_vector, vec["vector"])
+        vector_scores.append({
+            "source": source,
+            "similarity": score,
+            "description": f"Cosine similarity with {source} vector: {score:.4f}"
+        })
+        logger.debug(f"Vector score for {source}: {score:.4f}")
+    
+    # Calculate combined score
+    combined_score = np.mean([s["similarity"] for s in vector_scores])
+    logger.info(f"Combined vector score: {combined_score:.4f}")
+    
+    return {
+        "value": combined_score,
+        "description": "Combined vector similarity score",
+        "details": vector_scores
+    }
+
+def combine_text_and_vector_scores(text_score: Dict[str, Any], vector_score: Dict[str, Any], 
+                                 text_weight: float = 0.4, vector_weight: float = 0.6) -> Dict[str, Any]:
+    """
+    Combine text and vector similarity scores with explanations
+    
+    Args:
+        text_score: Text similarity score explanation from Elasticsearch
+        vector_score: Vector similarity score explanation 
+        text_weight: Weight for text score (default 0.4)
+        vector_weight: Weight for vector score (default 0.6)
+        
+    Returns:
+        Combined score explanation
+    """
+    text_value = text_score.get("value", 0)
+    vector_value = vector_score.get("value", 0)
+    
+    logger.info(f"Text score: {text_value:.4f}, Vector score: {vector_value:.4f}")
+    logger.info(f"Weights - Text: {text_weight}, Vector: {vector_weight}")
+    
+    combined_value = (text_value * text_weight) + (vector_value * vector_weight)
+    logger.info(f"Combined score: {combined_value:.4f}")
+    
+    return {
+        "value": combined_value,
+        "description": "Combined text and vector similarity score",
+        "details": [
+            {
+                "value": text_value,
+                "weight": text_weight,
+                "description": "Text similarity score (BM25)",
+                "explanation": text_score
+            },
+            {
+                "value": vector_value, 
+                "weight": vector_weight,
+                "description": "Vector similarity score",
+                "explanation": vector_score
+            }
+        ]
+    } 

--- a/botnim/vector_store/vector_score_explainer.py
+++ b/botnim/vector_store/vector_score_explainer.py
@@ -16,7 +16,9 @@ def cosine_similarity(vec1: List[float], vec2: List[float]) -> float:
 
 def explain_vector_scores(query_vector: List[float], doc_vectors: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
-    Calculate and explain vector similarity scores for document vectors
+    Calculate and explain vector similarity scores for document vectors.
+    Uses max similarity to maximize recall - a document is considered relevant if ANY of its vectors
+    match well with the query, rather than requiring all vectors to match well on average.
     
     Args:
         query_vector: Query embedding vector
@@ -41,13 +43,14 @@ def explain_vector_scores(query_vector: List[float], doc_vectors: List[Dict[str,
         })
         logger.debug(f"Vector score for {source}: {score:.4f}")
     
-    # Calculate combined score
-    combined_score = np.mean([s["similarity"] for s in vector_scores])
-    logger.info(f"Combined vector score: {combined_score:.4f}")
+    # Calculate combined score using max to maximize recall
+    # This ensures a document is considered relevant if ANY of its vectors match well
+    combined_score = np.max([s["similarity"] for s in vector_scores])
+    logger.info(f"Combined vector score (max similarity): {combined_score:.4f}")
     
     return {
         "value": combined_score,
-        "description": "Combined vector similarity score",
+        "description": "Combined vector similarity score (max)",
         "details": vector_scores
     }
 

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -99,12 +99,17 @@ class VectorStoreES(VectorStoreBase):
         }
         
         vector_match = {
-            "knn": {
-                "field": "vector",      # field to search in
-                "query_vector": embedding,  # embedding to search for
-                "k": num_results,       # number of results to get
-                "num_candidates": 20,   # number of candidates to consider
-                "boost": 0.5           # boost for vector match
+            "nested": {
+                "path": "vectors",
+                "query": {
+                    "knn": {
+                        "field": "vectors.vector",
+                        "query_vector": embedding,
+                        "k": num_results,
+                        "num_candidates": 20,
+                        "boost": 0.5
+                    }
+                }
             }
         }
         

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -226,7 +226,10 @@ class VectorStoreES(VectorStoreBase):
                 # Prepare base document
                 document = {
                     "content": content,
-                    "vector": vector,
+                    "vectors": [{
+                        "vector": vector,
+                        "source": "content"
+                    }]
                 }
                 
                 # Add metadata to document

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -156,11 +156,19 @@ class VectorStoreES(VectorStoreBase):
                 "mappings": {
                     "properties": {
                         "content": {"type": "text"},
-                        "vector": {
-                            "type": "dense_vector",
-                            "dims": DEFAULT_EMBEDDING_SIZE,
-                            "index": True,
-                            "similarity": "cosine"
+                        "vectors": {
+                            "type": "nested",
+                            "properties": {
+                                "vector": {
+                                    "type": "dense_vector",
+                                    "dims": DEFAULT_EMBEDDING_SIZE,
+                                    "index": True,
+                                    "similarity": "cosine"
+                                },
+                                "source": {
+                                    "type": "keyword"
+                                }
+                            }
                         },
                         "metadata": {
                             "type": "object",


### PR DESCRIPTION
closes #43 

@akariv notice - It seems to work technically (please verify...), but the query results are not good yet.  The optimizations would require a separate PR (see #51 for suggested plan).

Currently, this is the new scoring logic:
   - The text match boost of 0.4 is significantly lower than vector matches (1.0 and 0.8)
   - Content vector matches get full weight (1.0)
   - Description vector matches get 80% weight (0.8)
   - The final score is the maximum of the two (using the 'should' clause).


