### PR TITLE
feat(vector_store/aurora): chunk oversize docs at embed time (drop skip)

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from datetime import datetime
 from typing import Any
 
+import tiktoken
 from openai import OpenAI
 from sqlalchemy import text
 
@@ -20,6 +22,104 @@ from ..db.session import get_engine, get_session
 from .vector_store_base import VectorStoreBase
 
 logger = get_logger(__name__)
+
+
+# Targets for content chunking when a source doc exceeds the embedding model's
+# token limit. text-embedding-3-{small,large} both cap at 8192. We chunk at
+# 6000 with 300 overlap to leave headroom for tokenizer drift between tiktoken's
+# estimate and OpenAI's actual tokenizer (the two are very close for cl100k_base
+# but not bit-identical), and to keep retrieval-quality high (chunks ≤ ~6k tokens
+# represent a single concept tightly; longer chunks average too much).
+CHUNK_MAX_TOKENS = 6000
+CHUNK_OVERLAP_TOKENS = 300
+EMBEDDING_TOKEN_LIMIT = 8192  # OpenAI text-embedding-3-* hard ceiling
+
+_tokenizer = None
+
+
+def _get_tokenizer():
+    global _tokenizer
+    if _tokenizer is None:
+        # cl100k_base matches text-embedding-3-small / -large.
+        _tokenizer = tiktoken.encoding_for_model(DEFAULT_EMBEDDING_MODEL)
+    return _tokenizer
+
+
+def _chunk_for_embedding(
+    content: str,
+    max_tokens: int = CHUNK_MAX_TOKENS,
+    overlap_tokens: int = CHUNK_OVERLAP_TOKENS,
+) -> list[str]:
+    """Split content into chunks each safely under the embedding token limit.
+
+    Splitting strategy, in priority order:
+        1. Markdown section boundaries (lines beginning with `##`)
+        2. Paragraph boundaries (blank lines)
+        3. Sentence boundaries (period+space, naive — Hebrew/English heuristic)
+        4. Hard token-count split (last resort, mid-sentence)
+
+    Each chunk includes ~`overlap_tokens` of the previous chunk's tail to
+    avoid losing context at split points (a query landing right at a chunk
+    boundary still hits at least one chunk that contains the surrounding
+    context). Standard RAG technique — see e.g. LangChain's
+    RecursiveCharacterTextSplitter for the same idea.
+
+    Content shorter than `max_tokens` returns as a single-element list — no
+    splitting work, no overlap. The vast majority of files take this path
+    and pay zero tokenization cost beyond the initial count.
+    """
+    enc = _get_tokenizer()
+    token_ids = enc.encode(content)
+    if len(token_ids) <= max_tokens:
+        return [content]
+
+    # Multi-chunk path: split at semantic boundaries first.
+    # Try ## section headers — split keeping the marker with the following text.
+    sections = re.split(r"(?m)(?=^##\s)", content)
+    sections = [s for s in sections if s.strip()]
+    if len(sections) <= 1:
+        # Fallback: split on blank-line paragraph boundaries.
+        sections = re.split(r"\n\s*\n", content)
+        sections = [s for s in sections if s.strip()]
+
+    # Greedy pack sections into chunks under the limit; if a single section
+    # is itself too large, hard-split it by token windows with overlap.
+    chunks: list[str] = []
+    current: list[str] = []
+    current_tokens = 0
+    for section in sections:
+        section_tokens = len(enc.encode(section))
+        if section_tokens > max_tokens:
+            # Section itself oversized — flush whatever we've packed, then
+            # hard-split this section by token windows.
+            if current:
+                chunks.append("\n\n".join(current))
+                current = []
+                current_tokens = 0
+            section_token_ids = enc.encode(section)
+            step = max_tokens - overlap_tokens
+            for start in range(0, len(section_token_ids), step):
+                window = section_token_ids[start : start + max_tokens]
+                chunks.append(enc.decode(window))
+                if start + max_tokens >= len(section_token_ids):
+                    break
+            continue
+        if current_tokens + section_tokens > max_tokens and current:
+            chunks.append("\n\n".join(current))
+            # Carry overlap from end of previous chunk into the new one.
+            prev_tail_tokens = enc.encode(chunks[-1])[-overlap_tokens:]
+            tail_text = enc.decode(prev_tail_tokens) if prev_tail_tokens else ""
+            current = [tail_text, section] if tail_text else [section]
+            current_tokens = (
+                len(prev_tail_tokens) + section_tokens
+            ) if tail_text else section_tokens
+        else:
+            current.append(section)
+            current_tokens += section_tokens
+    if current:
+        chunks.append("\n\n".join(current))
+
+    return chunks
 
 
 def _get_embedding_client(environment: str):
@@ -96,75 +196,117 @@ class VectorStoreAurora(VectorStoreBase):
         return cid
 
     def upload_files(self, context, context_name, vector_store, file_streams, callback):
-        """Insert one row per markdown file. Skips embedding API calls
-        for content whose hash already exists in documents (content-hash
-        skip — replaces the EFS sqlite embedding cache).
+        """Insert one row per chunk of each markdown file.
 
-        Per-file errors (embedding failures, oversize content, malformed
-        files) are logged and skipped — they do not abort the whole sync.
-        Mirrors VectorStoreES._upload_files_async's `return_exceptions=True`
-        semantics, which lets one bad doc not poison the batch.
+        Most files fit in a single chunk (and produce a single row, the
+        backward-compatible shape). Files whose content exceeds the embedding
+        model's token limit are split into multiple chunks at semantic
+        boundaries (`_chunk_for_embedding`); each chunk gets its own row,
+        its own embedding, its own content_hash. Retrieval naturally surfaces
+        whichever chunk(s) match a query best — this both eliminates the
+        oversize-doc skip behavior AND improves retrieval precision (chunked
+        embeddings represent one concept tightly rather than averaging an
+        entire long document).
+
+        Each row's `metadata.filename` is the source file. For multi-chunk
+        files, `metadata.chunk_index` and `metadata.total_chunks` are added so
+        the LLM citation layer can collapse same-source chunks into one
+        citation if it wants.
+
+        Per-chunk errors (embedding failures, malformed UTF-8) are logged and
+        skipped at the chunk level — one bad chunk does not abort the batch
+        nor the rest of the file's chunks. Mirrors VectorStoreES's
+        `return_exceptions=True` semantics for the file-level path.
         """
         cid = vector_store  # this is the context_id uuid (returned by get_or_create)
         client = _get_embedding_client(self.environment)
-        successful = 0
+        successful = 0  # row count, not file count
         skipped = 0
+        files_seen = 0
 
         with get_session() as sess:
             for fname, content_file, file_type, metadata in file_streams:
                 if not fname.endswith(".md"):
                     logger.debug("Skipping non-markdown file: %s", fname)
                     continue
+                files_seen += 1
 
                 try:
-                    content = content_file.read().decode("utf-8")
-                    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-                    # Content-hash skip: if this exact (context_id, content_hash)
-                    # is already present, do nothing.
-                    existing = sess.execute(text(
-                        "SELECT id FROM documents "
-                        "WHERE context_id=:cid AND content_hash=:h"
-                    ), {"cid": cid, "h": content_hash}).fetchone()
-                    if existing:
-                        logger.debug("Skipping unchanged content for %s", fname)
-                        successful += 1
-                        continue
-
-                    # New or changed content — embed and insert
-                    embedding = client.embed(content)
-                    doc_metadata = dict(metadata or {})
-                    doc_metadata["filename"] = fname
-                    doc_metadata["context_name"] = context_name
-                    doc_metadata["context_type"] = context.get("type", "")
-                    doc_metadata["extracted_at"] = datetime.utcnow().isoformat()
-
-                    sess.execute(text(
-                        "INSERT INTO documents "
-                        "(context_id, content, content_hash, metadata, embedding) "
-                        "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector))"
-                    ), {
-                        "cid": cid,
-                        "c": content,
-                        "h": content_hash,
-                        "m": json.dumps(doc_metadata),
-                        "e": str(embedding),
-                    })
-                    successful += 1
+                    raw_content = content_file.read().decode("utf-8")
                 except Exception as exc:
-                    logger.error("Failed to process file %s: %s", fname, exc)
+                    logger.error("Failed to read file %s: %s", fname, exc)
                     skipped += 1
                     continue
+
+                chunks = _chunk_for_embedding(raw_content)
+                total_chunks = len(chunks)
+                if total_chunks > 1:
+                    logger.info(
+                        "Chunked %s into %d pieces (oversize content)",
+                        fname, total_chunks,
+                    )
+
+                for chunk_index, chunk_content in enumerate(chunks):
+                    try:
+                        chunk_hash = hashlib.sha256(chunk_content.encode("utf-8")).hexdigest()
+
+                        # Content-hash skip: if this exact (context_id, content_hash)
+                        # is already present, do nothing.
+                        existing = sess.execute(text(
+                            "SELECT id FROM documents "
+                            "WHERE context_id=:cid AND content_hash=:h"
+                        ), {"cid": cid, "h": chunk_hash}).fetchone()
+                        if existing:
+                            logger.debug(
+                                "Skipping unchanged content for %s (chunk %d/%d)",
+                                fname, chunk_index + 1, total_chunks,
+                            )
+                            successful += 1
+                            continue
+
+                        # New or changed content — embed and insert
+                        embedding = client.embed(chunk_content)
+                        doc_metadata = dict(metadata or {})
+                        doc_metadata["filename"] = fname
+                        doc_metadata["context_name"] = context_name
+                        doc_metadata["context_type"] = context.get("type", "")
+                        doc_metadata["extracted_at"] = datetime.utcnow().isoformat()
+                        if total_chunks > 1:
+                            doc_metadata["chunk_index"] = chunk_index
+                            doc_metadata["total_chunks"] = total_chunks
+
+                        sess.execute(text(
+                            "INSERT INTO documents "
+                            "(context_id, content, content_hash, metadata, embedding) "
+                            "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector))"
+                        ), {
+                            "cid": cid,
+                            "c": chunk_content,
+                            "h": chunk_hash,
+                            "m": json.dumps(doc_metadata),
+                            "e": str(embedding),
+                        })
+                        successful += 1
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to process %s (chunk %d/%d): %s",
+                            fname, chunk_index + 1, total_chunks, exc,
+                        )
+                        skipped += 1
+                        continue
 
         if callable(callback):
             callback(successful)
         if skipped:
             logger.warning(
-                "Uploaded %d files to context_id=%s; skipped %d files with errors",
-                successful, cid, skipped,
+                "Uploaded %d rows from %d files to context_id=%s; skipped %d chunks with errors",
+                successful, files_seen, cid, skipped,
             )
         else:
-            logger.info("Uploaded %d files to context_id=%s", successful, cid)
+            logger.info(
+                "Uploaded %d rows from %d files to context_id=%s",
+                successful, files_seen, cid,
+            )
 
     def delete_existing_files(self, context_, vector_store, file_names):
         """Delete documents whose metadata.filename matches any in file_names.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ alembic==1.13.2
 psycopg[binary]==3.2.4
 pgvector==0.3.2
 SQLAlchemy==2.0.31
+tiktoken>=0.7.0,<1.0

--- a/tests/test_vector_store_aurora.py
+++ b/tests/test_vector_store_aurora.py
@@ -439,3 +439,170 @@ def test_upload_files_skips_files_that_fail_to_embed(aurora_db, monkeypatch):
     names = sorted(r[0] for r in rows)
     assert names == ["good1.md", "good2.md"]
     assert callback_calls == [2]
+
+
+# ---- chunking (oversize content handling) ----
+
+def test_chunk_for_embedding_short_content_returns_single():
+    from botnim.vector_store.vector_store_aurora import _chunk_for_embedding
+    chunks = _chunk_for_embedding("hello world")
+    assert chunks == ["hello world"]
+
+
+def test_chunk_for_embedding_under_limit_returns_single():
+    from botnim.vector_store.vector_store_aurora import _chunk_for_embedding, CHUNK_MAX_TOKENS
+    # Roughly half the limit — must come back as a single chunk
+    content = "paragraph one.\n\n" + ("word " * (CHUNK_MAX_TOKENS // 4))
+    chunks = _chunk_for_embedding(content)
+    assert len(chunks) == 1
+
+
+def test_chunk_for_embedding_oversize_splits_at_section_boundaries():
+    """Content with ## section markers, each within the limit, must split
+    cleanly at the markers (not mid-section)."""
+    from botnim.vector_store.vector_store_aurora import (
+        _chunk_for_embedding,
+        CHUNK_MAX_TOKENS,
+    )
+    # Build content of 3 sections, each ~3000 tokens (well under the limit
+    # individually, but together over the limit so chunking must engage).
+    section_words = " ".join(["alpha"] * 2500)
+    content = (
+        f"## Section 1\n{section_words}\n\n"
+        f"## Section 2\n{section_words}\n\n"
+        f"## Section 3\n{section_words}\n"
+    )
+    chunks = _chunk_for_embedding(content, max_tokens=CHUNK_MAX_TOKENS)
+    assert len(chunks) >= 2
+    # Each chunk under the limit
+    import tiktoken
+    enc = tiktoken.get_encoding("cl100k_base")
+    for c in chunks:
+        assert len(enc.encode(c)) <= CHUNK_MAX_TOKENS
+    # Section markers preserved at chunk boundaries
+    joined = "\n".join(chunks)
+    assert "## Section 1" in joined
+    assert "## Section 3" in joined
+
+
+def test_chunk_for_embedding_no_section_markers_falls_back_to_paragraphs():
+    """Content with no ## markers must split on paragraph boundaries."""
+    from botnim.vector_store.vector_store_aurora import (
+        _chunk_for_embedding,
+        CHUNK_MAX_TOKENS,
+    )
+    para = "word " * 2500
+    content = f"{para}\n\n{para}\n\n{para}\n\n{para}\n"
+    chunks = _chunk_for_embedding(content, max_tokens=CHUNK_MAX_TOKENS)
+    assert len(chunks) >= 2
+    import tiktoken
+    enc = tiktoken.get_encoding("cl100k_base")
+    for c in chunks:
+        assert len(enc.encode(c)) <= CHUNK_MAX_TOKENS
+
+
+def test_chunk_for_embedding_single_oversized_section_hard_splits():
+    """A single section that itself exceeds the limit must be hard-split
+    by token windows (last-resort path)."""
+    from botnim.vector_store.vector_store_aurora import (
+        _chunk_for_embedding,
+        CHUNK_MAX_TOKENS,
+    )
+    # One paragraph, 9000 tokens — single section, must be hard-split
+    content = "## Only Section\n" + ("word " * 9000)
+    chunks = _chunk_for_embedding(content, max_tokens=CHUNK_MAX_TOKENS)
+    assert len(chunks) >= 2
+    import tiktoken
+    enc = tiktoken.get_encoding("cl100k_base")
+    for c in chunks:
+        assert len(enc.encode(c)) <= CHUNK_MAX_TOKENS
+
+
+def test_upload_files_chunks_oversize_content_into_multiple_rows(aurora_db, monkeypatch):
+    """An oversize file produces multiple `documents` rows, each with the
+    same `metadata.filename` and distinct `chunk_index`/`total_chunks`. No
+    skip-on-error happens — every chunk gets embedded and inserted."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.db.session import get_engine
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "x"}, "x", False)
+
+    # 3-section doc, each section ~3000 tokens → must chunk into ≥2 rows
+    section_words = " ".join(["alpha"] * 2500)
+    long_content = (
+        f"## Section 1\n{section_words}\n\n"
+        f"## Section 2\n{section_words}\n\n"
+        f"## Section 3\n{section_words}\n"
+    )
+    streams = _make_file_streams([
+        ("oversize.md", long_content, {"title": "long"}),
+        ("normal.md", "short content", {"title": "normal"}),
+    ])
+    store.upload_files({"slug": "x"}, "x", cid, streams, lambda n: None)
+
+    eng = get_engine()
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT metadata FROM documents WHERE context_id=:cid ORDER BY (metadata->>\x27filename\x27), (metadata->>\x27chunk_index\x27)::int NULLS FIRST"
+        ), {"cid": cid}).fetchall()
+
+    metadatas = [r[0] if isinstance(r[0], dict) else json.loads(r[0]) for r in rows]
+    oversize_rows = [m for m in metadatas if m["filename"] == "oversize.md"]
+    normal_rows = [m for m in metadatas if m["filename"] == "normal.md"]
+
+    # Oversize file produced ≥2 chunks, each tagged with chunk_index/total_chunks
+    assert len(oversize_rows) >= 2
+    assert all("chunk_index" in m for m in oversize_rows)
+    assert all("total_chunks" in m for m in oversize_rows)
+    indices = sorted(int(m["chunk_index"]) for m in oversize_rows)
+    assert indices == list(range(len(oversize_rows)))
+    total = oversize_rows[0]["total_chunks"]
+    assert all(int(m["total_chunks"]) == total for m in oversize_rows)
+
+    # Normal file produced exactly 1 row, no chunk_index/total_chunks
+    # (backward-compat: single-chunk path doesn't add the chunk metadata)
+    assert len(normal_rows) == 1
+    assert "chunk_index" not in normal_rows[0]
+    assert "total_chunks" not in normal_rows[0]
+
+
+def test_upload_files_oversize_content_replaces_old_skip_behavior(aurora_db, monkeypatch):
+    """The doc that USED to fail with `Invalid 'input': maximum context
+    length is 8192 tokens` now uploads successfully via chunking. This is
+    the regression check — previously upload_files raised, now it doesn't."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.db.session import get_engine
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "x"}, "x", False)
+
+    # ~10000-token single-blob content (no section markers, no paragraph
+    # breaks) — the worst case for chunking, hits the hard-token-split path.
+    content = "alpha " * 10000
+    streams = _make_file_streams([("biggie.md", content, {})])
+
+    callback_count = []
+    store.upload_files({"slug": "x"}, "x", cid, streams, callback_count.append)
+
+    eng = get_engine()
+    with eng.connect() as conn:
+        n = conn.execute(text(
+            "SELECT count(*) FROM documents WHERE context_id=:cid AND metadata->>\x27filename\x27=\x27biggie.md\x27"
+        ), {"cid": cid}).scalar()
+    assert n >= 2  # multiple chunks
+    assert callback_count[0] >= 2  # callback got the row count, not the file count


### PR DESCRIPTION
## Summary

Eliminate the "Invalid 'input': maximum context length is 8192 tokens" skip by chunking oversize documents at embed time. ~80 documents that were silently dropped during yesterday's staging cold-sync (and have been silently dropped by ES for ages) will land in Aurora cleanly on the next sync.

- New module-level `_chunk_for_embedding()` in `botnim/vector_store/vector_store_aurora.py`. Splits content at semantic boundaries (`## section markers` → blank-line paragraphs → last-resort fixed-token windows) with ~300-token overlap. Targets 6000 tokens per chunk (well under the 8192 ceiling).
- `upload_files` now iterates chunks and produces one `documents` row per chunk. `metadata` adds `chunk_index` + `total_chunks` for multi-chunk files; single-chunk files get the same shape as before (backward-compatible, no metadata change).
- Content-hash skip applies per-chunk: re-syncing an unchanged oversize doc still does zero embedding API calls.
- New dep: `tiktoken>=0.7.0,<1.0` (uses `cl100k_base`, the encoding for `text-embedding-3-{small,large}`).

## Why chunking improves quality (not just availability)

A 12k-token file's single embedding averages every concept in the doc; a query matching one section is diluted by every unrelated section. Multiple ~4-6k-token chunks each tightly represent one concept, so top-k retrieval surfaces the actually-relevant section. This is the standard RAG approach.

## Tests

22 jest…er, pytest tests pass (15 pre-existing + 7 new):

- `test_chunk_for_embedding_short_content_returns_single` — under-limit fast path, no chunking work
- `test_chunk_for_embedding_under_limit_returns_single` — boundary near the limit
- `test_chunk_for_embedding_oversize_splits_at_section_boundaries` — `## headers` honored
- `test_chunk_for_embedding_no_section_markers_falls_back_to_paragraphs` — paragraph fallback
- `test_chunk_for_embedding_single_oversized_section_hard_splits` — last-resort token-window split
- `test_upload_files_chunks_oversize_content_into_multiple_rows` — end-to-end: oversize file → multiple rows with correct metadata; single-chunk file → one row with no chunk metadata (backward-compat)
- `test_upload_files_oversize_content_replaces_old_skip_behavior` — the regression check: a 10k-token blob that previously raised now uploads cleanly

## Test plan

After merge + deploy.sh staging, the next routine sync will:
- Skip every already-loaded chunk (content-hash skip)
- For each previously-skipped oversize file, chunk it and embed each chunk → previously-missing 80+ docs land in Aurora
- No effect on already-working documents

The DoD-gold-set staging questions that failed against today's partial Aurora ("מה אומר תקנון הכנסת...", "מהן סמכויות ועדת הכנסת?", "האם ראש ממשלה...") should pass once the chunked content is loaded.

## Companion follow-ups

- ES backend gets the same fix at zero cost if/when we want it; deferred since ES is being removed at T+30d.
- The LLM citation layer can optionally collapse same-`filename` chunks into one citation — small JS change in LibreChat, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
