### PR TITLE
fix(config): default DEFAULT_ENVIRONMENT to running container env

### DIFF
--- a/botnim/config.py
+++ b/botnim/config.py
@@ -81,7 +81,11 @@ DEFAULT_BATCH_SIZE = 50
 
 # Constants
 VALID_ENVIRONMENTS = ['production', 'staging', 'local']
-DEFAULT_ENVIRONMENT = 'staging'
+# Use the running container's ENVIRONMENT env var so prod ECS serves prod
+# config to callers that omit ?environment=. Falls back to 'staging' for
+# local dev. The result is still validated against VALID_ENVIRONMENTS by
+# callers, so a typo in the env var becomes a 400 instead of a silent miss.
+DEFAULT_ENVIRONMENT = os.environ.get('ENVIRONMENT', 'staging')
 
 def is_production(environment: str) -> bool:
     """


### PR DESCRIPTION
## Summary

Hardcoded `DEFAULT_ENVIRONMENT = 'staging'` made `/botnim/config/<bot>` return staging config to anyone who omitted `?environment=`, including on prod ECS.

The misleading default produced confusing diagnostics (e.g., prod tools appeared to carry the staging `__dev` suffix when inspected via curl without the query param). The actual prod bot is unaffected — LibreChat reads the agent record from MongoDB at chat time, not from this endpoint — but anyone debugging from the API endpoint got staging output on prod.

## Fix

Read `DEFAULT_ENVIRONMENT` from the running container's `ENVIRONMENT` env var (production / staging / local), with `staging` as the local-dev fallback. The result is still validated against `VALID_ENVIRONMENTS` by callers, so a typo becomes a 400 instead of a silent miss.

```python
DEFAULT_ENVIRONMENT = os.environ.get('ENVIRONMENT', 'staging')
```

5 LOC. No callers break.

## Test plan

- [x] Verified prod ECS has `ENVIRONMENT=production` already set
- [ ] After merge + deploy: `curl https://botnim.build-up.team/botnim/config/unified` (no query param) returns `environment: production`, `name: בוט מאוחד - תקנון, חוקים ותקציב` (no `- פיתוח` suffix), tool names without `__dev`
- [ ] Staging unchanged: `curl https://botnim.staging.build-up.team/botnim/config/unified` (no query param) returns staging config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
