### PR TITLE
fix(prompts): alembic 0010 must DELETE non-body rows, not just deactivate

### DIFF
--- a/botnim/db/migrations/versions/0010_collapse_unified_prompt.py
+++ b/botnim/db/migrations/versions/0010_collapse_unified_prompt.py
@@ -33,14 +33,15 @@ concretizing the read in Python first removes the cognitive load of
 reasoning about that and protects against future refactors that might
 split the work across statements.
 
-Drafts (``is_draft=true``) are not collapsed. Open drafts pre-migration
-are mechanically incompatible with the post-migration single-row schema
-(they have arbitrary section_keys); the editor will silently start fresh
-on the first post-migration draft save. This is acceptable for v1 — the
-UPE has been in prod for under 24h.
+All non-body rows are deleted, including in-flight drafts (``is_draft=true``)
+and inactive history. Drafts pre-migration have arbitrary section_keys
+that don't fit the post-migration single-row schema, and history is
+intentionally collapsed away ("snapshots become whole-prompt snapshots"
+— spec decision). Admin will need to re-enter any in-flight draft after
+the migration runs; loud, recoverable, acceptable for v1.
 
 Idempotent: a no-op if the agent already has exactly one active row with
-section_key='body'.
+section_key='body' and no other rows.
 """
 from __future__ import annotations
 
@@ -85,10 +86,10 @@ _SELECT_SQL = """
 """
 
 
-_DEACTIVATE_SQL = """
-    UPDATE agent_prompts
-    SET active = false
-    WHERE agent_type = :agent_type AND active = true
+_DELETE_OLD_SQL = """
+    DELETE FROM agent_prompts
+    WHERE agent_type = :agent_type
+      AND section_key != 'body'
 """
 
 
@@ -110,43 +111,39 @@ def upgrade() -> None:
     rows = bind.execute(text(_SELECT_SQL)).fetchall()
     if not rows:
         return
-    # Phase 2 — for each agent, deactivate then insert. The read in phase 1
-    # has already returned the joined body, so the deactivation here cannot
-    # corrupt the source data we're about to insert.
+    # Phase 2 — for each agent, DELETE every row whose section_key is not
+    # 'body' (active rows AND drafts AND inactive history), then INSERT the
+    # new collapsed body row.
+    #
+    # Why DELETE instead of UPDATE active=false? The LibreChat-side
+    # `aurora.listSections` query uses
+    #     SELECT DISTINCT ON (section_key) *
+    #     FROM agent_prompts WHERE agent_type=$1
+    #     ORDER BY section_key, active DESC, created_at DESC
+    # which falls back to inactive/draft rows when no active row exists for
+    # a given section_key. After a soft-deactivate every old section_key
+    # still has rows, so listSections returns N+1 rows (1 body + N
+    # fall-back per old key) and the assemble() invariant ('exactly one
+    # section') trips. DELETE removes the section_keys entirely so the
+    # DISTINCT ON has nothing to fall back to.
+    #
+    # History trade-off: per-section history is lost. This is the spec
+    # decision recorded in the brainstorm — "Per-section history is lost
+    # (snapshots become whole-prompt snapshots). Cleanest end state."
     for row in rows:
         params = {"agent_type": row.agent_type, "body": row.body}
-        bind.execute(text(_DEACTIVATE_SQL), {"agent_type": row.agent_type})
+        bind.execute(text(_DELETE_OLD_SQL), {"agent_type": row.agent_type})
         bind.execute(text(_INSERT_SQL), params)
 
 
 def downgrade() -> None:
-    # The downgrade cannot reconstruct the original section bodies — the
-    # collapse is one-way at the data level. Restore the previous active
-    # state by demoting the collapsed body and reactivating the most
-    # recent pre-collapse rows for each agent.
-    op.execute("""
-        WITH collapsed AS (
-            SELECT id, agent_type
-            FROM agent_prompts
-            WHERE active = true
-              AND section_key = 'body'
-              AND change_note = 'collapsed by alembic 0010'
-        ),
-        previously_active AS (
-            SELECT DISTINCT ON (p.agent_type, p.section_key) p.id
-            FROM agent_prompts p
-            JOIN collapsed c USING (agent_type)
-            WHERE p.id != c.id
-              AND p.section_key != 'body'
-            ORDER BY p.agent_type, p.section_key, p.created_at DESC
-        ),
-        deactivate_collapsed AS (
-            UPDATE agent_prompts
-            SET active = false
-            WHERE id IN (SELECT id FROM collapsed)
-            RETURNING 1
-        )
-        UPDATE agent_prompts
-        SET active = true
-        WHERE id IN (SELECT id FROM previously_active);
-    """)
+    # The DELETE in upgrade() drops every non-body row, so the original
+    # multi-section data — including inactive history and pending drafts —
+    # is gone irrecoverably. There is no SQL we can run to reconstruct it.
+    # Fail loudly rather than silently leave the DB in a half-state.
+    raise RuntimeError(
+        "0010_collapse_unified_prompt: downgrade is not supported. "
+        "The upgrade DELETEs every section row whose key is not 'body'. "
+        "Restore from a logical backup taken before the upgrade ran "
+        "(pre-collapse `agent_prompts` rows for the affected agents)."
+    )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -465,8 +465,12 @@ def test_0010_collapses_active_sections_into_single_body_row(database_url):
     assert active[0].body == "PRE\n\n---\n\nRUL\n\n---\n\nCLO"
 
 
-def test_0010_preserves_history_rows(database_url):
-    """Old non-active rows + drafts must remain (history)."""
+def test_0010_deletes_all_non_body_rows(database_url):
+    """Every non-body row (including inactive history and drafts) must be
+    deleted. Without this, LibreChat's `aurora.listSections` DISTINCT ON
+    falls back to inactive/draft rows when no active row exists for a
+    section_key, which trips the `assemble: at most one section` invariant
+    in `getJoined` and 503s the editor."""
     _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
     eng = create_engine(database_url)
     with eng.begin() as conn:
@@ -478,8 +482,12 @@ def test_0010_preserves_history_rows(database_url):
         total = conn.execute(text(
             "SELECT count(*) FROM agent_prompts WHERE agent_type='unified'"
         )).scalar()
-    # 5 seeded + 1 new "body" row = 6 (inactive seeds preserved, draft preserved)
-    assert total == 6, f"expected 6 total rows after collapse, got {total}"
+        non_body = conn.execute(text(
+            "SELECT count(*) FROM agent_prompts "
+            "WHERE agent_type='unified' AND section_key != 'body'"
+        )).scalar()
+    assert total == 1, f"expected exactly one row (the body) after collapse, got {total}"
+    assert non_body == 0, f"expected zero non-body rows after collapse, got {non_body}"
 
 
 def test_0010_idempotent(database_url):
@@ -556,3 +564,56 @@ def test_0010_collapsed_body_contains_every_section_body(database_url):
         assert fragment in body, f"missing fragment {fragment!r} in collapsed body"
     # Triple-check we did not accidentally end up with an empty body.
     assert body, "collapsed body must not be empty"
+
+
+def test_0010_listsections_distinct_on_returns_exactly_one_row(database_url):
+    """Direct regression for the prod fire on 2026-05-08: after upgrade,
+    the SAME query LibreChat's aurora.js:listSections runs (DISTINCT ON
+    section_key, falling back through active DESC, created_at DESC) must
+    return exactly ONE row. If this assertion fails, the editor will 503
+    again because assemble() rejects multi-section input post-collapse."""
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        _seed_multi_section(conn)
+
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    with eng.connect() as conn:
+        rows = conn.execute(text(
+            "WITH latest AS ("
+            " SELECT DISTINCT ON (section_key) * "
+            " FROM agent_prompts WHERE agent_type='unified' "
+            " ORDER BY section_key, active DESC, created_at DESC"
+            ") SELECT count(*) FROM latest"
+        )).scalar()
+    assert rows == 1, (
+        f"listSections-shape query returned {rows} rows; assemble() will 503. "
+        "Migration must DELETE non-body rows so DISTINCT ON has nothing "
+        "to fall back to."
+    )
+
+
+def test_0010_downgrade_raises_with_clear_message(database_url):
+    """The DELETE in upgrade is destructive and irreversible at the data
+    level. Downgrade must not silently leave the DB in a partial state —
+    it must fail loudly so the operator restores from backup."""
+    import pytest as _pytest
+
+    _alembic(["upgrade", "0009_unified_prompt_editor"], database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as conn:
+        _seed_multi_section(conn)
+    _alembic(["upgrade", "0010_collapse_unified_prompt"], database_url)
+
+    proc = subprocess.run(
+        ["alembic", "--config", "alembic.ini", "downgrade", "0009_unified_prompt_editor"],
+        cwd=REPO_ROOT,
+        env={**os.environ, "DATABASE_URL": database_url},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0, "downgrade must fail (destructive op)"
+    assert "downgrade is not supported" in (proc.stderr + proc.stdout), (
+        f"downgrade must explain why; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )


### PR DESCRIPTION
fix(prompts): alembic 0010 must DELETE non-body rows, not just deactivate

The original 0010 deactivated old section rows but left them in place.
LibreChat-side aurora.listSections uses DISTINCT ON (section_key) with
fall-back to inactive/draft rows when no active row exists for a
section_key — so all 14 old section_keys still surfaced via the
fall-back, returned 15 rows, tripped the assemble() "exactly one
section" invariant, and 503'd the editor on prod (2026-05-08).

DELETE removes the section_keys entirely so the DISTINCT ON has nothing
to fall back to. Drafts and inactive history for those keys are
removed too — accepted spec trade-off ("snapshots become whole-prompt
snapshots").

Tests:
* test_0010_deletes_all_non_body_rows — exactly 1 row remains, 0 non-body
* test_0010_listsections_distinct_on_returns_exactly_one_row — direct
  regression for the prod fire; simulates the LC SQL verbatim
* test_0010_downgrade_raises_with_clear_message — irreversible op fails
  loudly instead of silently corrupting

7/7 0010 tests pass against pgvector/pg17 in pytest-postgresql.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
