### PR TITLE
fix(word_doc): sign presigned URLs with long-lived IAM user creds

### DIFF
--- a/botnim/word_doc/storage.py
+++ b/botnim/word_doc/storage.py
@@ -40,17 +40,39 @@ def upload_word_doc(
     if not bucket:
         raise RuntimeError("WORD_DOCS_BUCKET is not set")
 
+    # SigV4 + virtual-hosted-style addressing forces the regional
+    # endpoint (e.g. s3.il-central-1.amazonaws.com) which il-central-1
+    # requires; otherwise URLs point at the legacy global endpoint and
+    # download attempts return IllegalLocationConstraintException.
+    _client_config = Config(signature_version="s3v4", s3={"addressing_style": "virtual"})
+
     if s3_client is None:
-        # SigV4 + virtual-hosted-style addressing forces the regional
-        # endpoint (e.g. s3.il-central-1.amazonaws.com) which il-central-1
-        # requires; otherwise the presigned URL points at the legacy
-        # global endpoint and download attempts return
-        # IllegalLocationConstraintException.
-        s3_client = boto3.client(
+        # Upload client uses the default credentials chain (task role).
+        # Task role has s3:PutObject on this bucket via word_docs.tf.
+        s3_client = boto3.client("s3", region_name=_AWS_REGION, config=_client_config)
+
+    # Signing client: when WORD_DOCS_SIGNING_AWS_* are set, sign presigned
+    # download URLs with a long-lived IAM user instead of the task role's
+    # STS creds. Why: STS-signed URLs include a multi-KB
+    # X-Amz-Security-Token query param that pushes the URL past ~2KB —
+    # LibreChat's markdown renderer drops the trailing &X-Amz-Signature
+    # param at that length, breaking every download link. IAM-user-signed
+    # URLs have no security token (~700 chars shorter) and also honor the
+    # full ?X-Amz-Expires=7d we advertise (STS sessions expire ≤36h on
+    # Fargate task roles). Falls back to the upload client (task role)
+    # when those env vars are absent — keeps local/test behavior unchanged.
+    signing_key = os.environ.get("WORD_DOCS_SIGNING_AWS_ACCESS_KEY_ID")
+    signing_secret = os.environ.get("WORD_DOCS_SIGNING_AWS_SECRET_ACCESS_KEY")
+    if signing_key and signing_secret:
+        signing_client = boto3.client(
             "s3",
             region_name=_AWS_REGION,
-            config=Config(signature_version="s3v4", s3={"addressing_style": "virtual"}),
+            config=_client_config,
+            aws_access_key_id=signing_key,
+            aws_secret_access_key=signing_secret,
         )
+    else:
+        signing_client = s3_client
 
     key = f"{uuid.uuid4().hex}/{filename}"
     s3_client.put_object(
@@ -63,7 +85,7 @@ def upload_word_doc(
     )
 
     encoded_filename = quote(filename, safe="")
-    url = s3_client.generate_presigned_url(
+    url = signing_client.generate_presigned_url(
         "get_object",
         Params={
             "Bucket": bucket,

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -67,6 +67,7 @@ module "botnim_api" {
 
   secret_arns = concat(
     [data.aws_ssm_parameter.database_credentials_secret_arn.value],
+    [aws_secretsmanager_secret.word_docs_signer.arn],
   )
 
   secret_environment_variables = merge(
@@ -82,6 +83,13 @@ module "botnim_api" {
       DB_NAME     = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:dbname::"
       DB_USER     = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:username::"
       DB_PASSWORD = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:password::"
+    },
+    {
+      # Long-lived IAM user creds used by botnim/word_doc/storage.py to sign
+      # presigned URLs. Avoids the STS-token bloat that breaks LibreChat's
+      # markdown renderer on URLs >2KB. See word_docs.tf rationale.
+      WORD_DOCS_SIGNING_AWS_ACCESS_KEY_ID     = "${aws_secretsmanager_secret.word_docs_signer.arn}:aws_access_key_id::"
+      WORD_DOCS_SIGNING_AWS_SECRET_ACCESS_KEY = "${aws_secretsmanager_secret.word_docs_signer.arn}:aws_secret_access_key::"
     },
   )
 

--- a/infra/envs/prod/word_docs.tf
+++ b/infra/envs/prod/word_docs.tf
@@ -81,3 +81,61 @@ data "aws_iam_policy_document" "word_docs_write" {
     resources = ["arn:aws:s3:::botnim-word-docs-${var.environment}/*"]
   }
 }
+
+# ───────────────────────────────────────────────────────────────────────────
+# Long-lived IAM user used to *sign* presigned download URLs.
+#
+# Why not just use the task role's STS creds? Two reasons:
+# (1) STS session tokens push the URL past ~2KB — LibreChat's markdown
+#     renderer drops the trailing &X-Amz-Signature query param at that
+#     length, breaking every link. With long-lived IAM user creds the
+#     URL has no X-Amz-Security-Token (~700 chars shorter) and renders
+#     fully.
+# (2) Presigned URLs signed by STS creds expire when the underlying
+#     session expires (≤36h on Fargate task roles), regardless of the
+#     ?X-Amz-Expires we ask for. Long-lived IAM creds let the 7-day
+#     ?X-Amz-Expires we advertise actually mean 7 days.
+#
+# Scope is intentionally narrow: GetObject on this bucket only. No
+# PutObject — uploads still go through the task role.
+# ───────────────────────────────────────────────────────────────────────────
+resource "aws_iam_user" "word_docs_signer" {
+  name = "botnim-word-docs-signer-${var.environment}"
+  path = "/botnim/"
+  tags = {
+    Project = "botnim"
+    Env     = var.environment
+    Purpose = "presigned-url-signing"
+  }
+}
+
+resource "aws_iam_user_policy" "word_docs_signer" {
+  name   = "GetObjectOnBucket"
+  user   = aws_iam_user.word_docs_signer.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "GetWordDocs"
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "arn:aws:s3:::botnim-word-docs-${var.environment}/*"
+    }]
+  })
+}
+
+resource "aws_iam_access_key" "word_docs_signer" {
+  user = aws_iam_user.word_docs_signer.name
+}
+
+resource "aws_secretsmanager_secret" "word_docs_signer" {
+  name        = "botnim-api/${var.environment}/word-docs-signer-creds"
+  description = "Long-lived IAM user creds used to sign presigned word-doc download URLs"
+}
+
+resource "aws_secretsmanager_secret_version" "word_docs_signer" {
+  secret_id = aws_secretsmanager_secret.word_docs_signer.id
+  secret_string = jsonencode({
+    aws_access_key_id     = aws_iam_access_key.word_docs_signer.id
+    aws_secret_access_key = aws_iam_access_key.word_docs_signer.secret
+  })
+}

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -68,6 +68,7 @@ module "botnim_api" {
 
   secret_arns = concat(
     [data.aws_ssm_parameter.database_credentials_secret_arn.value],
+    [aws_secretsmanager_secret.word_docs_signer.arn],
   )
 
   secret_environment_variables = merge(
@@ -83,6 +84,11 @@ module "botnim_api" {
       DB_NAME     = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:dbname::"
       DB_USER     = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:username::"
       DB_PASSWORD = "${data.aws_ssm_parameter.database_credentials_secret_arn.value}:password::"
+    },
+    {
+      # Long-lived IAM user creds for signing presigned URLs. See word_docs.tf.
+      WORD_DOCS_SIGNING_AWS_ACCESS_KEY_ID     = "${aws_secretsmanager_secret.word_docs_signer.arn}:aws_access_key_id::"
+      WORD_DOCS_SIGNING_AWS_SECRET_ACCESS_KEY = "${aws_secretsmanager_secret.word_docs_signer.arn}:aws_secret_access_key::"
     },
   )
 

--- a/infra/envs/staging/word_docs.tf
+++ b/infra/envs/staging/word_docs.tf
@@ -81,3 +81,46 @@ data "aws_iam_policy_document" "word_docs_write" {
     resources = ["arn:aws:s3:::botnim-word-docs-${var.environment}/*"]
   }
 }
+
+# Long-lived IAM user for signing presigned download URLs. See prod/word_docs.tf
+# for full rationale (STS-token-bloat breaks LibreChat's >2KB URL renderer).
+resource "aws_iam_user" "word_docs_signer" {
+  name = "botnim-word-docs-signer-${var.environment}"
+  path = "/botnim/"
+  tags = {
+    Project = "botnim"
+    Env     = var.environment
+    Purpose = "presigned-url-signing"
+  }
+}
+
+resource "aws_iam_user_policy" "word_docs_signer" {
+  name   = "GetObjectOnBucket"
+  user   = aws_iam_user.word_docs_signer.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "GetWordDocs"
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "arn:aws:s3:::botnim-word-docs-${var.environment}/*"
+    }]
+  })
+}
+
+resource "aws_iam_access_key" "word_docs_signer" {
+  user = aws_iam_user.word_docs_signer.name
+}
+
+resource "aws_secretsmanager_secret" "word_docs_signer" {
+  name        = "botnim-api/${var.environment}/word-docs-signer-creds"
+  description = "Long-lived IAM user creds used to sign presigned word-doc download URLs"
+}
+
+resource "aws_secretsmanager_secret_version" "word_docs_signer" {
+  secret_id = aws_secretsmanager_secret.word_docs_signer.id
+  secret_string = jsonencode({
+    aws_access_key_id     = aws_iam_access_key.word_docs_signer.id
+    aws_secret_access_key = aws_iam_access_key.word_docs_signer.secret
+  })
+}


### PR DESCRIPTION
Closes the X-Amz-Signature truncation bug + closes followup #42. Long-lived IAM user with narrow s3:GetObject scope + access key in Secrets Manager. URL drops from 2090 → ~1300 chars; LibreChat renderer no longer truncates. Direct prod deploy after merge per user request.