### PR TITLE
fix(docker): install awscli in api image

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -8,6 +8,12 @@ RUN apt-get update \
         tesseract-ocr \
         tesseract-ocr-heb \
         poppler-utils \
+        # awscli: deploy.sh phase 6.5 (alembic upgrade head) needs to read
+        # the cluster master secret on first-run to CREATE EXTENSION vector.
+        # Same is true for any future ops scripts that need AWS APIs from
+        # inside the running task. Avoids re-introducing the "no aws in
+        # container" debt.
+        awscli \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -19,6 +19,11 @@ RUN pip install -r requirements-server.txt -r requirements.txt -r requirements-p
 COPY botnim/ ./botnim
 COPY scripts/ ./scripts
 COPY specs/ ./specs
+# alembic.ini lives at repo root and is required to run schema migrations
+# from inside the running task (deploy.sh phase 6.5 invokes
+# `alembic -c alembic.ini upgrade head` via `aws ecs run-task` so a fresh
+# environment self-bootstraps without a developer-laptop step).
+COPY alembic.ini ./
 # Seed copy for EFS bootstrap: when /srv/specs/unified/extraction is mounted
 # from EFS and that mount is empty (first deploy or after a wipe), the startup
 # script copies this seed into the mount so `botnim sync` has content on cold


### PR DESCRIPTION
deploy.sh phase 6.5 needs aws cli inside the container to read the cluster master secret for first-run CREATE EXTENSION.