### PR TITLE
feat(infra): bring prod to staging parity for gov_il_decisions + daily refresh

### DIFF
--- a/infra/envs/prod/efs.tf
+++ b/infra/envs/prod/efs.tf
@@ -1,14 +1,22 @@
 ################################################################################
-# EFS filesystem for botnim-api
+# Shared EFS filesystem for botnim-api
 #
-# The es-data access point has been removed as part of the Aurora migration
-# (the ES sidecar no longer runs in production). The EFS filesystem module is
-# retained here because backups.tf still references module.es_efs.file_system_id
-# for AWS Backup.
+# Two POSIX-isolated access points on one filesystem:
+#  - cache:           /srv/cache in the primary api container — sqlite KV caches
+#                     (metadata extraction + embeddings) warmed across task restarts
+#                     so the first botnim sync after a deploy is the only expensive one.
+#                     SAFE ONLY WHILE desired_count = 1; see main.tf for the reason.
+#  - specs-extraction: /srv/specs/unified/extraction in the primary container.
+#                     Daily refresh job writes fresh CSVs here. On first deploy
+#                     (empty EFS) api_server.sh seeds from the image-baked copy
+#                     at /srv/specs-seed. Backed up via the same aws_backup_plan
+#                     as the other APs (whole-filesystem snapshot).
 #
-# TODO(post-soak): after Window C closes (~T+30d), evaluate decommissioning
-# this EFS filesystem entirely if no access points remain and AWS Backup can
-# be pointed at a different target (or removed).
+# Note: the es-data access point has been removed as part of the Aurora migration
+# (the ES sidecar no longer runs). The EFS filesystem itself is retained for the
+# cache + specs-extraction APs.
+# TODO(post-soak): remove after Window C closes (~T+30d) — evaluate whether
+# the EFS filesystem itself can be decommissioned once the soak period ends.
 ################################################################################
 
 module "es_efs" {
@@ -18,5 +26,18 @@ module "es_efs" {
   vpc_id             = local.contract.network.vpc_id
   private_subnet_ids = local.contract.network.private_subnet_ids
 
-  access_points = []
+  access_points = [
+    {
+      name      = "cache"
+      path      = "/cache"
+      posix_uid = 1000
+      posix_gid = 1000
+    },
+    {
+      name      = "specs-extraction"
+      path      = "/specs-extraction"
+      posix_uid = 1000
+      posix_gid = 1000
+    },
+  ]
 }

--- a/infra/envs/prod/efs_backup.tf
+++ b/infra/envs/prod/efs_backup.tf
@@ -1,0 +1,94 @@
+################################################################################
+# AWS Backup for the botnim-api EFS filesystem
+#
+# Primary motivation: protect the /srv/cache access point (two sqlite KV stores
+# for dynamic_extraction metadata + OpenAI embeddings). Losing /srv/cache forces
+# another ~5.5 h cold sync; AWS Backup guarantees a point-in-time copy.
+#
+# The same plan also snapshots /es (the ES sidecar's Lucene data dir) but we
+# do NOT rely on it for ES recovery. Lucene files are written continuously and
+# a crash-consistent file-level snapshot can capture half-merged segments that
+# refuse to boot. ES's native repository-s3 snapshot API is what we'll use for
+# real ES recovery once that hook lands (see Monday task on post-sync snapshot).
+# The EFS backup is belt-and-suspenders for the /cache side.
+#
+# Schedule: once daily at 03:00 UTC (quiet hour). Retention: 30 days.
+# No cold-storage transition — the filesystem is small enough that warm
+# storage is cheaper than the pre-conversion floor cost.
+################################################################################
+
+resource "aws_backup_vault" "efs" {
+  name = "botnim-api-${var.environment}"
+  # No KMS key — AWS Backup auto-creates and manages a CMK per account per
+  # region for the default vault. We don't need CMK-level access controls
+  # here; the vault is scoped to this account and AWS Backup's service role.
+}
+
+resource "aws_backup_plan" "efs" {
+  name = "botnim-api-${var.environment}-efs"
+
+  rule {
+    rule_name         = "daily"
+    target_vault_name = aws_backup_vault.efs.name
+    # 03:00 UTC every day. Far from any likely deploy window.
+    schedule = "cron(0 3 * * ? *)"
+
+    start_window      = 60  # minutes AWS Backup has to start the job
+    completion_window = 180 # minutes to finish it
+
+    lifecycle {
+      delete_after = 30 # days; no cold transition
+    }
+  }
+}
+
+################################################################################
+# Service role for AWS Backup to read/write EFS + tag resources
+################################################################################
+
+data "aws_iam_policy_document" "backup_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "backup" {
+  name               = "botnim-api-${var.environment}-efs-backup"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "backup_restores" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+################################################################################
+# Which resources this plan protects
+################################################################################
+
+resource "aws_backup_selection" "efs" {
+  name         = "botnim-api-${var.environment}-efs"
+  plan_id      = aws_backup_plan.efs.id
+  iam_role_arn = aws_iam_role.backup.arn
+
+  resources = [
+    # Single target: the shared EFS filesystem that holds both /es and /cache
+    # access points. AWS Backup snapshots the whole filesystem, not individual
+    # access points, so both access points end up in every recovery point.
+    "arn:aws:elasticfilesystem:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/${module.es_efs.file_system_id}",
+  ]
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/infra/envs/prod/lambda/refresh_invoker/handler.py
+++ b/infra/envs/prod/lambda/refresh_invoker/handler.py
@@ -1,0 +1,91 @@
+"""Lambda entrypoint that invokes botnim-api /admin/refresh.
+
+Triggered by EventBridge Schedule. Reads the admin API key from Secrets
+Manager, POSTs to the refresh endpoint via VPC (Service Connect), and
+raises on non-2xx so Lambda's built-in `Errors` metric increments — an
+independent CloudWatch alarm on that metric covers the case where the
+in-API logging path can't fire because the API task itself is down.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+SECRET_ARN = os.environ["ADMIN_API_KEY_SECRET_ARN"]
+ENDPOINT_URL = os.environ["REFRESH_ENDPOINT_URL"]
+
+
+def _diagnose_endpoint(url: str) -> str:
+    """Resolve and TCP-probe the endpoint host before opening the HTTP
+    connection. Lambda VPC + Route53 split-horizon DNS quirks tend to
+    surface as opaque urlopen errors (e.g. EBUSY on connect when the
+    name resolves to an IP that isn't reachable from the Lambda ENI).
+    Returning a structured trace string up front makes the actual
+    failure mode visible in CloudWatch instead of buried in a stack
+    trace inside `do_open`.
+    """
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+
+    # Read the Lambda runtime's resolver config — useful if getaddrinfo
+    # blows up with EBUSY (often filesystem contention reading these).
+    resolv = ""
+    try:
+        with open("/etc/resolv.conf", "r") as f:
+            resolv = f.read().strip()
+    except OSError as e:
+        resolv = f"<resolv.conf read failed: {e}>"
+
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        ips = sorted({info[4][0] for info in infos})
+        return f"DNS_OK host={host} port={port} ips={ips} resolv={resolv!r}"
+    except OSError as e:
+        return f"DNS_FAIL host={host} errno={getattr(e, 'errno', '?')} err={e!r} resolv={resolv!r}"
+
+
+def handler(event, context):  # noqa: ARG001 (Lambda entrypoint signature)
+    sm = boto3.client("secretsmanager")
+    secret = sm.get_secret_value(SecretId=SECRET_ARN)
+    api_key = secret["SecretString"]
+
+    diag = _diagnose_endpoint(ENDPOINT_URL)
+    logger.info(f"endpoint diag: {diag}")
+
+    req = urllib.request.Request(
+        url=ENDPOINT_URL,
+        method="POST",
+        headers={
+            "X-API-Key": api_key,
+            "Content-Type": "application/json",
+        },
+        data=b"{}",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            status = resp.status
+            body = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        status = e.code
+        logger.error(f"refresh endpoint returned {status}: {body}")
+        raise RuntimeError(f"refresh endpoint returned {status}: {body}") from e
+    except urllib.error.URLError as e:
+        logger.error(f"refresh endpoint unreachable: {e} (diag: {diag})")
+        raise
+
+    logger.info(f"refresh endpoint returned {status}: {body}")
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"refresh endpoint returned {status}: {body}")
+    return {"statusCode": status, "body": body}

--- a/infra/envs/prod/lambda/refresh_invoker/test_handler.py
+++ b/infra/envs/prod/lambda/refresh_invoker/test_handler.py
@@ -1,0 +1,63 @@
+"""Unit tests for the refresh-invoker Lambda handler."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _path_and_env(monkeypatch: pytest.MonkeyPatch):
+    here = os.path.dirname(__file__)
+    sys.path.insert(0, here)
+    monkeypatch.setenv("ADMIN_API_KEY_SECRET_ARN", "arn:aws:secretsmanager:il-central-1:000:secret:x")
+    monkeypatch.setenv("REFRESH_ENDPOINT_URL", "http://botnim-api:8000/botnim/admin/refresh")
+    # Clear cached module
+    sys.modules.pop("handler", None)
+
+
+def _fake_secrets_client(secret_string: str = "s3cret") -> MagicMock:
+    client = MagicMock()
+    client.get_secret_value.return_value = {"SecretString": secret_string}
+    return client
+
+
+def test_happy_path_posts_with_x_api_key_header():
+    import handler  # noqa: WPS433 (local import for monkeypatched env)
+
+    mock_response = MagicMock()
+    mock_response.status = 202
+    mock_response.read.return_value = b'{"status":"accepted"}'
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=None)
+
+    with patch.object(handler.boto3, "client", return_value=_fake_secrets_client("s3cret")) as mock_boto, \
+         patch.object(handler.urllib.request, "urlopen", return_value=mock_response) as mock_urlopen:
+        result = handler.handler(event={}, context=None)
+
+    assert result["statusCode"] == 202
+    # boto3 client called for secretsmanager
+    assert mock_boto.call_args.args == ("secretsmanager",)
+    # urllib.request.Request passed as first arg to urlopen; grab it
+    req = mock_urlopen.call_args.args[0]
+    assert req.full_url == "http://botnim-api:8000/botnim/admin/refresh"
+    assert req.get_method() == "POST"
+    assert req.headers.get("X-api-key") == "s3cret"
+
+
+def test_non_202_raises_so_lambda_error_metric_fires():
+    import handler
+
+    bad_response = MagicMock()
+    bad_response.status = 500
+    bad_response.read.return_value = b"nope"
+    bad_response.__enter__ = MagicMock(return_value=bad_response)
+    bad_response.__exit__ = MagicMock(return_value=None)
+
+    with patch.object(handler.boto3, "client", return_value=_fake_secrets_client()), \
+         patch.object(handler.urllib.request, "urlopen", return_value=bad_response):
+        with pytest.raises(RuntimeError):
+            handler.handler(event={}, context=None)

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -41,6 +41,16 @@ module "botnim_api" {
     path_patterns     = ["/botnim/*"]
   }
 
+  # Publish botnim-api as an internal Service Connect endpoint so librechat
+  # (same VPC, different Fargate task) can call it without hairpinning
+  # through the public ALB. The public /botnim/* route above still works for
+  # external callers; this just adds an in-VPC path for siblings.
+  #
+  # Defaults: discovery_name = app_name = "botnim-api", client_alias_port =
+  # container_port = 8000, app_protocol = "http". In-cluster URL:
+  #   http://botnim-api:8000
+  internal_server = {}
+
   enable_aurora_access = true
 
   environment_variables = {
@@ -54,6 +64,9 @@ module "botnim_api" {
   secret_environment_variables = merge(
     {
       OPENAI_API_KEY_PRODUCTION = aws_secretsmanager_secret.openai_api_key.arn
+      # Consumed by backend/api/refresh_auth.py to authenticate the Lambda's
+      # calls to /admin/refresh. Value is set out-of-band via Secrets Manager.
+      BOTNIM_ADMIN_API_KEY = aws_secretsmanager_secret.refresh_admin_api_key.arn
     },
     {
       DB_HOST     = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:host::"
@@ -63,6 +76,64 @@ module "botnim_api" {
       DB_PASSWORD = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:password::"
     },
   )
+
+  efs_volumes = [
+    # Persistent cache for botnim sync. Two sqlite KV stores live under
+    # /srv/cache: `metadata` (dynamic_extraction schema results) and
+    # `embedding` (OpenAI embedding vectors), both keyed on source content
+    # hash. Warming this across task restarts turns a ~30-min cold sync into
+    # a ~1-min warm sync — every doc that hasn't changed skips both OpenAI
+    # round trips. api_server.sh creates the subdirs at runtime since the
+    # mount shadows whatever the Dockerfile pre-created.
+    #
+    # SINGLE-WRITER CONSTRAINT: the cache is sqlite-over-NFS. That is safe
+    # with exactly one writer and silently corrupts with concurrent writers
+    # because NFS does not honor POSIX advisory locks the way a local FS
+    # does. This is only OK while desired_count = 1 and no autoscaling.
+    # If we ever need >1 task, this mount must be removed (or the caches
+    # must move to a concurrency-safe store like DynamoDB/ElastiCache).
+    {
+      name               = "cache"
+      file_system_id     = module.es_efs.file_system_id
+      access_point_id    = module.es_efs.access_point_ids["cache"]
+      transit_encryption = "ENABLED"
+      iam_authorization  = "DISABLED"
+      root_directory     = "/"
+    },
+    # Daily refresh job writes fresh extraction CSVs to this AP via the
+    # /admin/refresh endpoint's background thread. Single-writer (api task
+    # only) — same sqlite-over-NFS rationale as /srv/cache applies, though
+    # this AP stores plain CSVs with no locking concerns.
+    {
+      name               = "specs-extraction"
+      file_system_id     = module.es_efs.file_system_id
+      access_point_id    = module.es_efs.access_point_ids["specs-extraction"]
+      transit_encryption = "ENABLED"
+      iam_authorization  = "DISABLED"
+      root_directory     = "/"
+    },
+  ]
+
+  # Mount EFS volumes in the primary container:
+  #  - /srv/cache: the persistent sqlite KV caches described above.
+  #  - /srv/specs/unified/extraction: the daily refresh job's output CSVs,
+  #    persisted across task restarts so a new deploy doesn't lose fresh
+  #    scrape results. Seeded from the image on first boot via
+  #    seed_extraction_if_empty in api_server.sh.
+  primary_container_mount_points = [
+    {
+      container_path = "/srv/cache"
+      source_volume  = "cache"
+      read_only      = false
+    },
+    {
+      container_path = "/srv/specs/unified/extraction"
+      source_volume  = "specs-extraction"
+      read_only      = false
+    },
+  ]
+
+  efs_security_group_ids = [module.es_efs.mount_target_security_group_id]
 
   # Grant S3 write access for on-demand Elasticsearch snapshots.
   # TODO(post-soak): remove after Window C closes (~T+30d) — ES backups bucket

--- a/infra/envs/prod/refresh.tf
+++ b/infra/envs/prod/refresh.tf
@@ -1,0 +1,272 @@
+################################################################################
+# Daily refresh automation for botnim-api knesset PDF feeds.
+#
+# Chain:
+#   EventBridge Schedule (cron)
+#     → Lambda "botnim-refresh-invoker" (NOT VPC-attached; calls public ALB)
+#       → POST https://botnim.build-up.team/botnim/admin/refresh
+#         → background thread in botnim-api runs fetch-and-process + sync
+#
+# Alerting:
+#   CloudWatch Logs metric filter on /ecs/botnim-api-<env>/api log group for
+#   "REFRESH_FAILED" → CloudWatch Alarm → SNS topic → email.
+#   Lambda's built-in Errors metric → same SNS topic (catches cases where the
+#   API is fully unreachable and the in-API logging path can't fire).
+################################################################################
+
+# ---------------------------------------------------------------------------
+# SNS topic + email subscription
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "refresh_failures" {
+  name = "botnim-refresh-failures-${var.environment}"
+}
+
+variable "refresh_alert_email" {
+  description = "Email address to subscribe to the refresh-failures SNS topic."
+  type        = string
+  default     = "amir.wilf@build-up.team"
+}
+
+resource "aws_sns_topic_subscription" "refresh_failures_email" {
+  topic_arn = aws_sns_topic.refresh_failures.arn
+  protocol  = "email"
+  endpoint  = var.refresh_alert_email
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch Logs metric filter + alarm on REFRESH_FAILED
+#
+# The botnim-api log group is created by Build-Up-IL/org-infra//modules/app
+# (which delegates to modules/ecs-service). Its actual name follows the
+# convention "/ecs/<environment>/<service_name>" and is exported as
+# module.botnim_api.log_group_name. Using the module output (instead of
+# reconstructing the name) gives us an implicit dependency on the log
+# group's creation, so this metric filter cannot apply before the log
+# group exists.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_metric_filter" "refresh_failed" {
+  name           = "botnim-refresh-failed-${var.environment}"
+  log_group_name = module.botnim_api.log_group_name
+  pattern        = "REFRESH_FAILED"
+
+  metric_transformation {
+    name          = "RefreshFailed"
+    namespace     = "Botnim/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "refresh_failed" {
+  alarm_name          = "botnim-refresh-failed-${var.environment}"
+  alarm_description   = "REFRESH_FAILED logged by botnim-api refresh thread"
+  namespace           = "Botnim/${var.environment}"
+  metric_name         = "RefreshFailed"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.refresh_failures.arn]
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: package + role + VPC + function
+# ---------------------------------------------------------------------------
+
+data "archive_file" "refresh_invoker" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/refresh_invoker"
+  output_path = "${path.module}/.terraform-artifacts/refresh_invoker.zip"
+  excludes    = ["test_handler.py", "__pycache__"]
+}
+
+data "aws_iam_policy_document" "refresh_lambda_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "refresh_lambda" {
+  name               = "botnim-refresh-invoker-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.refresh_lambda_assume.json
+}
+
+# AWS-managed basic Lambda execution role — grants CloudWatch Logs write.
+# (Switched from AWSLambdaVPCAccessExecutionRole when the Lambda came out
+#  of the VPC; see the Lambda function block for the full reasoning.)
+resource "aws_iam_role_policy_attachment" "refresh_lambda_basic" {
+  role       = aws_iam_role.refresh_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "refresh_lambda_secrets" {
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.refresh_admin_api_key.arn]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [local.contract.ecs.kms_key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "refresh_lambda_secrets" {
+  name   = "refresh-admin-secret-read"
+  role   = aws_iam_role.refresh_lambda.id
+  policy = data.aws_iam_policy_document.refresh_lambda_secrets.json
+}
+
+resource "aws_lambda_function" "refresh_invoker" {
+  function_name = "botnim-refresh-invoker-${var.environment}"
+  role          = aws_iam_role.refresh_lambda.arn
+  runtime       = "python3.12"
+  handler       = "handler.handler"
+  timeout       = 30
+  memory_size   = 128
+
+  filename         = data.archive_file.refresh_invoker.output_path
+  source_code_hash = data.archive_file.refresh_invoker.output_base64sha256
+
+  # Intentionally NOT VPC-attached. The Lambda needs to:
+  #   (1) read the admin API key secret — works via the public AWS
+  #       Secrets Manager regional endpoint, no VPC needed
+  #   (2) POST to https://botnim.build-up.team/botnim/admin/refresh —
+  #       which resolves to public ALB IPs and is reachable from any
+  #       internet-connected client
+  # Putting the Lambda in the VPC was breaking it: the runtime's libc
+  # resolver only had `nameserver 169.254.100.5` (the local extension
+  # proxy) active in /etc/resolv.conf with the VPC resolver commented
+  # out, and that proxy returned `OSError(16, EBUSY)` for every
+  # getaddrinfo call. Diagnostic logs confirmed it. Pulling out of the
+  # VPC avoids the broken runtime resolver path entirely.
+
+  environment {
+    variables = {
+      ADMIN_API_KEY_SECRET_ARN = aws_secretsmanager_secret.refresh_admin_api_key.arn
+      REFRESH_ENDPOINT_URL     = "https://botnim.build-up.team/botnim/admin/refresh"
+    }
+  }
+}
+
+# Alarm on Lambda itself failing to invoke the endpoint (separate from the
+# in-API REFRESH_FAILED path).
+resource "aws_cloudwatch_metric_alarm" "refresh_lambda_errors" {
+  alarm_name          = "botnim-refresh-invoker-errors-${var.environment}"
+  alarm_description   = "Refresh invoker Lambda is failing to reach botnim-api"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.refresh_invoker.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.refresh_failures.arn]
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge Scheduler: daily at 04:00 UTC (07:00 Asia/Jerusalem).
+# Backups run at 03:00 UTC (see efs_backup.tf); refresh runs an hour later so
+# the two jobs don't contend for the filesystem. Same UTC hour as staging
+# per operator policy.
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "refresh_scheduler_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "refresh_scheduler" {
+  name               = "botnim-refresh-scheduler-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.refresh_scheduler_assume.json
+}
+
+data "aws_iam_policy_document" "refresh_scheduler_invoke" {
+  statement {
+    effect    = "Allow"
+    actions   = ["lambda:InvokeFunction"]
+    resources = [aws_lambda_function.refresh_invoker.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "refresh_scheduler_invoke" {
+  name   = "invoke-refresh-lambda"
+  role   = aws_iam_role.refresh_scheduler.id
+  policy = data.aws_iam_policy_document.refresh_scheduler_invoke.json
+}
+
+resource "aws_scheduler_schedule" "refresh" {
+  name                = "botnim-refresh-${var.environment}"
+  group_name          = "default"
+  schedule_expression = "cron(0 4 * * ? *)"
+  state               = "ENABLED"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_lambda_function.refresh_invoker.arn
+    role_arn = aws_iam_role.refresh_scheduler.arn
+    input    = jsonencode({})
+  }
+}
+
+# ---------------------------------------------------------------------------
+# kms:Decrypt for the ECS task execution role on the CMK that encrypts our
+# Secrets Manager entries.
+#
+# Build-Up-IL/org-infra//modules/app grants the execution role
+# secretsmanager:GetSecretValue on every ARN in secret_environment_variables,
+# but does NOT grant kms:Decrypt on the CMK. Existing secrets (openai, es)
+# work today because their stored ciphertext predates the move to a CMK
+# (encrypted with the AWS-managed aws/secretsmanager key). New secrets
+# (and any future put-secret-value on the existing ones) get encrypted with
+# the CMK and fail at task-start with "AccessDeniedException: Access to KMS
+# is not allowed". Granting decrypt on the CMK to the exec role closes that
+# gap once and for all. Scoped narrowly: kms:Decrypt only, on this CMK only,
+# only when invoked via the secretsmanager service.
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "exec_role_kms_decrypt" {
+  statement {
+    sid       = "DecryptSMSecretsCMK"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [local.contract.ecs.kms_key_arn]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["secretsmanager.${data.aws_region.current.name}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "exec_role_kms_decrypt" {
+  name   = "kms-decrypt-sm-cmk"
+  role   = "botnim-api-${var.environment}-api-execution-role"
+  policy = data.aws_iam_policy_document.exec_role_kms_decrypt.json
+}

--- a/infra/envs/prod/secrets.tf
+++ b/infra/envs/prod/secrets.tf
@@ -19,3 +19,9 @@ resource "aws_secretsmanager_secret" "elasticsearch_password" {
   description = "Password for the elasticsearch 'elastic' superuser"
   kms_key_id  = local.contract.ecs.kms_key_arn
 }
+
+resource "aws_secretsmanager_secret" "refresh_admin_api_key" {
+  name        = "botnim-api/${var.environment}/refresh-admin-api-key"
+  description = "API key the refresh-invoker Lambda sends as X-API-Key to /admin/refresh"
+  kms_key_id  = local.contract.ecs.kms_key_arn
+}


### PR DESCRIPTION
## Summary

Brings `infra/envs/prod/` to feature parity with `infra/envs/staging/` so we can deploy `gov_il_decisions` (and the rest of the daily-refresh chain) to prod. Diff against staging was 132 lines on `main.tf` plus three missing files. **DO NOT MERGE** until the operator reviews + plans this in `infra/live/prod/`.

## What changed, file-by-file

### `infra/envs/prod/efs.tf`
- Replaced empty `access_points = []` with the staging pair: `cache` (POSIX uid/gid 1000, /cache) and `specs-extraction` (/specs-extraction). The filesystem itself was already declared.

### `infra/envs/prod/efs_backup.tf` *(new)*
- Verbatim copy from staging — daily AWS Backup at 03:00 UTC, 30-day retention, dedicated vault + service role. Snapshots the whole EFS filesystem (both APs).

### `infra/envs/prod/refresh.tf` *(new)*
- Daily refresh chain: SNS topic, email subscription (`amir.wilf@build-up.team` default — override via `-var refresh_alert_email=...`), CloudWatch metric filter on `REFRESH_FAILED`, alarms (in-API + Lambda Errors), Lambda function (NOT VPC-attached, calls public ALB), IAM roles for Lambda + scheduler, EventBridge schedule.
- **Schedule:** `cron(0 4 * * ? *)` — same UTC hour as staging per operator decision.
- **Endpoint:** `https://botnim.build-up.team/botnim/admin/refresh` (vs staging's `botnim.staging.build-up.team`).
- Includes the `kms:Decrypt` exec-role policy for the SM CMK.

### `infra/envs/prod/lambda/refresh_invoker/{handler.py,test_handler.py}` *(new)*
- Verbatim copy from staging. Env-agnostic — endpoint URL + secret ARN come from env vars set on the Lambda.

### `infra/envs/prod/secrets.tf`
- Added `aws_secretsmanager_secret.refresh_admin_api_key` matching staging. Value must be set out-of-band.

### `infra/envs/prod/main.tf`
Surgical additions to `module "botnim_api"` (existing prod values preserved):
- `internal_server = {}` — Service Connect endpoint at `http://botnim-api:8000` for LibreChat siblings.
- `efs_volumes = [...]` — both APs.
- `primary_container_mount_points = [...]` — `/srv/cache` and `/srv/specs/unified/extraction`.
- `efs_security_group_ids = [module.es_efs.mount_target_security_group_id]`.
- `BOTNIM_ADMIN_API_KEY = aws_secretsmanager_secret.refresh_admin_api_key.arn` in `secret_environment_variables`.

### Files NOT touched (intentional)
- `infra/live/prod/terragrunt.hcl` — already correct (image_tag default = `bootstrap`, environment = `prod`).
- `data.tf`, `variables.tf`, `outputs.tf`, `backups.tf` — already correct for prod.
- Kept `OPENAI_API_KEY_PRODUCTION` hardcoded in main.tf rather than `OPENAI_API_KEY_${upper(var.environment)}` — `var.environment = "prod"` would yield `OPENAI_API_KEY_PROD` which doesn't match `rebuilding-bots/config.py` convention.
- Kept `host_headers = ["botnim.build-up.team"]`, `task_role_policy_json = es_backups_write`.

## AWS prerequisites BEFORE `terragrunt apply`

- [ ] **Create the secret value** for `botnim-api/prod/refresh-admin-api-key` in AWS Secrets Manager after the resource is applied (terraform creates the entry, value must be set out-of-band — same as staging).
- [ ] Confirm `botnim-api/prod/openai-api-key` already has a value (Aurora migration may have created it during a prior apply; if not, set it).
- [ ] Confirm `/buildup/projects/botnim/prod/database_credentials_secret_arn` SSM parameter exists (Aurora cluster `buildup-shared` should have populated it).
- [ ] Confirm `/buildup/shared/prod/contract` SSM parameter exists.

## Validation done

- `terraform -chdir=<copy of envs/prod> init -backend=false && terraform validate` -> `Success` (modulo two pre-existing `data.aws_region.current.name` deprecation warnings that also exist in staging).
- All `*.tf` files brace-balanced.
- `tests/document_parser/gov_il_decisions/` Python tests: 24 passed (no Python touched; sanity check).

## Test plan

- [ ] Operator reviews diff (especially `main.tf` block ordering vs staging - they're functionally identical but lines may differ).
- [ ] `cd infra/live/prod && terragrunt validate` (will need AWS creds for backend init).
- [ ] `terragrunt plan` and confirm the additions match this PR description (one new EFS module config, one new Lambda, one new SNS topic, one new EventBridge schedule, one new SM secret, plus mount points/env vars on the existing ECS task).
- [ ] After apply: set the `refresh-admin-api-key` secret value, then run `./deploy.sh prod` (will need the deploy.sh prod guard removed in a separate PR).

**DO NOT MERGE** until operator review.

Generated with [Claude Code](https://claude.com/claude-code)
