### PR TITLE
feat(sync): delta-sync mode by default; --force-rebuild as escape hatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# rebuilding-bots — Operational Notes for Claude
+
+> Repo-specific notes that supplement `README.md`. The README covers
+> architecture and end-user CLI usage; this file documents semantics
+> and gotchas that bite during real debugging / deploy sessions.
+
+## `botnim sync` semantics (post-2026-05-06 delta-sync)
+
+Three explicit modes control what happens to the `documents` table:
+
+| Invocation | Documents table | Cost |
+|---|---|---|
+| `botnim sync <env> <bot>` (default) | Delta — embed new/changed chunks; reuse unchanged via content-hash skip | Near-zero in steady state |
+| `botnim sync <env> <bot> --force-rebuild` | DELETE all + re-embed every chunk | Full embed cost |
+| `botnim sync <env> <bot> --replace-context none` | No-op for documents (still refreshes prompt + writes snapshot) | $0 |
+
+Single-context targeting still works: pass `--replace-context legal_advisor_opinions` (or any other context slug) to process only that context. Combine with `--force-rebuild` to scope the wipe to that context only.
+
+**Orphan handling:** delta mode keeps rows whose `source_id` no longer appears upstream — they linger in `documents` until an operator runs `--force-rebuild` to purge them. This is by design (resilient to upstream blips). For periodic cleanup, schedule a `--force-rebuild` per quarter or similar cadence.
+
+**The previous default** (`replace_context=False` = no-op for documents) was a footgun — it made `botnim sync` after a fap silently throw away the new content. That default was changed on 2026-05-06.

--- a/botnim/cli.py
+++ b/botnim/cli.py
@@ -29,13 +29,20 @@ def cli():
 @cli.command(name='sync')
 @click.argument('environment', type=click.Choice(VALID_ENVIRONMENTS))
 @click.argument('bots', type=click.Choice(AVAILABLE_BOTS + ['all']))
-@click.option('--replace-context', type=str, help='Replace existing context with a specific context name or use "all" to replace all contexts')
-@click.option('--backend', type=click.Choice(['aurora', 'es', 'openai']), default='aurora', help='Vector store backend (default: aurora; use --backend es for legacy rollback)')
+@click.option('--replace-context', type=str, default='all',
+              help="Which contexts to process. 'all' (default) = delta-sync every "
+                   "context. Pass a slug for one. Pass 'none' to skip the data layer.")
+@click.option('--backend', type=click.Choice(['aurora', 'es', 'openai']), default='aurora',
+              help='Vector store backend (default: aurora; use --backend es for legacy rollback)')
 @click.option('--reindex', is_flag=True, default=False, help='Force reindexing to update mapping changes')
-def sync(environment, bots, replace_context, backend, reindex):
+@click.option('--force-rebuild', is_flag=True, default=False,
+              help="Wipe and re-embed every selected context (replaces delta-sync's "
+                   "content-hash skip). Use for upstream schema changes.")
+def sync(environment, bots, replace_context, backend, reindex, force_rebuild):
     """Sync bot configs and vector indices for ``bots`` in ``environment``."""
     click.echo(f"Syncing {bots} to {environment}")
-    sync_agents(environment, bots, backend=backend, replace_context=replace_context, reindex=reindex)
+    sync_agents(environment, bots, backend=backend, replace_context=replace_context,
+                reindex=reindex, force_rebuild=force_rebuild)
 
 # Run benchmarks command, receives three arguments: production/staging, a bot from AVAILABLE_BOTS (or 'all') and whether to run benchmarks on the production environment to work locally (true/false)
 @cli.command(name='benchmarks')

--- a/botnim/sync.py
+++ b/botnim/sync.py
@@ -88,7 +88,7 @@ def _write_snapshots(bot_slug: str) -> None:
 
 
 def _sync_vector_store(config: dict, config_dir, backend: str, environment: str,
-                       replace_context, reindex: bool) -> None:
+                       replace_context, reindex: bool, force_rebuild: bool = False) -> None:
     """Run the backend-specific vector-store update for a bot's contexts.
 
     The returned tools/tool_resources from :meth:`vector_store_update` are
@@ -112,6 +112,7 @@ def _sync_vector_store(config: dict, config_dir, backend: str, environment: str,
         config['context'],
         replace_context=replace_context,
         reindex=reindex,
+        force_rebuild=force_rebuild,
     )
 
 
@@ -135,7 +136,8 @@ def publish_bot(bot_slug: str, environment: str) -> BotConfig:
 
 
 def sync_agents(environment: str, bots: str, backend: str = 'aurora',
-                replace_context=False, reindex: bool = False) -> None:
+                replace_context='all', reindex: bool = False,
+                force_rebuild: bool = False) -> None:
     """Sync one or more bots: ES indices + published config.
 
     Parameters
@@ -149,9 +151,15 @@ def sync_agents(environment: str, bots: str, backend: str = 'aurora',
         escape hatch, kept for one-release deprecation window), or
         ``"openai"``.
     replace_context:
-        Forwarded to the vector store's update logic.
+        Selects which contexts to process this run. Default ``'all'`` =
+        delta-sync every context. Pass a context slug for one. Pass
+        ``'none'`` to skip the data layer entirely.
     reindex:
         Forwarded to the vector store's update logic; forces a full rebuild.
+    force_rebuild:
+        DELETE all rows for the selected context(s) before re-embedding.
+        Use only when upstream extraction logic changed in a way that
+        invalidates previous content-hashes.
     """
     for config_fn in SPECS.glob('*/config.yaml'):
         config_dir = config_fn.parent
@@ -168,6 +176,7 @@ def sync_agents(environment: str, bots: str, backend: str = 'aurora',
         _sync_vector_store(
             raw, config_dir, backend, environment,
             replace_context=replace_context, reindex=reindex,
+            force_rebuild=force_rebuild,
         )
 
         # 2. Publish the canonical Responses-API bot config.

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -182,12 +182,17 @@ class VectorStoreAurora(VectorStoreBase):
 
     # ---- abstract method overrides -----------------------------------------
 
-    def get_or_create_vector_store(self, context, context_name, replace_context):
+    def get_or_create_vector_store(self, context, context_name, replace_context, force_rebuild=False):
         """Return the context_id (uuid str) for (bot, context_name).
 
         - Inserts a row into contexts if it doesn't exist.
-        - If replace_context is True, deletes all rows in documents that
-          reference this context (CASCADE handles the join).
+        - If force_rebuild is True, deletes all rows in documents that
+          reference this context (CASCADE handles the join). Default
+          behavior keeps existing rows so upload_files's content-hash skip
+          can reuse them — that's the delta-sync path.
+
+        replace_context is preserved in the signature for caller-API
+        compatibility but no longer drives the DELETE; force_rebuild does.
         """
         bot = self.config["slug"]
         with get_session() as sess:
@@ -198,11 +203,12 @@ class VectorStoreAurora(VectorStoreBase):
             ), {"bot": bot, "name": context_name}).fetchone()
             cid = str(row[0])
 
-            if replace_context:
+            if force_rebuild:
                 sess.execute(text(
                     "DELETE FROM documents WHERE context_id = :cid"
                 ), {"cid": cid})
-                logger.info("Cleared documents for context %s/%s (id=%s)", bot, context_name, cid)
+                logger.info("Cleared documents for context %s/%s (id=%s) — force_rebuild",
+                            bot, context_name, cid)
         return cid
 
     def upload_files(self, context, context_name, vector_store, file_streams, callback):

--- a/botnim/vector_store/vector_store_base.py
+++ b/botnim/vector_store/vector_store_base.py
@@ -21,40 +21,60 @@ class VectorStoreBase(ABC):
             name += '__dev'
         return name
 
-    def vector_store_update(self, context, replace_context, reindex=False):
+    def vector_store_update(self, context, replace_context, reindex=False, force_rebuild=False):
         self.tool_resources = None
         self.tools = []
         for context_ in context:
             context_name = context_['slug']
-            # Determine if we should process this context:
-            # - replace_context matches this context name or is 'all'
-            # - reindex flag forces processing regardless of replace_context
-            should_replace_context = replace_context in ('all', context_name)
-            should_force_reindex = reindex
-            should_process_context = should_replace_context or should_force_reindex
-            
-            vector_store = self.get_or_create_vector_store(context_, context_name, should_process_context)    
-        
-            if should_process_context:
-                print(f'Processing context: {context_name}')
+            # `replace_context` selects WHICH contexts to process this run:
+            #   'all'       -> every context (delta semantics by default)
+            #   '<slug>'    -> just that context
+            #   'none'      -> explicit no-op for the data layer
+            #   None        -> treated as 'all' for back-compat (callers
+            #                  using positional / no-flag CLI)
+            # `force_rebuild` (when True AND this context is being processed)
+            # adds a DELETE-then-re-embed; without it, upload_files's
+            # content-hash skip handles the delta naturally.
+            normalized = replace_context if replace_context is not None else 'all'
+            if normalized == 'none':
+                # `reindex` is the explicit "force processing regardless of
+                # selection" override and beats even an explicit 'none'.
+                should_process = bool(reindex)
+            elif normalized == 'all' or normalized == context_name:
+                should_process = True
+            else:
+                should_process = bool(reindex)
+            should_force_rebuild = force_rebuild and should_process
+
+            vector_store = self.get_or_create_vector_store(
+                context_, context_name, should_process, force_rebuild=should_force_rebuild,
+            )
+
+            if should_process:
+                if force_rebuild or reindex:
+                    print(f'Processing context (force_rebuild={should_force_rebuild}, reindex={reindex}): {context_name}')
+                else:
+                    print(f'Processing context (delta): {context_name}')
                 file_streams = collect_context_sources(context_, self.config_dir)
                 file_streams = [((fname if self.production else '_' + fname), f, t, m) for fname, f, t, m in file_streams]
                 file_names = [fname for fname, _, _, _ in file_streams]
-                
-                # Delete existing files since we're replacing the context
-                deleted = self.delete_existing_files(context_, vector_store, file_names)
-                print(f'VECTOR STORE {context_name} deleted {deleted}')
-                
+
+                # Force-rebuild path: existing files were already wiped via
+                # get_or_create_vector_store. Skip the per-name delete.
+                if not should_force_rebuild:
+                    deleted = self.delete_existing_files(context_, vector_store, file_names)
+                    print(f'VECTOR STORE {context_name} deleted {deleted}')
+
                 total = len(file_streams)
-                self.upload_files(context_, context_name, vector_store, file_streams, 
+                self.upload_files(context_, context_name, vector_store, file_streams,
                                   lambda x: print(f'VECTOR STORE {context_name} uploaded {x}/{total}'))
-                
+
             self.update_tool_resources(context_, vector_store)
             self.update_tools(context_, vector_store)
         return self.tools, self.tool_resources
 
     @abstractmethod
-    def get_or_create_vector_store(self, context, context_name, replace_context):
+    def get_or_create_vector_store(self, context, context_name, replace_context, force_rebuild=False):
         pass
 
     @abstractmethod

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -279,15 +279,18 @@ class VectorStoreES(VectorStoreBase):
         
         return results
 
-    def get_or_create_vector_store(self, context, context_name, replace_context):
+    def get_or_create_vector_store(self, context, context_name, replace_context, force_rebuild=False):
         """Get or create a vector store for the given context.
+        replace_context is preserved for caller-API compatibility; force_rebuild
+        controls the destructive index-delete (delta-sync default keeps the
+        index alive and relies on per-row content-hash skip in upload_files).
         """
-        
+
         index_name = self._index_name_for_context(context_name)
-        
-        # Delete existing index if replace_context is True
-        if replace_context and self.es_client.indices.exists(index=index_name):
-            logger.info(f"Replacing existing index: {index_name}")
+
+        # Delete existing index if force_rebuild is True
+        if force_rebuild and self.es_client.indices.exists(index=index_name):
+            logger.info(f"Force-rebuilding existing index: {index_name}")
             self.es_client.indices.delete(index=index_name)
         
         # Create new index if it doesn't exist

--- a/botnim/vector_store/vector_store_openai.py
+++ b/botnim/vector_store/vector_store_openai.py
@@ -8,13 +8,25 @@ class VectorStoreOpenAI(VectorStoreBase):
         self.openai_client = openai_client
         self.init = False
 
-    def get_or_create_vector_store(self, context, context_name, replace_context):
+    def get_or_create_vector_store(self, context, context_name, replace_context, force_rebuild=False):
+        """Get or create the OpenAI Vector Store for this bot.
+
+        OpenAI Vector Stores have no per-row content-hash skip (unlike Aurora),
+        so any sync that processes a context is effectively a full rebuild.
+        ``replace_context`` is preserved for caller-API compatibility and is
+        OR'd with ``force_rebuild`` to gate the destructive delete.
+
+        With the new sync default ``replace_context='all'`` (post-delta-sync),
+        every sync wipes and re-uploads the OpenAI Vector Store. The previous
+        no-op-by-default behavior now requires explicit ``--replace-context none``.
+        This backend is legacy (see CLAUDE.md); Aurora is the canonical path.
+        """
         ret = None
         vs_name = self.env_name(self.config['name'])
         vector_store = self.openai_client.beta.vector_stores.list()
         for vs in vector_store:
             if vs.name == vs_name:
-                if replace_context and not self.init:
+                if (replace_context or force_rebuild) and not self.init:
                     self.openai_client.beta.vector_stores.delete(vs.id)
                 else:
                     ret = vs

--- a/tests/test_vector_store_aurora.py
+++ b/tests/test_vector_store_aurora.py
@@ -98,8 +98,8 @@ def test_get_or_create_replace_context_clears_documents(aurora_db):
         ), {"cid": cid})
         conn.commit()
 
-    # replace_context=True should preserve the context row but clear its docs
-    cid2 = store.get_or_create_vector_store({"slug": "x"}, "x", replace_context=True)
+    # force_rebuild=True should preserve the context row but clear its docs
+    cid2 = store.get_or_create_vector_store({"slug": "x"}, "x", replace_context=False, force_rebuild=True)
     assert cid2 == cid
     with eng.connect() as conn:
         n = conn.execute(text(

--- a/tests/vector_store/test_aurora_delta.py
+++ b/tests/vector_store/test_aurora_delta.py
@@ -1,0 +1,212 @@
+"""Delta-sync semantics: re-running sync only embeds new/changed chunks.
+
+These tests pin down the new force_rebuild kwarg semantics. Pattern
+mirrors tests/test_vector_store_aurora.py — uses the same aurora_db
+fixture (per-test postgres DB + alembic upgrade head + DATABASE_URL +
+cached-engine reset) and the same _get_embedding_client patch target.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _alembic_upgrade(database_url: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        ["alembic", "--config", "alembic.ini", "upgrade", "head"],
+        cwd=REPO_ROOT, env=env, check=True, capture_output=True,
+    )
+
+
+@pytest.fixture
+def aurora_db(database_url, monkeypatch):
+    """Aurora backend pointed at a fresh per-test DB with schema applied."""
+    _alembic_upgrade(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-test")
+    from botnim.db import session as s
+    s._engine = None
+    return database_url
+
+
+class _FakeEmbeddingClient:
+    """Counts embed calls so we can prove the content-hash skip works."""
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def embed(self, content: str) -> list:
+        self.calls.append(content)
+        h = hashlib.sha256(content.encode()).digest()
+        return [(b / 255.0) for b in h] * 48  # 1536-dim
+
+
+def _file_streams(items: list[tuple[str, str, dict]]):
+    """items: [(filename, content_str, metadata)]. Returns the
+    (fname, file, type, metadata) tuple shape upload_files expects."""
+    return [
+        (fname, io.BytesIO(content.encode()), "md", metadata)
+        for fname, content, metadata in items
+    ]
+
+
+def _doc_count(cid: str) -> int:
+    from botnim.db.session import get_engine
+    eng = get_engine()
+    with eng.connect() as conn:
+        return conn.execute(
+            text("SELECT count(*) FROM documents WHERE context_id=:cid"),
+            {"cid": cid},
+        ).scalar_one()
+
+
+def test_delta_default_inserts_new_chunks_only(aurora_db, monkeypatch):
+    """force_rebuild=False: keep existing rows, embed only what's missing."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_delta"}, "ctx_delta",
+        replace_context=False, force_rebuild=False,
+    )
+
+    # Pre-seed one row that should be REUSED on the next upload.
+    streams_seed = _file_streams([("a.md", "alpha", {"title": "A"})])
+    store.upload_files({"slug": "ctx_delta"}, "ctx_delta", cid, streams_seed,
+                      callback=lambda x: None)
+    assert _doc_count(cid) == 1
+    seed_calls = len(fake.calls)
+    assert seed_calls == 1, f"seed should embed once, got {seed_calls}"
+
+    # Now upload again with the same chunk + a new chunk. Default
+    # force_rebuild=False: existing chunk is reused (no embed),
+    # new chunk is inserted (one embed).
+    streams_delta = _file_streams([
+        ("a.md", "alpha", {"title": "A"}),
+        ("b.md", "beta",  {"title": "B"}),
+    ])
+    store.upload_files({"slug": "ctx_delta"}, "ctx_delta", cid, streams_delta,
+                      callback=lambda x: None)
+    assert _doc_count(cid) == 2
+    assert len(fake.calls) - seed_calls == 1, (
+        f"expected exactly 1 new embed call (for 'beta'), got "
+        f"{len(fake.calls) - seed_calls}: {fake.calls[seed_calls:]}"
+    )
+
+
+def test_force_rebuild_wipes_and_reembeds_all(aurora_db, monkeypatch):
+    """force_rebuild=True: DELETE pre-existing rows, re-embed every chunk."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_rebuild"}, "ctx_rebuild",
+        replace_context=False, force_rebuild=False,
+    )
+    streams_seed = _file_streams([
+        ("x.md", "ex content", {"title": "X"}),
+        ("y.md", "wy content", {"title": "Y"}),
+    ])
+    store.upload_files({"slug": "ctx_rebuild"}, "ctx_rebuild", cid, streams_seed,
+                      callback=lambda x: None)
+    assert _doc_count(cid) == 2
+    seed_calls = len(fake.calls)
+    assert seed_calls == 2
+
+    # Now force_rebuild=True: get_or_create wipes the table for this cid.
+    cid_after = store.get_or_create_vector_store(
+        {"slug": "ctx_rebuild"}, "ctx_rebuild",
+        replace_context=False, force_rebuild=True,
+    )
+    assert cid_after == cid, f"force_rebuild must preserve the contexts row id; expected {cid}, got {cid_after}"
+    assert _doc_count(cid) == 0, "force_rebuild should have wiped documents"
+
+    # Re-upload — every chunk is a fresh embed (no cache to hit).
+    # Build a fresh stream list with new BytesIO instances, since
+    # streams_seed's BytesIO read pointers are at EOF after the first upload.
+    streams_reupload = _file_streams([
+        ("x.md", "ex content", {"title": "X"}),
+        ("y.md", "wy content", {"title": "Y"}),
+    ])
+    store.upload_files({"slug": "ctx_rebuild"}, "ctx_rebuild", cid, streams_reupload,
+                      callback=lambda x: None)
+    assert _doc_count(cid) == 2
+    assert len(fake.calls) - seed_calls == 2, (
+        f"expected 2 new embeds after wipe, got {len(fake.calls) - seed_calls}"
+    )
+
+
+def test_replace_context_none_with_force_rebuild_false_is_noop(aurora_db, monkeypatch):
+    """vector_store_update with replace_context='none' must not call
+    upload_files for any context. This tests the should_process logic in
+    vector_store_base.vector_store_update."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+
+    # Pre-create a context + one row so we can verify it's preserved.
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_noop"}, "ctx_noop",
+        replace_context=False, force_rebuild=False,
+    )
+    streams_seed = _file_streams([("p.md", "preserve", {"title": "P"})])
+    store.upload_files({"slug": "ctx_noop"}, "ctx_noop", cid, streams_seed,
+                      callback=lambda x: None)
+    pre_count = _doc_count(cid)
+    assert pre_count == 1
+
+    # Now run vector_store_update with replace_context='none'. Patch the
+    # downstream methods so we can verify upload_files is NEVER reached.
+    contexts = [{"slug": "ctx_noop", "name": "ctx_noop", "type": "csv"}]
+    with patch.object(store, "upload_files") as mock_upload, \
+         patch.object(store, "update_tool_resources"), \
+         patch.object(store, "update_tools"), \
+         patch.object(store, "delete_existing_files") as mock_delete:
+        store.vector_store_update(
+            contexts, replace_context="none", force_rebuild=False,
+        )
+
+    assert mock_upload.call_count == 0, (
+        f"replace_context='none' must not upload; got {mock_upload.call_count} call(s)"
+    )
+    assert mock_delete.call_count == 0, (
+        f"replace_context='none' must not delete; got {mock_delete.call_count} call(s)"
+    )
+    assert _doc_count(cid) == pre_count, "row count unchanged"


### PR DESCRIPTION
## Summary

Replace today's two-mode (no-op vs DELETE-and-re-embed-all) `botnim sync` semantics with three explicit modes; make delta the default.

- `botnim sync` (no flags) → delta-sync every context. Embeds new chunks; reuses unchanged via existing content-hash skip; doesn't delete.
- `--replace-context none` → explicit no-op escape (rare).
- `--force-rebuild` → wipe-and-re-embed (escape hatch for upstream schema changes).
- Single-context targeting: `--replace-context <slug>` still works as before.

Spec: `docs/superpowers/specs/2026-05-06-delta-sync-design.md` (on a separate branch — see attached).
Plan: `docs/superpowers/plans/2026-05-06-delta-sync.md` (same).

Closes the bug observed on 2026-05-06: today's migrated-fap silently threw away ~370 freshly-extracted Knesset PDFs because sync was called without `--replace-context`.

## Test plan

- [x] 3 new pytest cases in `tests/vector_store/test_aurora_delta.py` cover delta-default, force-rebuild, and explicit-noop
- [x] All 74 tests in the broader suite pass (PDF extractor, fetch-and-process dispatcher, word-doc, vector-store-aurora, etc.)
- [x] CLI `--help` includes the new flags with explicit semantics
- [x] `--reindex` semantic preserved (forces processing even with `--replace-context none`)
- [x] OpenAI backend behavior change documented in `vector_store_openai.py` docstring
- [ ] Post-merge: deploy to prod, then re-run migrated-fap on prod with default flags. `/admin/sources` doc_count for the four migrated contexts should climb past 04-27 baselines (34/77/219/273) within ~95 min.

## Out of scope (followups)

- Per-snapshot delta metrics (`chunks_added`, `chunks_skipped`)
- `mode` enum refactor of `replace_context`
- Orphan-cleanup policy (currently kept by design)
- UNIQUE constraint on `(context_id, content_hash)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
