### PR TITLE
feat: admin /sources screen — schema + sync writes

### DIFF
--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -135,11 +135,14 @@ async def _process_file_stream_async(
     filename: str,
     content: Union[str, io.BufferedReader],
     content_type: str,
+    source_id: str,
     concurrency: SyncConcurrency,
     client,
 ):
     fname, text, ctype = _prepare_file_content(filename, content, content_type)
     metadata = await _get_metadata_for_content_async(text, fname, ctype, concurrency, client=client)
+    metadata = dict(metadata or {})
+    metadata['source_id'] = source_id
     return (fname, io.BytesIO(text.encode('utf-8')), ctype, metadata)
 
 def _collect_raw_streams_files(config_dir: Path, source):
@@ -200,21 +203,29 @@ def _collect_raw_streams_csv(config_dir, context_name, source, offset=0):
         return raw
 
 def _raw_streams_for_context(config_dir, context_name, context_, offset=0):
-    """Gather raw (filename, content, content_type) without calling OpenAI.
+    """Gather raw (filename, content, content_type, source_id) tuples without calling OpenAI.
 
-    Mirrors ``file_streams_for_context`` but defers the extraction step.
+    Each tuple now carries the derived `source_id` so per-source attribution
+    survives through the async extraction pipeline into upload_files.
     """
+    from .sync import _source_id_for  # local import avoids circular at module load
     context_type = context_['type']
     source = context_['source']
+    fetcher = context_.get('fetcher')
+    source_id = _source_id_for(fetcher, source)
+
     if context_type == 'files':
-        return _collect_raw_streams_files(config_dir, source)
-    if context_type == 'split':
-        return _collect_raw_streams_split(config_dir, context_name, source, offset=offset)
-    if context_type == 'google-spreadsheet':
-        return _collect_raw_streams_google_spreadsheet(context_name, source, offset=offset)
-    if context_type == 'csv':
-        return _collect_raw_streams_csv(config_dir, context_name, source, offset=offset)
-    raise ValueError(f'Unknown context type: {context_type}')
+        raw = _collect_raw_streams_files(config_dir, source)
+    elif context_type == 'split':
+        raw = _collect_raw_streams_split(config_dir, context_name, source, offset=offset)
+    elif context_type == 'google-spreadsheet':
+        raw = _collect_raw_streams_google_spreadsheet(context_name, source, offset=offset)
+    elif context_type == 'csv':
+        raw = _collect_raw_streams_csv(config_dir, context_name, source, offset=offset)
+    else:
+        raise ValueError(f'Unknown context type: {context_type}')
+
+    return [(fname, content, ctype, source_id) for fname, content, ctype in raw]
 
 
 async def collect_context_sources_async(
@@ -233,7 +244,7 @@ async def collect_context_sources_async(
     cache = KVFile(location=str(Path(__file__).parent.parent / 'cache' / 'metadata'))
 
     context_name = context_['name']
-    raw: list[tuple[str, object, str]] = []
+    raw: list[tuple[str, object, str, str]] = []
     if 'sources' in context_:
         for source in context_['sources']:
             raw.extend(_raw_streams_for_context(config_dir, context_name, source, offset=len(raw)))
@@ -243,12 +254,12 @@ async def collect_context_sources_async(
     # asyncio.gather preserves input order in its output list — this is
     # what keeps SYNC_CONCURRENCY=1 byte-equal to the serial implementation.
     tasks = [
-        _process_file_stream_async(fn, content, ct, concurrency, client)
-        for fn, content, ct in raw
+        _process_file_stream_async(fn, content, ct, sid, concurrency, client)
+        for fn, content, ct, sid in raw
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
     file_streams: list = []
-    for r, (fn, _, _) in zip(results, raw):
+    for r, (fn, _, _, _) in zip(results, raw):
         if isinstance(r, BaseException):
             # Error isolation: one failed document must not poison the batch.
             logger.error(f"Extraction failed for {fn}: {r}")

--- a/botnim/db/migrations/data/0005_backfill_source_id.sql
+++ b/botnim/db/migrations/data/0005_backfill_source_id.sql
@@ -1,0 +1,22 @@
+-- One-shot backfill for documents.source_id (added in migration 0005).
+-- Idempotent: only touches rows where source_id IS NULL. Re-runnable.
+-- Run against staging then production AFTER alembic upgrade head.
+--
+-- Single-source contexts: assign the fixed source_id. Multi-source
+-- contexts (legal_text, common_takanon_knowledge): derive from the
+-- markdown '# <page_name>' header that the wikitext extractor writes
+-- as the first line of every chunk. Lexicon / google-sheet docs in
+-- common_takanon_knowledge that don't have a wikisource header keep
+-- '(unknown)' until the next normal sync overwrites them properly.
+--
+-- Anything still NULL after the below stays NULL — _write_snapshots
+-- groups those under '(unknown)' and a future routine sync will
+-- populate them properly via the threaded source_id path.
+SELECT 1;
+UPDATE documents SET source_id = 'common-knowledge' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='common_budget_knowledge');
+UPDATE documents SET source_id = 'knesset_legal_advisor' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='legal_advisor_opinions');
+UPDATE documents SET source_id = 'knesset_legal_advisor_letters' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='legal_advisor_letters');
+UPDATE documents SET source_id = 'knesset_committee_decisions' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='committee_decisions');
+UPDATE documents SET source_id = 'ethics_committee_decisions' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='ethics_decisions');
+UPDATE documents SET source_id = 'bk_csv' WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name='government_decisions');
+UPDATE documents SET source_id = (regexp_match(content, '^# (\S+)'))[1] WHERE source_id IS NULL AND context_id IN (SELECT id FROM contexts WHERE bot='unified' AND name IN ('legal_text', 'common_takanon_knowledge')) AND content ~ '^# \S';

--- a/botnim/db/migrations/versions/0005_documents_source_id.py
+++ b/botnim/db/migrations/versions/0005_documents_source_id.py
@@ -1,0 +1,32 @@
+"""documents.source_id column for per-fetcher attribution
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-27
+
+Adds a nullable text column `source_id` to `documents` so each chunk can be
+attributed to its underlying fetcher (wikitext URL, pdf CSV, lexicon, etc.).
+Populated by sync code in a follow-up commit; existing rows stay NULL until
+the one-shot backfill (botnim/db/migrations/data/0005_backfill_source_id.sql)
+runs against staging/prod.
+"""
+from alembic import op
+
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE documents ADD COLUMN source_id TEXT")
+    op.execute(
+        "CREATE INDEX documents_context_source "
+        "ON documents (context_id, source_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS documents_context_source")
+    op.execute("ALTER TABLE documents DROP COLUMN IF EXISTS source_id")

--- a/botnim/db/migrations/versions/0006_context_snapshots.py
+++ b/botnim/db/migrations/versions/0006_context_snapshots.py
@@ -1,0 +1,39 @@
+"""context_snapshots table for per-sync drift history
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-27
+
+Append-only audit log of (bot, context, source_id, doc_count) per sync.
+The aggregate row uses source_id='*'. No foreign keys — context/source
+rows may disappear from live tables, their history must remain readable.
+"""
+from alembic import op
+
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE context_snapshots (
+            id           UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+            snapshot_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            bot          TEXT NOT NULL,
+            context      TEXT NOT NULL,
+            source_id    TEXT NOT NULL,
+            doc_count    INTEGER NOT NULL
+        )
+    """)
+    op.execute("""
+        CREATE INDEX context_snapshots_lookup
+            ON context_snapshots (bot, context, source_id, snapshot_at DESC)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS context_snapshots_lookup")
+    op.execute("DROP TABLE IF EXISTS context_snapshots")

--- a/botnim/sync.py
+++ b/botnim/sync.py
@@ -56,6 +56,37 @@ def _source_id_for(fetcher: dict | None, source_path: str | None) -> str:
     return "unknown"
 
 
+def _write_snapshots(bot_slug: str) -> None:
+    """Append per-(bot, context, source_id) and per-context aggregate rows
+    to context_snapshots, as a single transaction. Called at the end of a
+    successful sync_agents run; failures mid-sync skip this step so a
+    half-failed sync doesn't pollute the drift history.
+    """
+    from .db.session import get_session  # local import — keep sync.py import-cheap
+    from sqlalchemy import text as _text
+
+    with get_session() as sess:
+        sess.execute(_text(
+            """
+            INSERT INTO context_snapshots (bot, context, source_id, doc_count)
+            SELECT c.bot, c.name, COALESCE(d.source_id, '(unknown)'), count(*)
+            FROM contexts c JOIN documents d ON d.context_id = c.id
+            WHERE c.bot = :bot
+            GROUP BY c.bot, c.name, COALESCE(d.source_id, '(unknown)')
+            """
+        ), {"bot": bot_slug})
+        sess.execute(_text(
+            """
+            INSERT INTO context_snapshots (bot, context, source_id, doc_count)
+            SELECT c.bot, c.name, '*', count(*)
+            FROM contexts c JOIN documents d ON d.context_id = c.id
+            WHERE c.bot = :bot
+            GROUP BY c.bot, c.name
+            """
+        ), {"bot": bot_slug})
+    logger.info("snapshots written for bot=%s", bot_slug)
+
+
 def _sync_vector_store(config: dict, config_dir, backend: str, environment: str,
                        replace_context, reindex: bool) -> None:
     """Run the backend-specific vector-store update for a bot's contexts.

--- a/botnim/sync.py
+++ b/botnim/sync.py
@@ -172,3 +172,8 @@ def sync_agents(environment: str, bots: str, backend: str = 'aurora',
 
         # 2. Publish the canonical Responses-API bot config.
         publish_bot(bot_id, environment)
+
+        # 3. Audit snapshot — drift history feed for /admin/sources.
+        # Inside the bot loop so a multi-bot future writes one snapshot per bot;
+        # any exception above this line skips the snapshot, which is the point.
+        _write_snapshots(bot_id)

--- a/botnim/sync.py
+++ b/botnim/sync.py
@@ -21,6 +21,9 @@ No ``client.beta.assistants.*`` calls remain.
 """
 from __future__ import annotations
 
+import urllib.parse
+from pathlib import Path
+
 import yaml
 
 from .bot_config import BotConfig, load_bot_config, publish_bot_config
@@ -28,6 +31,29 @@ from .config import SPECS, get_logger, get_openai_client, is_production
 from .vector_store import VectorStoreES, VectorStoreOpenAI, VectorStoreAurora
 
 logger = get_logger(__name__)
+
+
+def _source_id_for(fetcher: dict | None, source_path: str | None) -> str:
+    """Stable, human-readable label for the originating fetcher of a document.
+
+    Pure function — derived entirely from the spec config, no I/O. See
+    docs/superpowers/specs/2026-04-27-admin-sources-screen-design.md for
+    the per-kind derivation rules.
+    """
+    if fetcher:
+        kind = fetcher.get("kind")
+        if kind == "wikitext":
+            url = fetcher.get("input_url", "")
+            decoded = urllib.parse.unquote(url)
+            last_segment = decoded.rstrip("/").rsplit("/", 1)[-1]
+            return last_segment.split("#")[0]
+        if kind in {"lexicon", "bk_csv"}:
+            return kind
+        if kind == "pdf":
+            return Path(source_path or "").stem
+    if source_path:
+        return Path(source_path).stem
+    return "unknown"
 
 
 def _sync_vector_store(config: dict, config_dir, backend: str, environment: str,

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -287,14 +287,15 @@ class VectorStoreAurora(VectorStoreBase):
 
                         sess.execute(text(
                             "INSERT INTO documents "
-                            "(context_id, content, content_hash, metadata, embedding) "
-                            "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector))"
+                            "(context_id, content, content_hash, metadata, embedding, source_id) "
+                            "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector), :sid)"
                         ), {
                             "cid": cid,
                             "c": chunk_content,
                             "h": chunk_hash,
                             "m": json.dumps(doc_metadata),
                             "e": str(embedding),
+                            "sid": (metadata or {}).get("source_id"),
                         })
                         successful += 1
                     except Exception as exc:

--- a/tests/test_backfill_source_id.py
+++ b/tests/test_backfill_source_id.py
@@ -1,0 +1,73 @@
+"""Verify the one-shot backfill SQL produces correct source_id assignments."""
+import os
+import subprocess
+from pathlib import Path
+
+from sqlalchemy import text
+
+from botnim.db.session import get_session
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKFILL_SQL = REPO_ROOT / "botnim" / "db" / "migrations" / "data" / "0005_backfill_source_id.sql"
+
+
+def _alembic_upgrade_head(database_url: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        ["alembic", "--config", "alembic.ini", "upgrade", "head"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_backfill_sets_source_id_on_legacy_rows(database_url, monkeypatch):
+    _alembic_upgrade_head(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    import botnim.db.session as s
+    s._engine = None
+    s._SessionFactory = None
+
+    with get_session() as sess:
+        cid_govt = sess.execute(text(
+            "INSERT INTO contexts (bot, name) VALUES ('unified', 'government_decisions') RETURNING id"
+        )).scalar()
+        cid_legal = sess.execute(text(
+            "INSERT INTO contexts (bot, name) VALUES ('unified', 'legal_text') RETURNING id"
+        )).scalar()
+        # Single-source context — backfill should fill all rows with 'bk_csv'.
+        for i in range(3):
+            sess.execute(text(
+                "INSERT INTO documents (context_id, content, content_hash) "
+                "VALUES (:c, :b, :h)"
+            ), {"c": cid_govt, "b": f"row{i}", "h": f"hgov{i}"})
+        # Multi-source legal_text — backfill derives from '# <name>' header.
+        sess.execute(text(
+            "INSERT INTO documents (context_id, content, content_hash) "
+            "VALUES (:c, '# חוק_הכנסת\n\nbody', :h)"
+        ), {"c": cid_legal, "h": "hch1"})
+        sess.execute(text(
+            "INSERT INTO documents (context_id, content, content_hash) "
+            "VALUES (:c, '# תקנון_הכנסת\n\nbody', :h)"
+        ), {"c": cid_legal, "h": "htk1"})
+
+    sql = BACKFILL_SQL.read_text()
+    with get_session() as sess:
+        for stmt in [s for s in sql.split(";") if s.strip() and not s.strip().startswith("--")]:
+            sess.execute(text(stmt))
+
+    with get_session() as sess:
+        rows = sess.execute(text(
+            "SELECT c.name, d.source_id, count(*) "
+            "FROM documents d JOIN contexts c ON c.id=d.context_id "
+            "WHERE c.bot='unified' GROUP BY c.name, d.source_id ORDER BY 1, 2"
+        )).fetchall()
+    assert rows == [
+        ("government_decisions", "bk_csv", 3),
+        ("legal_text", "חוק_הכנסת", 1),
+        ("legal_text", "תקנון_הכנסת", 1),
+    ], f"unexpected: {rows}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -191,3 +191,32 @@ def test_0005_downgrade_drops_source_id(database_url):
             "WHERE table_name='documents' AND column_name='source_id'"
         )).fetchall()
     assert cols == [], "source_id should be dropped"
+
+
+def test_0006_creates_context_snapshots_table(database_url):
+    _alembic(["upgrade", "0006"], database_url)
+    eng = create_engine(database_url)
+    with eng.connect() as conn:
+        cols = sorted(conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='context_snapshots' ORDER BY column_name"
+        )).fetchall())
+        assert cols == [
+            ("bot",), ("context",), ("doc_count",), ("id",),
+            ("snapshot_at",), ("source_id",),
+        ], f"unexpected columns: {cols}"
+        idx = conn.execute(text(
+            "SELECT 1 FROM pg_indexes WHERE indexname='context_snapshots_lookup'"
+        )).fetchone()
+        assert idx is not None, "context_snapshots_lookup index missing"
+
+
+def test_0006_downgrade_drops_table(database_url):
+    _alembic(["upgrade", "0006"], database_url)
+    _alembic(["downgrade", "0005"], database_url)
+    eng = create_engine(database_url)
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT to_regclass('public.context_snapshots')"
+        )).fetchone()
+    assert rows[0] is None, "context_snapshots should be dropped"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -164,3 +164,30 @@ def test_0003_downgrade_drops_table(database_url):
             "WHERE tablename='agent_prompt_test_questions'"
         )).fetchall()
     assert rows == []
+
+
+def test_0005_adds_source_id_column_and_index(database_url):
+    _alembic(["upgrade", "0005"], database_url)
+    eng = create_engine(database_url)
+    with eng.connect() as conn:
+        cols = conn.execute(text(
+            "SELECT column_name, is_nullable FROM information_schema.columns "
+            "WHERE table_name='documents' AND column_name='source_id'"
+        )).fetchall()
+        assert cols == [("source_id", "YES")], "source_id should exist and be nullable"
+        idx = conn.execute(text(
+            "SELECT 1 FROM pg_indexes WHERE indexname='documents_context_source'"
+        )).fetchone()
+        assert idx is not None, "documents_context_source index missing"
+
+
+def test_0005_downgrade_drops_source_id(database_url):
+    _alembic(["upgrade", "0005"], database_url)
+    _alembic(["downgrade", "0004"], database_url)
+    eng = create_engine(database_url)
+    with eng.connect() as conn:
+        cols = conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name='documents' AND column_name='source_id'"
+        )).fetchall()
+    assert cols == [], "source_id should be dropped"

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -70,3 +70,17 @@ def test_write_snapshots_inserts_per_source_and_aggregate(database_url, monkeypa
         ("legal_text", "חוק_הכנסת", 2),
         ("legal_text", "תקנון_הכנסת", 1),
     ], f"unexpected rows: {rows}"
+
+
+def test_sync_agents_calls_write_snapshots_on_success(monkeypatch):
+    """Verify sync_agents invokes _write_snapshots once after iterating bots."""
+    from unittest.mock import patch
+
+    with patch("botnim.sync._sync_vector_store") as mock_sync, \
+         patch("botnim.sync.publish_bot") as mock_publish, \
+         patch("botnim.sync._write_snapshots") as mock_snapshots:
+        from botnim.sync import sync_agents
+        # Use 'unified' (only spec'd bot) so the SPECS.glob matches one config.
+        sync_agents("staging", "unified", backend="aurora")
+    assert mock_snapshots.called, "expected _write_snapshots to be called"
+    assert mock_snapshots.call_args.args == ("unified",)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,72 @@
+"""Integration test for the snapshot writer in sync.py."""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from botnim.db.session import get_session
+from botnim.sync import _write_snapshots
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _alembic_upgrade_head(database_url: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        ["alembic", "--config", "alembic.ini", "upgrade", "head"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_write_snapshots_inserts_per_source_and_aggregate(database_url, monkeypatch):
+    """Given some documents, _write_snapshots should write one row per
+    (context, source_id) plus one aggregate '*' row per context."""
+    _alembic_upgrade_head(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    # Fresh engine per test — DATABASE_URL changed
+    import botnim.db.session
+    botnim.db.session._engine = None
+    botnim.db.session._SessionFactory = None
+
+    with get_session() as sess:
+        cid_legal = sess.execute(text(
+            "INSERT INTO contexts (bot, name) VALUES ('unified', 'legal_text') RETURNING id"
+        )).scalar()
+        cid_eth = sess.execute(text(
+            "INSERT INTO contexts (bot, name) VALUES ('unified', 'ethics_decisions') RETURNING id"
+        )).scalar()
+        # 2 legal_text docs from חוק_הכנסת + 1 from תקנון_הכנסת + 3 ethics docs
+        for src, n in [("חוק_הכנסת", 2), ("תקנון_הכנסת", 1)]:
+            for i in range(n):
+                sess.execute(text(
+                    "INSERT INTO documents (context_id, content, content_hash, source_id) "
+                    "VALUES (:c, :body, :h, :s)"
+                ), {"c": cid_legal, "body": f"x{i}", "h": f"h{src}{i}", "s": src})
+        for i in range(3):
+            sess.execute(text(
+                "INSERT INTO documents (context_id, content, content_hash, source_id) "
+                "VALUES (:c, :body, :h, 'pdf_ethics')"
+            ), {"c": cid_eth, "body": f"e{i}", "h": f"hethic{i}"})
+
+    _write_snapshots("unified")
+
+    with get_session() as sess:
+        rows = sess.execute(text(
+            "SELECT context, source_id, doc_count FROM context_snapshots "
+            "WHERE bot='unified' ORDER BY context, source_id"
+        )).fetchall()
+    assert rows == [
+        ("ethics_decisions", "*", 3),
+        ("ethics_decisions", "pdf_ethics", 3),
+        ("legal_text", "*", 3),
+        ("legal_text", "חוק_הכנסת", 2),
+        ("legal_text", "תקנון_הכנסת", 1),
+    ], f"unexpected rows: {rows}"

--- a/tests/test_source_id.py
+++ b/tests/test_source_id.py
@@ -1,0 +1,47 @@
+"""Unit tests for _source_id_for — pure derivation, no DB or network."""
+from botnim.sync import _source_id_for
+
+
+def test_wikitext_returns_decoded_last_path_segment():
+    fetcher = {
+        "kind": "wikitext",
+        "input_url": "https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA",
+    }
+    assert _source_id_for(fetcher, None) == "חוק_הכנסת"
+
+
+def test_wikitext_strips_url_fragment():
+    fetcher = {
+        "kind": "wikitext",
+        "input_url": "https://he.wikisource.org/wiki/%D7%AA%D7%A7%D7%A0%D7%95%D7%9F_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA#section_3",
+    }
+    assert _source_id_for(fetcher, None) == "תקנון_הכנסת"
+
+
+def test_wikitext_handles_trailing_slash():
+    fetcher = {
+        "kind": "wikitext",
+        "input_url": "https://he.wikisource.org/wiki/page/",
+    }
+    assert _source_id_for(fetcher, None) == "page"
+
+
+def test_pdf_uses_basename_minus_extension():
+    fetcher = {"kind": "pdf"}
+    assert _source_id_for(fetcher, "extraction/knesset_committee_decisions.csv") == "knesset_committee_decisions"
+
+
+def test_lexicon_returns_fixed_string():
+    assert _source_id_for({"kind": "lexicon"}, None) == "lexicon"
+
+
+def test_bk_csv_returns_fixed_string():
+    assert _source_id_for({"kind": "bk_csv"}, None) == "bk_csv"
+
+
+def test_no_fetcher_uses_source_basename():
+    assert _source_id_for(None, "common-knowledge.md") == "common-knowledge"
+
+
+def test_no_fetcher_no_source_returns_unknown():
+    assert _source_id_for(None, None) == "unknown"

--- a/tests/test_vector_store_aurora.py
+++ b/tests/test_vector_store_aurora.py
@@ -606,3 +606,36 @@ def test_upload_files_oversize_content_replaces_old_skip_behavior(aurora_db, mon
         ), {"cid": cid}).scalar()
     assert n >= 2  # multiple chunks
     assert callback_count[0] >= 2  # callback got the row count, not the file count
+
+
+def test_upload_files_writes_source_id_from_metadata(aurora_db, monkeypatch):
+    """A file_stream tuple whose metadata carries source_id should result
+    in documents.source_id being populated."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.db.session import get_engine
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "legal_text"}, "legal_text", False)
+
+    streams = [(
+        "doc1.md",
+        io.BytesIO("# חוק_הכנסת\n\nbody text".encode("utf-8")),
+        "text/markdown",
+        {"title": "x", "source_id": "חוק_הכנסת"},
+    )]
+    store.upload_files({"slug": "legal_text"}, "legal_text", cid, streams, callback=None)
+
+    eng = get_engine()
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT source_id FROM documents WHERE context_id = :cid"
+        ), {"cid": cid}).fetchall()
+    assert rows, "expected at least one row inserted"
+    assert all(r[0] == "חוק_הכנסת" for r in rows), f"all rows should have source_id; got {rows!r}"


### PR DESCRIPTION
Pairs with parlibot:`docs/superpowers/specs/2026-04-27-admin-sources-screen-design.md` and parlibot:`docs/superpowers/plans/2026-04-27-admin-sources-screen.md`.

Adds the schema and sync-time writer for the upcoming admin /sources drift-detection screen. UI side ships in a follow-up LibreChat PR.

## Changes
- **Migration 0005** — `documents.source_id` (nullable TEXT) + index `(context_id, source_id)`.
- **Migration 0006** — `context_snapshots` (id UUID, snapshot_at timestamptz, bot, context, source_id, doc_count) + index `(bot, context, source_id, snapshot_at DESC)`.
- **`_source_id_for`** helper in `botnim/sync.py`: pure derivation per fetcher kind (wikitext → URL-decoded last segment, pdf → file basename, lexicon/bk_csv → fixed strings, no-fetcher → source basename).
- **`collect_sources` threading**: `_raw_streams_for_context` now returns 4-tuples carrying `source_id`; `_process_file_stream_async` folds it into the file's metadata dict; `collect_context_sources_async` passes it through. Confirmed no external callers of either function.
- **`upload_files` writes source_id**: `INSERT INTO documents` now includes `source_id` from per-stream metadata.
- **`_write_snapshots(bot_slug)`**: writes one row per `(bot, context, source_id)` plus one `'*'` aggregate per context. Single transaction.
- **Wired into `sync_agents`**: called after `publish_bot` per bot iteration. Failures upstream skip the snapshot.
- **One-shot backfill SQL** at `botnim/db/migrations/data/0005_backfill_source_id.sql` for legacy rows. Idempotent (`WHERE source_id IS NULL`).

## Test plan
- `pytest tests/test_source_id.py` — pure helper unit tests (8 specs).
- `pytest tests/test_migrations.py` — 0005 + 0006 schema + downgrade assertions.
- `pytest tests/test_snapshots.py` — `_write_snapshots` integration + sync_agents wire.
- `pytest tests/test_backfill_source_id.py` — backfill SQL applied against fresh DB.
- `pytest tests/test_vector_store_aurora.py::test_upload_files_writes_source_id_from_metadata` — end-to-end source_id lands in INSERT.

## Out-of-scope (followups)
- LibreChat-side `/api/admin/sources` endpoint + React UI (separate PR).
- Wiring `alembic upgrade head` into `deploy.sh` phase 8 — currently manual.
- The backfill-SQL test parser uses naive `sql.split(';')` filtering on comment-only chunks; works for this file but fragile to future edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
