### PR TITLE
feat(prompts): collapse multi-section agent_prompts into single body row (alembic 0010)

### DIFF
--- a/botnim/db/migrations/versions/0010_collapse_unified_prompt.py
+++ b/botnim/db/migrations/versions/0010_collapse_unified_prompt.py
@@ -1,0 +1,152 @@
+"""collapse multi-section prompts into a single body row per agent
+
+Revision ID: 0010_collapse_unified_prompt
+Revises: 0009_unified_prompt_editor
+Create Date: 2026-05-08
+
+The Unified Prompt Editor (UPE) was originally implemented with one
+``agent_prompts`` row per logical section (preamble, core_characteristics,
+domain_routing, …). Sections were stitched back together by the editor's
+client-side ``assemble`` helper, which inserted ``<!-- SECTION_KEY: ... -->``
+HTML comments between bodies. The markers leaked into the visible textarea
+and into the LLM's system prompt — neither of which the UI/UX called for.
+
+The system prompt that actually reaches the LLM (``bot_config.py:237``)
+was always just ``"\\n\\n---\\n\\n".join(bodies)`` with no markers, so
+the multi-row decomposition was operationally moot.
+
+This migration collapses every agent's active section rows into a single
+``section_key='body'`` row whose body is the existing concatenation. Old
+rows are kept (history is preserved) but flagged ``active=false`` so the
+``WHERE active = true ORDER BY ordinal`` query in
+``_load_instructions_from_aurora`` returns exactly one row.
+
+The collapse runs in two explicit phases (Python-mediated, not CTE-mediated)
+to avoid any risk of seeing the deactivation before the read:
+
+1. SELECT: read every agent's full concatenated body into Python memory.
+2. UPDATE then INSERT, per agent: deactivate the old rows, write the new
+   single body row.
+
+Even though Postgres CTEs in a single statement share one snapshot,
+concretizing the read in Python first removes the cognitive load of
+reasoning about that and protects against future refactors that might
+split the work across statements.
+
+Drafts (``is_draft=true``) are not collapsed. Open drafts pre-migration
+are mechanically incompatible with the post-migration single-row schema
+(they have arbitrary section_keys); the editor will silently start fresh
+on the first post-migration draft save. This is acceptable for v1 — the
+UPE has been in prod for under 24h.
+
+Idempotent: a no-op if the agent already has exactly one active row with
+section_key='body'.
+"""
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = '0010_collapse_unified_prompt'
+down_revision = '0009_unified_prompt_editor'
+branch_labels = None
+depends_on = None
+
+
+_SELECT_SQL = """
+    WITH agents AS (
+        SELECT DISTINCT agent_type
+        FROM agent_prompts
+        WHERE active = true
+    ),
+    needs_collapse AS (
+        -- Skip agents already in single-row form (idempotent re-runs).
+        SELECT a.agent_type
+        FROM agents a
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM agent_prompts p
+            WHERE p.agent_type = a.agent_type
+              AND p.active = true
+              AND p.section_key = 'body'
+              AND (
+                  SELECT count(*) FROM agent_prompts q
+                  WHERE q.agent_type = a.agent_type AND q.active = true
+              ) = 1
+        )
+    )
+    SELECT
+        n.agent_type,
+        string_agg(p.body, E'\n\n---\n\n' ORDER BY p.ordinal) AS body
+    FROM needs_collapse n
+    JOIN agent_prompts p ON p.agent_type = n.agent_type AND p.active = true
+    GROUP BY n.agent_type
+"""
+
+
+_DEACTIVATE_SQL = """
+    UPDATE agent_prompts
+    SET active = false
+    WHERE agent_type = :agent_type AND active = true
+"""
+
+
+_INSERT_SQL = """
+    INSERT INTO agent_prompts (
+        agent_type, section_key, ordinal, header_text, body,
+        active, is_draft, change_note, created_by, published_at
+    ) VALUES (
+        :agent_type, 'body', 0, '', :body,
+        true, false,
+        'collapsed by alembic 0010', 'alembic-0010', now()
+    )
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    # Phase 1 — read concatenated bodies into memory before any write.
+    rows = bind.execute(text(_SELECT_SQL)).fetchall()
+    if not rows:
+        return
+    # Phase 2 — for each agent, deactivate then insert. The read in phase 1
+    # has already returned the joined body, so the deactivation here cannot
+    # corrupt the source data we're about to insert.
+    for row in rows:
+        params = {"agent_type": row.agent_type, "body": row.body}
+        bind.execute(text(_DEACTIVATE_SQL), {"agent_type": row.agent_type})
+        bind.execute(text(_INSERT_SQL), params)
+
+
+def downgrade() -> None:
+    # The downgrade cannot reconstruct the original section bodies — the
+    # collapse is one-way at the data level. Restore the previous active
+    # state by demoting the collapsed body and reactivating the most
+    # recent pre-collapse rows for each agent.
+    op.execute("""
+        WITH collapsed AS (
+            SELECT id, agent_type
+            FROM agent_prompts
+            WHERE active = true
+              AND section_key = 'body'
+              AND change_note = 'collapsed by alembic 0010'
+        ),
+        previously_active AS (
+            SELECT DISTINCT ON (p.agent_type, p.section_key) p.id
+            FROM agent_prompts p
+            JOIN collapsed c USING (agent_type)
+            WHERE p.id != c.id
+              AND p.section_key != 'body'
+            ORDER BY p.agent_type, p.section_key, p.created_at DESC
+        ),
+        deactivate_collapsed AS (
+            UPDATE agent_prompts
+            SET active = false
+            WHERE id IN (SELECT id FROM collapsed)
+            RETURNING 1
+        )
+        UPDATE agent_prompts
+        SET active = true
+        WHERE id IN (SELECT id FROM previously_active);
+    """)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -426,3 +426,133 @@ def test_0009_round_trips(database_url):
         )).fetchone()
     assert table[0] is not None
     assert view[0] is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 0010 — collapse multi-section prompts into single body row
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _seed_multi_section(conn):
+    """Seed 3 active sections + 1 inactive history row + 1 draft."""
+    conn.execute(text("""
+        INSERT INTO agent_prompts (
+            agent_type, section_key, ordinal, body, active, is_draft, published_at, created_by
+        ) VALUES
+            ('unified', 'preamble', 0, 'PRE',  true,  false, now(), 'seed'),
+            ('unified', 'rules',    1, 'RUL',  true,  false, now(), 'seed'),
+            ('unified', 'closing',  2, 'CLO',  true,  false, now(), 'seed'),
+            ('unified', 'preamble', 0, 'OLD',  false, false, now(), 'seed'),
+            ('unified', 'wip',      9, 'WIP',  false, true,  NULL,  'seed')
+    """))
+
+
+def test_0010_collapses_active_sections_into_single_body_row(database_url):
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        _seed_multi_section(conn)
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        active = conn.execute(text(
+            "SELECT section_key, body FROM agent_prompts "
+            "WHERE agent_type='unified' AND active=true"
+        )).fetchall()
+    assert len(active) == 1, f"expected exactly one active row, got {len(active)}: {active}"
+    assert active[0].section_key == "body"
+    assert active[0].body == "PRE\n\n---\n\nRUL\n\n---\n\nCLO"
+
+
+def test_0010_preserves_history_rows(database_url):
+    """Old non-active rows + drafts must remain (history)."""
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        _seed_multi_section(conn)
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        total = conn.execute(text(
+            "SELECT count(*) FROM agent_prompts WHERE agent_type='unified'"
+        )).scalar()
+    # 5 seeded + 1 new "body" row = 6 (inactive seeds preserved, draft preserved)
+    assert total == 6, f"expected 6 total rows after collapse, got {total}"
+
+
+def test_0010_idempotent(database_url):
+    """Running 0010 twice must not produce duplicate body rows."""
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        _seed_multi_section(conn)
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        active = conn.execute(text(
+            "SELECT count(*) FROM agent_prompts "
+            "WHERE agent_type='unified' AND active=true"
+        )).scalar()
+    assert active == 1
+
+
+def test_0010_no_op_when_already_collapsed(database_url):
+    """An agent already in single-row form must be left untouched."""
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        conn.execute(text("""
+            INSERT INTO agent_prompts (
+                agent_type, section_key, ordinal, body, active, is_draft, published_at, created_by
+            ) VALUES ('takanon', 'body', 0, 'ALREADY-ONE', true, false, now(), 'seed')
+        """))
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT body FROM agent_prompts WHERE agent_type='takanon' AND active=true"
+        )).fetchall()
+    assert len(rows) == 1
+    assert rows[0].body == "ALREADY-ONE"
+
+
+def test_0010_collapsed_body_contains_every_section_body(database_url):
+    """Defensive: even with weird ordinals + many sections, the new body
+    row must contain every original active body in ordinal order. Guards
+    against a refactor that accidentally reads the deactivation before
+    the aggregation."""
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        conn.execute(text("""
+            INSERT INTO agent_prompts (
+                agent_type, section_key, ordinal, body, active, is_draft, published_at, created_by
+            ) VALUES
+                ('unified', 's_a', 5,  'aaa', true,  false, now(), 'seed'),
+                ('unified', 's_b', 1,  'bbb', true,  false, now(), 'seed'),
+                ('unified', 's_c', 9,  'ccc', true,  false, now(), 'seed'),
+                ('unified', 's_d', 0,  'ddd', true,  false, now(), 'seed')
+        """))
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        body = conn.execute(text(
+            "SELECT body FROM agent_prompts "
+            "WHERE agent_type='unified' AND active=true AND section_key='body'"
+        )).scalar()
+
+    # Order: ddd(ord 0), bbb(ord 1), aaa(ord 5), ccc(ord 9).
+    assert body == "ddd\n\n---\n\nbbb\n\n---\n\naaa\n\n---\n\nccc", (
+        f"collapsed body should contain every section body in ordinal order, got: {body!r}"
+    )
+    # Triple-check no body fragment is missing.
+    for fragment in ("aaa", "bbb", "ccc", "ddd"):
+        assert fragment in body, f"missing fragment {fragment!r} in collapsed body"
+    # Triple-check we did not accidentally end up with an empty body.
+    assert body, "collapsed body must not be empty"


### PR DESCRIPTION
feat(prompts): collapse multi-section agent_prompts into single body row (alembic 0010)

The Unified Prompt Editor (UPE) was originally implemented with one
row per logical section, stitched back together with
`<!-- SECTION_KEY: ... -->` HTML comments by the editor's `assemble`
helper. The markers leaked into the user-facing textarea AND into the
LLM's system prompt with no operational benefit — `bot_config.py`'s
`_load_instructions_from_aurora` was always just doing
`"\n\n---\n\n".join(bodies)` with no markers.

This migration collapses every agent's active rows into a single
`section_key='body'` row whose body is the existing concatenation.
The migration runs in two explicit phases (Python read first, then
write) to eliminate any reliance on CTE-snapshot semantics:

1. SELECT: read each agent's full concatenated body into Python.
2. UPDATE then INSERT, per agent: deactivate the old rows, write the
   new single body row.

History rows (active=false) and pending drafts (is_draft=true) are
preserved untouched. Re-running the migration is a no-op for any
agent already in single-row form.

Tests cover:
* the canonical multi-section → single-row collapse
* history preservation (5 → 6 rows, only 1 active)
* idempotence on re-run
* no-op on already-collapsed agents
* defensive: collapsed body contains every section body in ordinal
  order and is never empty (guards against future refactors that
  might read the deactivation before the aggregation)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
