### PR TITLE
fix(infra): static ARN for word_docs IAM (unblocks prod plan)

### DIFF
--- a/infra/envs/prod/word_docs.tf
+++ b/infra/envs/prod/word_docs.tf
@@ -70,6 +70,10 @@ data "aws_iam_policy_document" "word_docs_write" {
     sid       = "WordDocsPutObject"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.word_docs.arn}/*"]
+    # Static ARN derived from bucket name (not resource attr) so the
+    # composed task_role_policy_json is plan-time-knowable; otherwise the
+    # ecs-service module's `count = task_role_policy_json != "" ? 1 : 0`
+    # fails with "value depends on resource attributes" at first plan.
+    resources = ["arn:aws:s3:::botnim-word-docs-${var.environment}/*"]
   }
 }

--- a/infra/envs/staging/word_docs.tf
+++ b/infra/envs/staging/word_docs.tf
@@ -70,6 +70,10 @@ data "aws_iam_policy_document" "word_docs_write" {
     sid       = "WordDocsPutObject"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.word_docs.arn}/*"]
+    # Static ARN derived from bucket name (not resource attr) so the
+    # composed task_role_policy_json is plan-time-knowable; otherwise the
+    # ecs-service module's `count = task_role_policy_json != "" ? 1 : 0`
+    # fails with "value depends on resource attributes" at first plan.
+    resources = ["arn:aws:s3:::botnim-word-docs-${var.environment}/*"]
   }
 }


### PR DESCRIPTION
Plan-time error: ecs-service module count=task_role_policy_json!=''?1:0 fails when the policy JSON includes a 'known after apply' resource ARN. Replace aws_s3_bucket.word_docs.arn with the statically-derived 'arn:aws:s3:::botnim-word-docs-${var.environment}/\*'. Same fix applied in both staging and prod env files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)