### PR TITLE
Update budget prompts for approved 2026 budget

### DIFF
--- a/specs/budgetkey/agent.txt
+++ b/specs/budgetkey/agent.txt
@@ -2,8 +2,8 @@ You are an expert data researcher, helping to find information on issues related
 You communicate efficiently in Hebrew.
 You use the tools provided to you to find relevant information. Your goal is to answer the user's question accurately or state that you do not know if you have no answer. In any case, you use only the information obtained through the use of tools and no other information.
 
-The current year is 2025.
-Budget data is available from 1997 to 2025.
+The current year is 2026.
+Budget data is available from 1997 to 2026.
 
 According to the user's question, you use the different tools available to you:
 - search_budgetkey__common_knowledge__dev: *Always* start with this tool to obtain insights relevant to the continuation of the process. However, never rely solely on these results! While it can provide useful insights, it should never be your only source of information, and you should always use the tools provided. Note that if you can't find anything relevant in the knowledge base, don't notify the user about it and simply proceed with the other tools.

--- a/specs/unified/agent.txt
+++ b/specs/unified/agent.txt
@@ -20,7 +20,7 @@ If no relevant tool output exists, you must explicitly say so.
 * **Uncertainty** — If no relevant result exists, clearly say:  
   **"לא ניתן להשיב על שאלה זו על בסיס המידע הזמין."**  
 
-The current year is 2025.
+The current year is 2026.
 
 ---
 
@@ -165,7 +165,7 @@ Your workflow consists of the following steps, in this exact order, for *every* 
 7. Always suggest follow-up questions that might interest the user or clarify what was not taken into account in the current response.
 
 
-Budget data is available from 1997 to 2025
+Budget data is available from 1997 to 2026
 
 **Note**: The common budget knowledge query was already performed during domain routing, so proceed directly to data analysis.
 
@@ -255,6 +255,6 @@ When question plausibly involves **both legal and budget** aspects:
 * **Off-topic queries** → politely refuse with examples.  
 * **Content queries** → must always use tools, never pure LLM.  
 * **Orientation** → both domains, then confirm focus.  
-* **Budget timeframe** → default 2025.  
+* **Budget timeframe** → default 2026.  
 * **Legal citations** → exact סעיף/decision only.  
 * **Cross-domain** → Dual-Track Mode.


### PR DESCRIPTION
## Summary
- The approved **2026 State Budget** has been published in Budgetkey, so the bot prompts should no longer present 2025 as the latest year with data
- Updates five hard-coded year references: two in `specs/budgetkey/agent.txt` and three in `specs/unified/agent.txt`
- Pure text change, no config/schema edits

## Files changed
- `specs/budgetkey/agent.txt` — lines 5–6 (`current year`, `Budget data is available from 1997 to 2025`)
- `specs/unified/agent.txt` — lines 23, 168, 258 (`current year`, `Budget data is available`, `Budget timeframe → default`)

## Follow-up after merge
Re-sync the affected bots so the updated `agent.txt` is pushed to the OpenAI Assistants:
```
make -C parlibot sync-budgetkey sync-unified
```
(The `takanon` bot doesn't reference budget years and doesn't need re-syncing.)

## Test plan
- [ ] Visual review of the diff (whitespace clean, only semantic year changes)
- [ ] After merge + sync, ask the budgetkey/unified bot a question about 2026 budget and confirm it no longer declines with "data only through 2025"

🤖 Generated with [Claude Code](https://claude.com/claude-code)