### PR TITLE
perf(gov_il_decisions): batch embeddings to cut bootstrap from ~2h to ~10min

### DIFF
--- a/botnim/document_parser/gov_il_decisions/aurora_writer.py
+++ b/botnim/document_parser/gov_il_decisions/aurora_writer.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from datetime import datetime
 
+from openai import OpenAI
 from sqlalchemy import text as sql_text
 
-from ...config import get_logger
+from ...config import DEFAULT_EMBEDDING_MODEL, get_logger
 from ...db.session import get_session
 from ...vector_store.vector_store_aurora import (
     _chunk_for_embedding,
@@ -30,6 +32,11 @@ from ...vector_store.vector_store_aurora import (
 logger = get_logger(__name__)
 
 SOURCE_ID = "gov_il_decisions"
+
+# OpenAI's embeddings endpoint accepts up to 2048 inputs per call. Default
+# bootstrap batch size is well under that — leaves headroom for chunking
+# expanding the count above the per-decision input batch.
+MAX_EMBEDDING_BATCH_SIZE = 2048
 
 
 def get_or_create_context(bot: str, name: str) -> str:
@@ -118,3 +125,140 @@ def write_decision(
                 continue
 
     return inserted
+
+
+def _resolve_openai_api_key(environment: str) -> str | None:
+    """Mirror `_get_embedding_client`'s key resolution rules.
+
+    Production reads OPENAI_API_KEY_PRODUCTION; everything else (local,
+    staging) reads OPENAI_API_KEY_STAGING. Documented at length in
+    CLAUDE.md ("OPENAI_API_KEY_STAGING is required even for ENV=local").
+    """
+    if environment == "production":
+        return os.getenv("OPENAI_API_KEY_PRODUCTION")
+    return os.getenv("OPENAI_API_KEY_STAGING")
+
+
+def write_decisions_batched(
+    records: list[dict],
+    *,
+    environment: str,
+    embedding_batch_size: int = 1000,
+) -> dict[str, int]:
+    """Embed + UPSERT many decisions in batched OpenAI calls.
+
+    ``records`` is a list of dicts with the same keys ``write_decision``
+    accepts: ``context_id, page_id, title, text, metadata``. ``context_id``
+    is per-record so callers can mix contexts in one call if they want; in
+    practice the bootstrap script passes the same context_id for every
+    record.
+
+    Pipeline:
+        1. For each record: chunk text via ``_chunk_for_embedding``, build
+           a plan of ``(record_idx, chunk_idx, total_chunks, chunk_text,
+           content_hash)``.
+        2. Batch the plan's chunks into groups of ``embedding_batch_size``
+           and call ``client.embeddings.create(input=[batch])`` once per
+           batch.
+        3. INSERT each chunk row with ``ON CONFLICT (context_id,
+           content_hash) DO NOTHING`` so re-runs over an already-imported
+           Aurora are no-ops.
+
+    Returns ``{"chunks_planned": N, "chunks_written": M, "decisions": K}``
+    where ``chunks_written`` reflects ``cursor.rowcount`` summed across
+    INSERTs — i.e., the count AFTER ON CONFLICT filtering.
+    """
+    if embedding_batch_size <= 0:
+        raise ValueError("embedding_batch_size must be positive")
+    if embedding_batch_size > MAX_EMBEDDING_BATCH_SIZE:
+        raise ValueError(
+            f"embedding_batch_size {embedding_batch_size} exceeds OpenAI's "
+            f"per-request maximum of {MAX_EMBEDDING_BATCH_SIZE}"
+        )
+
+    if not records:
+        return {"chunks_planned": 0, "chunks_written": 0, "decisions": 0}
+
+    # ---- Phase 1: build the plan ------------------------------------------
+    extracted_at = datetime.utcnow().isoformat()
+    plan: list[dict] = []
+    for record_idx, rec in enumerate(records):
+        text_value = rec.get("text") or ""
+        chunks = _chunk_for_embedding(text_value)
+        # _chunk_for_embedding always returns at least one element (the
+        # empty-string case yields ['']), so total_chunks >= 1.
+        total_chunks = len(chunks)
+        for chunk_idx, chunk_content in enumerate(chunks):
+            chunk_hash = hashlib.sha256(chunk_content.encode("utf-8")).hexdigest()
+            doc_metadata = dict(rec.get("metadata") or {})
+            doc_metadata["page_id"] = rec["page_id"]
+            doc_metadata["title"] = doc_metadata.get("title", rec.get("title", ""))
+            doc_metadata["chunk_index"] = chunk_idx
+            doc_metadata["total_chunks"] = total_chunks
+            doc_metadata["extracted_at"] = extracted_at
+            plan.append({
+                "record_idx": record_idx,
+                "context_id": rec["context_id"],
+                "chunk_content": chunk_content,
+                "content_hash": chunk_hash,
+                "metadata": doc_metadata,
+            })
+
+    chunks_planned = len(plan)
+    if chunks_planned == 0:
+        return {"chunks_planned": 0, "chunks_written": 0, "decisions": len(records)}
+
+    # ---- Phase 2 + 3: batch embed + INSERT --------------------------------
+    api_key = _resolve_openai_api_key(environment)
+    client = OpenAI(api_key=api_key)
+
+    total_batches = (chunks_planned + embedding_batch_size - 1) // embedding_batch_size
+    chunks_written = 0
+    cumulative = 0
+
+    for batch_idx in range(total_batches):
+        start = batch_idx * embedding_batch_size
+        end = min(start + embedding_batch_size, chunks_planned)
+        batch = plan[start:end]
+        inputs = [item["chunk_content"] for item in batch]
+
+        response = client.embeddings.create(
+            input=inputs,
+            model=DEFAULT_EMBEDDING_MODEL,
+        )
+        # OpenAI guarantees response.data is in the same order as inputs.
+        if len(response.data) != len(batch):
+            raise RuntimeError(
+                f"OpenAI returned {len(response.data)} embeddings for a "
+                f"batch of {len(batch)} inputs"
+            )
+
+        with get_session() as sess:
+            for item, datum in zip(batch, response.data):
+                result = sess.execute(sql_text(
+                    "INSERT INTO documents "
+                    "(context_id, content, content_hash, metadata, embedding, source_id) "
+                    "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector), :sid) "
+                    "ON CONFLICT (context_id, content_hash) DO NOTHING"
+                ), {
+                    "cid": item["context_id"],
+                    "c": item["chunk_content"],
+                    "h": item["content_hash"],
+                    "m": json.dumps(item["metadata"]),
+                    "e": str(datum.embedding),
+                    "sid": SOURCE_ID,
+                })
+                if result.rowcount and result.rowcount > 0:
+                    chunks_written += 1
+
+        cumulative += len(batch)
+        logger.info(
+            "embedded batch %d/%d (chunks=%d, cumulative=%d)",
+            batch_idx + 1, total_batches, len(batch), cumulative,
+        )
+
+    return {
+        "chunks_planned": chunks_planned,
+        "chunks_written": chunks_written,
+        "decisions": len(records),
+    }

--- a/scripts/bootstrap_gov_decisions.py
+++ b/scripts/bootstrap_gov_decisions.py
@@ -42,12 +42,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from botnim.document_parser.gov_il_decisions.aurora_writer import (  # noqa: E402
     existing_page_ids,
     get_or_create_context,
-    write_decision,
+    write_decisions_batched,
 )
 from botnim.document_parser.gov_il_decisions.categorize import (  # noqa: E402
     ACTION_TYPES,
     DOMAINS,
 )
+
+
+# Number of decisions buffered before each batched flush. Each flush
+# embeds all buffered chunks in one OpenAI multi-input call (capped at
+# 2048 inputs per request); 500 decisions averages ~530 chunks, well
+# under the cap and large enough to amortize HTTP latency.
+BUFFER_SIZE = 500
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -109,6 +116,7 @@ def bootstrap(
     environment: str,
     bot: str,
     context: str,
+    buffer_size: int = BUFFER_SIZE,
 ) -> None:
     wb = openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)
     ws = wb[wb.sheetnames[0]]
@@ -133,6 +141,35 @@ def bootstrap(
     ok = 0
     skipped_existing = 0
     skipped_unknown_vocab = 0
+    buffer: list[dict] = []
+
+    def _flush() -> None:
+        """Embed + write all buffered records in one batched OpenAI call."""
+        nonlocal ok
+        if not buffer:
+            return
+        try:
+            result = write_decisions_batched(buffer, environment=environment)
+            ok += result["decisions"]
+            logger.info(
+                "flushed batch: decisions=%d chunks_planned=%d chunks_written=%d",
+                result["decisions"], result["chunks_planned"], result["chunks_written"],
+            )
+        except Exception as exc:
+            # On batch failure, fall back to per-record writes so a single
+            # bad record doesn't lose the rest of the buffer. Re-running
+            # the script is also safe (ON CONFLICT DO NOTHING).
+            logger.warning("batched flush failed (%s); retrying per-record", exc)
+            for rec in buffer:
+                try:
+                    write_decisions_batched([rec], environment=environment)
+                    ok += 1
+                except Exception as inner:
+                    logger.warning(
+                        "write_decisions_batched failed for %s: %s",
+                        rec.get("page_id"), inner,
+                    )
+        buffer.clear()
 
     for raw in rows:
         if not raw:
@@ -175,25 +212,26 @@ def bootstrap(
             "part": part,
         }
 
-        try:
-            write_decision(
-                cid,
-                page_id=page_id,
-                title=title,
-                text=text,
-                metadata=metadata,
-                environment=environment,
-            )
-            ok += 1
-            seen.add(page_id)
-        except Exception as exc:
-            logger.warning("write_decision failed for %s: %s", page_id, exc)
+        buffer.append({
+            "context_id": cid,
+            "page_id": page_id,
+            "title": title,
+            "text": text,
+            "metadata": metadata,
+        })
+        seen.add(page_id)
+
+        if len(buffer) >= buffer_size:
+            _flush()
 
         if total % 500 == 0:
             logger.info(
                 "bootstrapped %d (ok=%d skipped_existing=%d skipped_unknown_vocab=%d)",
                 total, ok, skipped_existing, skipped_unknown_vocab,
             )
+
+    # Final flush of any partial buffer.
+    _flush()
 
     logger.info(
         "DONE total=%d ok=%d skipped_existing=%d skipped_unknown_vocab=%d",
@@ -215,6 +253,15 @@ def main() -> None:
     )
     parser.add_argument("--bot", default="unified")
     parser.add_argument("--context", default="government_decisions")
+    parser.add_argument(
+        "--buffer-size",
+        type=int,
+        default=BUFFER_SIZE,
+        help=(
+            "Decisions to buffer between batched embed+upsert flushes. "
+            f"Defaults to {BUFFER_SIZE}."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.xlsx.exists():
@@ -226,6 +273,7 @@ def main() -> None:
         environment=args.environment,
         bot=args.bot,
         context=args.context,
+        buffer_size=args.buffer_size,
     )
 
 

--- a/tests/document_parser/gov_il_decisions/test_aurora_writer.py
+++ b/tests/document_parser/gov_il_decisions/test_aurora_writer.py
@@ -170,3 +170,221 @@ def test_idempotent_on_rerun(aurora_db, fake_embedder):
             "SELECT count(*) FROM documents WHERE context_id=:cid"
         ), {"cid": cid}).scalar()
     assert total == 1
+
+
+# ---------------------------------------------------------------------------
+# write_decisions_batched — bulk path used by the Excel bootstrap.
+# ---------------------------------------------------------------------------
+
+
+class _FakeBatchOpenAI:
+    """Mimics the subset of openai.OpenAI used by write_decisions_batched.
+
+    Returns deterministic 1536-dim embeddings keyed off the input text's
+    sha256 digest so each call is order-preserving and content-distinct.
+    """
+
+    def __init__(self):
+        self.batch_calls: list[list[str]] = []
+        self.embeddings = self  # let `client.embeddings.create(...)` work
+
+    def create(self, *, input, model):
+        # OpenAI accepts either str or list[str]; the batched path always
+        # passes a list, so assert that and record it for later inspection.
+        assert isinstance(input, list)
+        self.batch_calls.append(list(input))
+
+        class _Datum:
+            def __init__(self, embedding):
+                self.embedding = embedding
+
+        class _Resp:
+            def __init__(self, data):
+                self.data = data
+
+        data = []
+        for txt in input:
+            h = hashlib.sha256(txt.encode("utf-8")).digest()
+            vec = [(b / 255.0) for b in h] * 48  # 32 * 48 = 1536
+            data.append(_Datum(vec))
+        return _Resp(data)
+
+
+@pytest.fixture
+def fake_batch_openai(monkeypatch):
+    fake = _FakeBatchOpenAI()
+    # The implementation constructs `openai.OpenAI(api_key=...)` directly to
+    # access the multi-input embeddings API. Patch the symbol it imports.
+    monkeypatch.setattr(
+        "botnim.document_parser.gov_il_decisions.aurora_writer.OpenAI",
+        lambda api_key=None: fake,
+    )
+    return fake
+
+
+def test_batched_round_trip(aurora_db, fake_batch_openai):
+    from botnim.document_parser.gov_il_decisions.aurora_writer import (
+        get_or_create_context,
+        write_decisions_batched,
+    )
+    from botnim.db.session import get_engine
+
+    cid = get_or_create_context("unified", "government_decisions")
+
+    # Build one short decision and one decision long enough to chunk.
+    long_body_parts = [f"מילה{i}" for i in range(8000)]
+    long_body = " ".join(long_body_parts)
+
+    records = [
+        {
+            "context_id": cid,
+            "page_id": "dec-a",
+            "title": "כותרת א",
+            "text": "גוף קצר א",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        },
+        {
+            "context_id": cid,
+            "page_id": "dec-b",
+            "title": "כותרת ב",
+            "text": "גוף קצר ב",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        },
+        {
+            "context_id": cid,
+            "page_id": "dec-long",
+            "title": "ארוכה",
+            "text": long_body,
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        },
+    ]
+    result = write_decisions_batched(records, environment="staging")
+
+    assert result["decisions"] == 3
+    assert result["chunks_planned"] >= 4  # 1 + 1 + (>=2 from the long one)
+    assert result["chunks_written"] == result["chunks_planned"]
+
+    # Verify the long decision produced multiple rows with proper indexing
+    eng = get_engine()
+    with eng.connect() as conn:
+        long_rows = conn.execute(text(
+            "SELECT metadata FROM documents "
+            "WHERE context_id=:cid AND metadata->>'page_id'=:pid"
+        ), {"cid": cid, "pid": "dec-long"}).fetchall()
+    assert len(long_rows) >= 2
+    totals = {r[0]["total_chunks"] for r in long_rows}
+    assert totals == {len(long_rows)}
+    chunk_indexes = sorted(r[0]["chunk_index"] for r in long_rows)
+    assert chunk_indexes == list(range(len(long_rows)))
+
+    # source_id is set
+    with eng.connect() as conn:
+        srcs = {r[0] for r in conn.execute(text(
+            "SELECT DISTINCT source_id FROM documents WHERE context_id=:cid"
+        ), {"cid": cid}).fetchall()}
+    assert srcs == {"gov_il_decisions"}
+
+    # The OpenAI client was called in batched form (one call per
+    # embedding_batch_size group) with the planned chunk count summing
+    # across all calls.
+    total_inputs = sum(len(c) for c in fake_batch_openai.batch_calls)
+    assert total_inputs == result["chunks_planned"]
+
+
+def test_batched_idempotent(aurora_db, fake_batch_openai):
+    from botnim.document_parser.gov_il_decisions.aurora_writer import (
+        get_or_create_context,
+        write_decisions_batched,
+    )
+    from botnim.db.session import get_engine
+
+    cid = get_or_create_context("unified", "government_decisions")
+    records = [
+        {
+            "context_id": cid,
+            "page_id": "dec-x",
+            "title": "x",
+            "text": "body x",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        },
+        {
+            "context_id": cid,
+            "page_id": "dec-y",
+            "title": "y",
+            "text": "body y",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        },
+    ]
+    r1 = write_decisions_batched(records, environment="staging")
+    assert r1["chunks_written"] == 2
+
+    r2 = write_decisions_batched(records, environment="staging")
+    assert r2["chunks_planned"] == 2
+    assert r2["chunks_written"] == 0  # ON CONFLICT DO NOTHING
+
+    eng = get_engine()
+    with eng.connect() as conn:
+        total = conn.execute(text(
+            "SELECT count(*) FROM documents WHERE context_id=:cid"
+        ), {"cid": cid}).scalar()
+    assert total == 2
+
+
+def test_batched_handles_empty_text(aurora_db, fake_batch_openai):
+    from botnim.document_parser.gov_il_decisions.aurora_writer import (
+        get_or_create_context,
+        write_decisions_batched,
+    )
+    from botnim.db.session import get_engine
+
+    cid = get_or_create_context("unified", "government_decisions")
+    result = write_decisions_batched(
+        [{
+            "context_id": cid,
+            "page_id": "dec-empty",
+            "title": "no body",
+            "text": "",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        }],
+        environment="staging",
+    )
+    assert result["decisions"] == 1
+    assert result["chunks_written"] == 1
+
+    eng = get_engine()
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT content, metadata FROM documents WHERE context_id=:cid"
+        ), {"cid": cid}).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == ""  # empty content row written
+    assert rows[0][1]["page_id"] == "dec-empty"
+    assert rows[0][1]["total_chunks"] == 1
+    assert rows[0][1]["chunk_index"] == 0
+
+
+def test_batched_respects_embedding_batch_size(aurora_db, fake_batch_openai):
+    """With 5 chunks and batch_size=2, expect ceil(5/2)=3 OpenAI calls."""
+    from botnim.document_parser.gov_il_decisions.aurora_writer import (
+        get_or_create_context,
+        write_decisions_batched,
+    )
+
+    cid = get_or_create_context("unified", "government_decisions")
+    records = [
+        {
+            "context_id": cid,
+            "page_id": f"dec-batch-{i}",
+            "title": f"t{i}",
+            "text": f"body {i}",
+            "metadata": {"action_type": "אחר", "domain": "כללי"},
+        }
+        for i in range(5)
+    ]
+    result = write_decisions_batched(
+        records, environment="staging", embedding_batch_size=2,
+    )
+    assert result["chunks_planned"] == 5
+    assert result["chunks_written"] == 5
+    # 3 batches of sizes [2, 2, 1]
+    assert [len(c) for c in fake_batch_openai.batch_calls] == [2, 2, 1]


### PR DESCRIPTION
## Summary

- New `write_decisions_batched(records, *, environment, embedding_batch_size=1000)` in `botnim/document_parser/gov_il_decisions/aurora_writer.py`. One OpenAI multi-input embeddings call per batch, then INSERTs all rows with the same `(context_id, content_hash)` ON CONFLICT DO NOTHING dedup the existing single-decision writer uses. Existing `write_decision` is kept untouched for the runtime fetcher.
- `scripts/bootstrap_gov_decisions.py` now buffers 500 decisions (configurable with `--buffer-size`) and flushes via the batched writer. Same pre-filter via `existing_page_ids`, same per-row parsing, same idempotency. On a batch failure the script falls back to per-record retries so a single bad row can't lose the rest of the buffer.

Expected impact on the prod bootstrap: ~2h 26min observed in staging drops to ~10 minutes (each batch is one HTTP round-trip embedding ~530 chunks instead of 530 sequential calls).

## Test plan

- [x] `AIRTABLE_API_KEY=dummy .venv/bin/python -m pytest tests/document_parser/gov_il_decisions/` -> 28 passed (24 prior + 4 new)
- [x] New test `test_batched_round_trip` covers short + multi-chunk decisions in one call, asserts `chunk_index`/`total_chunks` correctness
- [x] New test `test_batched_idempotent` re-runs and asserts `chunks_written: 0` while no rows duplicated
- [x] New test `test_batched_handles_empty_text` writes a metadata-only row for empty text (mirrors `write_decision`)
- [x] New test `test_batched_respects_embedding_batch_size` validates the batching call shape (5 chunks, batch_size=2 -> 3 OpenAI calls of [2, 2, 1])
- [ ] Bootstrap dry-run on staging Aurora once merged: `python scripts/bootstrap_gov_decisions.py --xlsx ... --environment staging`
- [ ] Confirm staging `/admin/sources` document count for `(unified, government_decisions)` matches the prior bootstrap

Generated with [Claude Code](https://claude.com/claude-code)
