### PR TITLE
chore(unified): list `botnim` in config.yaml tools

### DIFF
--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -6,6 +6,7 @@ tools:
 - code-interpreter
 - budgetkey
 - generate_word_doc
+- botnim
 context:
 - slug: common_budget_knowledge
   name: ידע רלוונטי על התקציב


### PR DESCRIPTION
## Summary

Adds `botnim` to `specs/unified/config.yaml`'s `tools:` list so the documented config matches the prod LibreChat agent's actually-registered actions.

## Why

`LibreChat/scripts/seed-botnim-agent.js:172-194` (`loadOpenApiSpecs`) registers all OpenAPI specs in `specs/openapi/` on the prod agent — `botnim.yaml` (containing `knesset_sessions_live` and `search_unified__*` retrieval) is already there. But `bot_config.py:280-290` reads `tools:` from `config.yaml` for the OpenAI Responses-API path and for benchmarks, and `botnim` was missing from that list — making the documented config inconsistent with the runtime.

## Behavior

- LibreChat prod path: unchanged (already has the tool registered).
- Responses-API path (`/botnim/config/<bot>`): now also includes botnim's operations, matching production reality.
- Benchmarks: now exercise the same toolset prod uses.

## Test plan

- [ ] `bot_config.load_bot_config('unified', 'production')` succeeds (file is present at `specs/openapi/botnim.yaml`)
- [ ] `/botnim/config/unified` response includes `knesset_sessions_live` in tools (smoke test post-deploy)
