### PR TITLE
fix(prompt): assemble instructions from agent_prompts (close Aurora migration loop)

### DIFF
--- a/botnim/bot_config.py
+++ b/botnim/bot_config.py
@@ -182,6 +182,36 @@ def _search_tool_for_context(bot_slug: str, context_slug: str, environment: str,
     }
 
 
+def _load_instructions_from_aurora(bot_slug: str) -> str:
+    """Assemble the bot's system prompt from the agent_prompts table.
+
+    Returns the joined body text (one section per row, separated by blank
+    lines + the same `---` rules the source file used) when one or more
+    active rows exist for `agent_type=bot_slug`. Returns an empty string
+    when the table is empty, has no active rows, or the DB is unreachable
+    — caller falls back to the file-based prompt in those cases (covers
+    local-dev pytest runs, first-deploy bootstrap, and any rollback path).
+
+    Local import + bare try/except so that environments without Aurora
+    connectivity (e.g. unit tests that mock `botnim.sync` at the module
+    level) don't blow up at module-load time.
+    """
+    try:
+        from sqlalchemy import text as _text
+        from .db.session import get_session
+        with get_session() as sess:
+            rows = sess.execute(_text(
+                "SELECT body FROM agent_prompts "
+                "WHERE agent_type = :a AND active = true "
+                "ORDER BY ordinal"
+            ), {"a": bot_slug}).fetchall()
+    except Exception:
+        return ''
+    if not rows:
+        return ''
+    return '\n\n---\n\n'.join(r[0] for r in rows if r[0])
+
+
 def load_bot_config(bot_slug: str, environment: str,
                     model: str | None = None,
                     temperature: float | None = None) -> BotConfig:
@@ -213,8 +243,15 @@ def load_bot_config(bot_slug: str, environment: str,
     with config_path.open() as f:
         cfg = yaml.safe_load(f)
 
-    instructions_path = bot_dir / cfg['instructions']
-    instructions = instructions_path.read_text()
+    # Prefer the Aurora-stored prompt (post-Aurora-migration design).
+    # When agent_prompts has active rows for this bot, assemble them into
+    # the system prompt; otherwise fall back to the file at cfg['instructions']
+    # (which after the migration is just the banner pointer, but useful
+    # in local-dev / first-run environments where Aurora is empty).
+    instructions = _load_instructions_from_aurora(bot_slug)
+    if not instructions:
+        instructions_path = bot_dir / cfg['instructions']
+        instructions = instructions_path.read_text()
     # Match pre-migration behavior: in production, strip any __dev markers the
     # prompt author used to annotate dev-only guidance.
     if is_production(environment):

--- a/scripts/backfill_agent_prompts.py
+++ b/scripts/backfill_agent_prompts.py
@@ -1,0 +1,126 @@
+"""Backfill agent_prompts table from a sectioned agent.txt.
+
+Parses an agent.txt that uses `<!-- SECTION_KEY: name -->` and
+`<!-- header_text -->` markers, then INSERTs one active row per section
+into agent_prompts. Idempotent: if active rows already exist for the
+agent_type, the script aborts unless --force is passed (which deactivates
+the existing rows first).
+
+Usage from inside the ECS task:
+    cd /srv && python3 scripts/backfill_agent_prompts.py \
+        --agent-type unified \
+        --file /tmp/agent.txt \
+        --created-by backfill-2026-04-27
+
+For local-dev validation, set DATABASE_URL env var first.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+from botnim.db.session import get_session
+
+SECTION_RE = re.compile(r"^<!--\s*SECTION_KEY:\s*([\w_]+)\s*-->\s*$", re.M)
+HEADER_RE = re.compile(r"^<!--\s*(.+?)\s*-->\s*$")
+
+
+def parse_sections(text_blob: str) -> list[tuple[str, str | None, str]]:
+    """Split agent.txt into [(section_key, header_text|None, body)] tuples.
+
+    The body for each section starts after the optional header_text comment
+    line and runs until the next SECTION_KEY marker or end-of-file. The
+    `---` horizontal rules between sections in the source file are stripped
+    from the trailing body so each row stores clean content.
+    """
+    matches = list(SECTION_RE.finditer(text_blob))
+    if not matches:
+        raise ValueError("no <!-- SECTION_KEY: ... --> markers found")
+    sections: list[tuple[str, str | None, str]] = []
+    for i, m in enumerate(matches):
+        section_key = m.group(1)
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text_blob)
+        chunk = text_blob[body_start:body_end].lstrip("\n")
+
+        # Optional header_text comment immediately after the SECTION_KEY line.
+        header_text: str | None = None
+        first_line, _, rest = chunk.partition("\n")
+        hm = HEADER_RE.match(first_line)
+        if hm:
+            header_text = hm.group(1)
+            chunk = rest.lstrip("\n")
+
+        # Strip a trailing `---` separator and surrounding whitespace.
+        body = re.sub(r"\n+---\s*$", "", chunk).strip()
+        sections.append((section_key, header_text, body))
+    return sections
+
+
+def backfill(
+    agent_type: str,
+    file_path: Path,
+    created_by: str,
+    force: bool,
+) -> None:
+    blob = file_path.read_text(encoding="utf-8")
+    sections = parse_sections(blob)
+    print(f"parsed {len(sections)} sections from {file_path}", file=sys.stderr)
+    for s in sections:
+        print(f"  - {s[0]} (header_text len={len(s[1] or '')}, body len={len(s[2])})",
+              file=sys.stderr)
+
+    with get_session() as sess:
+        existing = sess.execute(text(
+            "SELECT count(*) FROM agent_prompts WHERE agent_type = :a AND active = true"
+        ), {"a": agent_type}).scalar()
+        if existing and not force:
+            raise SystemExit(
+                f"refusing to insert: {existing} active rows already exist for "
+                f"agent_type={agent_type!r}. Pass --force to deactivate them first."
+            )
+        if force and existing:
+            print(f"deactivating {existing} existing active rows for {agent_type}",
+                  file=sys.stderr)
+            sess.execute(text(
+                "UPDATE agent_prompts SET active = false "
+                "WHERE agent_type = :a AND active = true"
+            ), {"a": agent_type})
+
+        for ordinal, (section_key, header_text, body) in enumerate(sections, start=1):
+            sess.execute(text(
+                "INSERT INTO agent_prompts "
+                "(agent_type, section_key, ordinal, header_text, body, "
+                " active, is_draft, created_by, published_at) "
+                "VALUES (:a, :k, :o, :h, :b, true, false, :u, now())"
+            ), {
+                "a": agent_type,
+                "k": section_key,
+                "o": ordinal,
+                "h": header_text,
+                "b": body,
+                "u": created_by,
+            })
+
+    print(f"inserted {len(sections)} active rows for agent_type={agent_type}",
+          file=sys.stderr)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--agent-type", required=True)
+    p.add_argument("--file", required=True, type=Path)
+    p.add_argument("--created-by", default="backfill")
+    p.add_argument("--force", action="store_true",
+                   help="Deactivate existing active rows before inserting.")
+    args = p.parse_args()
+    backfill(args.agent_type, args.file, args.created_by, args.force)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the Aurora-migration loop that left agent.txt as a banner pointing at an empty agent_prompts table. Prefer Aurora when populated, fall back to file. Adds scripts/backfill_agent_prompts.py to seed the table from a sectioned agent.txt.

Companion ops: backfill staging via SSM exec, then `botnim sync staging unified` to republish the assembled prompt.