### PR TITLE
fix(knesset_apps): dedupe by URL not ItemId — recover lost decisions

### DIFF
--- a/botnim/document_parser/knesset_apps/committee_decisions_json.py
+++ b/botnim/document_parser/knesset_apps/committee_decisions_json.py
@@ -184,7 +184,6 @@ def fetch_committee_decisions_index(
     }
     knesset_num = _knesset_num_from_ids(config.knesset_ids)
     seen_urls: set[str] = set()
-    seen_item_ids: set = set()
     rows: list[DocRow] = []
     cursor_to_date: Optional[str] = _to_api_datetime(config.to_date)
     last_total: Optional[int] = None
@@ -215,18 +214,20 @@ def fetch_committee_decisions_index(
         if not items:
             break
 
-        new_items = [it for it in items if it.get("ItemId") not in seen_item_ids]
-        for it in new_items:
-            seen_item_ids.add(it.get("ItemId"))
-        new_rows = _items_to_rows(new_items, knesset_num)
-        for r in new_rows:
-            if r.url in seen_urls:
-                continue
+        # Dedupe at the URL level, NOT ItemId. ``ItemId`` is a meeting
+        # id and one meeting can have multiple decision documents (each
+        # with a distinct DocumentPath). Combined with the API's date-
+        # level ToDate truncation, the same meeting can surface across
+        # pages with different docs each time — so an ItemId-keyed
+        # filter would silently drop documents on the second page.
+        page_rows = _items_to_rows(items, knesset_num)
+        new_rows_this_page = [r for r in page_rows if r.url not in seen_urls]
+        for r in new_rows_this_page:
             seen_urls.add(r.url)
             rows.append(r)
 
-        if not new_items:
-            # All items in this page were already seen — exhausted.
+        if not new_rows_this_page:
+            # All PDF URLs in this page were already collected — exhausted.
             break
         # Advance cursor to one second before the oldest DecisionDate
         # we saw, so the next call returns strictly older rows.

--- a/tests/document_parser/knesset_apps/test_committee_decisions_json.py
+++ b/tests/document_parser/knesset_apps/test_committee_decisions_json.py
@@ -170,6 +170,71 @@ def test_fetch_paginates_via_to_date_cursor(tmp_path: Path):
     assert second_call_body["ToDate"] == "2024-01-15T09:59:59"
 
 
+def test_fetch_collects_all_urls_when_meeting_spans_pages(tmp_path: Path):
+    """Regression: ItemId is a *meeting* id, not a decision id. One meeting
+    can have multiple decisions (distinct DocumentPath URLs) — verified
+    live: ItemId 2242119 has 4 distinct URLs. Combined with the API's
+    date-level ToDate truncation (verified live: ToDate=YYYY-MM-DDThh:mm:ss
+    returns same-DAY items regardless of time), the same meeting can
+    appear on multiple pages with *different* docs each time.
+
+    Old bug: the loop filtered rows by ``ItemId not in seen_item_ids``
+    BEFORE inspecting URLs, so any decision document of an already-seen
+    meeting was silently dropped. Live impact (committee 2211, knesset 25,
+    from_date=2022-11-15): server has 89 distinct PDF URLs, fetcher
+    collected 85 — 4 lost to this bug.
+    """
+    out = tmp_path / "x.csv"
+    cfg = CommitteeDecisionsConfig(output_csv_path=out)
+
+    # Page 1: meeting M (ItemId=200) has 1 of its 3 decisions on this page,
+    # plus 2 newer items at meeting M_NEW (ItemId=100, 2 decisions).
+    page1 = [
+        {"ItemId": 100, "DecisionDate": "2024-06-15T10:00:00",
+         "DocumentTitle": "X1", "DocumentPath": "https://fs/m1.pdf",
+         "FileFormat": "pdf"},
+        {"ItemId": 100, "DecisionDate": "2024-06-15T10:00:00",
+         "DocumentTitle": "X2", "DocumentPath": "https://fs/m2.pdf",
+         "FileFormat": "pdf"},
+        {"ItemId": 200, "DecisionDate": "2024-05-20T12:15:00",
+         "DocumentTitle": "Y1", "DocumentPath": "https://fs/o1.pdf",
+         "FileFormat": "pdf"},
+    ]
+    # Cursor advances to 2024-05-20T12:14:59. The API treats ToDate as
+    # date-level (verified live), so it returns 2024-05-20 items again,
+    # this time surfacing meeting 200's *other* 2 decisions, plus an
+    # older filler at meeting 300.
+    page2 = [
+        {"ItemId": 200, "DecisionDate": "2024-05-20T12:15:00",
+         "DocumentTitle": "Y2", "DocumentPath": "https://fs/o2.pdf",
+         "FileFormat": "pdf"},
+        {"ItemId": 200, "DecisionDate": "2024-05-20T12:15:00",
+         "DocumentTitle": "Y3", "DocumentPath": "https://fs/o3.pdf",
+         "FileFormat": "pdf"},
+        {"ItemId": 300, "DecisionDate": "2024-04-01T10:00:00",
+         "DocumentTitle": "Z", "DocumentPath": "https://fs/z.pdf",
+         "FileFormat": "pdf"},
+    ]
+    http = MagicMock(side_effect=[
+        _resp({"TotalItems": 6, "Items": page1}),
+        _resp({"TotalItems": 4, "Items": page2}),
+        _resp({"Items": []}),  # exhausted
+    ])
+    rows = fetch_committee_decisions_index(cfg, http_post=http)
+
+    # All 6 distinct URLs must be collected, including o2/o3 that share
+    # an already-seen ItemId with o1.
+    assert {r.url for r in rows} == {
+        "https://fs/m1.pdf",
+        "https://fs/m2.pdf",
+        "https://fs/o1.pdf",
+        "https://fs/o2.pdf",
+        "https://fs/o3.pdf",
+        "https://fs/z.pdf",
+    }
+    assert len(rows) == 6
+
+
 def test_fetch_stops_when_no_new_items(tmp_path: Path):
     out = tmp_path / "x.csv"
     cfg = CommitteeDecisionsConfig(output_csv_path=out)


### PR DESCRIPTION
## Summary

- `ItemId` in the `GetCommitteePortalsDecisions` API is a **meeting** id, not a decision id. One meeting can have multiple decision PDFs (different `DocumentPath` URLs).
- Combined with the API's **date-level `ToDate` truncation** (verified live: `ToDate=2023-01-09T09:29:59` still returns 2023-01-09T09:30 items), the same meeting surfaces across multiple pages with different documents each time.
- The old loop pre-filtered rows by `ItemId not in seen_item_ids` **before** inspecting URLs, so any decision document of an already-seen meeting was silently dropped — and `if not new_items: break` could exit the loop early.
- **Fix**: dedupe at the URL level only, drop the `seen_item_ids` set entirely, break when no new URLs were collected from a page.

## Live impact

For the production config (`committee_id=2211` ועדת הכנסת, `knesset_ids="25"`, `from_date="2022-11-15"`):

| | rows |
|---|---:|
| Server `TotalItems` (date-filtered) | 89 |
| Old fetcher collected | 85 |
| **Lost to bug** | **4** |
| New fetcher collects | **89** ✓ |

Verified end-to-end against `https://www.knesset.gov.il/WebSiteApi/knessetapi/CommitteeDecisions/GetCommitteePortalsDecisions`.

## Test plan

- [x] New regression test `test_fetch_collects_all_urls_when_meeting_spans_pages` — RED on old code (drops o2.pdf + o3.pdf), GREEN with fix.
- [x] All 16 tests in `tests/document_parser/knesset_apps/test_committee_decisions_json.py` pass.
- [x] All 27 tests in `tests/document_parser/knesset_apps/` pass.
- [x] Live re-run of `fetch_committee_decisions_index` with prod config returns 89 rows (was 85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
