### PR TITLE
fix(aurora): bump ivfflat.probes to 10 in vector search

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -354,6 +354,16 @@ class VectorStoreAurora(VectorStoreBase):
         # keeps the search call self-contained and resilient to context
         # rows being added/removed mid-process.
         with get_session() as sess:
+            # ivfflat default `probes = 1` searches only 1 of `lists` partitions,
+            # which makes top-K depend on which partition the query embedding
+            # lands in — different ivfflat builds (e.g. local vs staging
+            # rebuilt at slightly different times) can return materially
+            # different rankings even for the same query+data. Bumping probes
+            # to 10 trades a small latency hit for deterministic, near-exact
+            # top-K. We use SET LOCAL so the change is scoped to this txn
+            # and doesn't leak across the connection pool.
+            sess.execute(text("SET LOCAL ivfflat.probes = 10"))
+
             row = sess.execute(text(
                 "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
             ), {"bot": bot, "name": context_name}).fetchone()


### PR DESCRIPTION
Fixes Q3 staging gold-set failure caused by pgvector ivfflat default probes=1 returning non-deterministic top-K across builds. SET LOCAL ivfflat.probes = 10 before the vector SELECT scopes the change to the txn. Local was already passing; staging needed this. See commit message for the concrete repro.