### PR TITLE
fix(sync): mkdir KVFile parent dir before opening — auto-create /srv/cache

### DIFF
--- a/backend/api/api_server.sh
+++ b/backend/api/api_server.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -eu
 
-# /srv/cache (sqlite KV caches for the legacy ES backend) was unmounted on
-# 2026-05-09 — under the Aurora backend, dedup lives in Aurora. The subdir
-# mkdir that used to live here is gone. If you need ES-mode locally, recreate
-# the dirs manually before invoking botnim sync --backend es.
+# /srv/cache: the entrypoint no longer pre-creates this directory. The
+# 2026-05-09 cleanup removed the mkdir under the (incorrect) belief that
+# Aurora replaced both kvfile caches; in fact ``collect_sources.py`` still
+# initializes a per-process L1 metadata kvfile under ``<repo_root>/cache/``
+# regardless of backend. The init helpers in ``collect_sources.py`` and
+# ``vector_store/vector_store_es.py`` now mkdir the parent themselves
+# (``_open_metadata_cache`` / ``_open_embedding_cache``), so the dir is
+# created on first use — no entrypoint setup required.
 
 # ─────────────────────────────────────────────────────────────────────────
 # EFS seed: /srv/specs/unified/extraction is an EFS access point in

--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -27,6 +27,25 @@ from ._concurrency import SyncConcurrency, get_sync_concurrency, run_async
 logger = get_logger(__name__)
 cache: KVFile = None
 
+
+def _open_metadata_cache() -> KVFile:
+    """Open the per-process L1 extraction-result cache.
+
+    Lives at ``<repo_root>/cache/metadata.sqlite``. The parent dir
+    ``<repo_root>/cache/`` is committed in the repo for dev/CI but is
+    NOT copied into the prod docker image (no ``COPY cache/`` in
+    ``backend/api/Dockerfile``), so a fresh ECS task has no
+    ``/srv/cache/``. Without this mkdir, ``KVFile(...)`` →
+    ``sqlite3.connect(...)`` raises ``OperationalError: unable to open
+    database file`` and the sync aborts mid-run — and if the
+    ``--force-rebuild`` wipe already ran, the context is left empty in
+    Aurora until a successful re-sync.
+    """
+    location = Path(__file__).parent.parent / 'cache' / 'metadata'
+    location.parent.mkdir(parents=True, exist_ok=True)
+    return KVFile(location=str(location))
+
+
 def _cache_key(content: str) -> str:
     return hashlib.sha256(content.strip().encode('utf-8')).hexdigest()[:16]
 
@@ -304,7 +323,7 @@ async def collect_context_sources_async(
     from .dynamic_extraction import RpdExhausted
 
     global cache
-    cache = KVFile(location=str(Path(__file__).parent.parent / 'cache' / 'metadata'))
+    cache = _open_metadata_cache()
 
     context_name = context_['name']
     raw: list[tuple[str, object, str, str]] = []

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -23,6 +23,20 @@ from .search_modes import SEARCH_MODES, DEFAULT_SEARCH_MODE
 
 logger = get_logger(__name__)
 
+
+def _open_embedding_cache() -> KVFile:
+    """Open the per-process L1 embedding cache.
+
+    Lives at ``<repo_root>/cache/embedding.sqlite``. Same caveat as
+    ``collect_sources._open_metadata_cache``: ``<repo_root>/cache/`` is
+    not in the prod docker image, so the parent dir must be created
+    before opening the kvfile or sqlite3 raises ``OperationalError``.
+    """
+    location = Path(__file__).parent.parent.parent / 'cache' / 'embedding'
+    location.parent.mkdir(parents=True, exist_ok=True)
+    return KVFile(location=str(location))
+
+
 class VectorStoreES(VectorStoreBase):
     """
     Vector store for Elasticsearch
@@ -475,7 +489,7 @@ class VectorStoreES(VectorStoreBase):
         callback,
         concurrency: SyncConcurrency,
     ):
-        embedding_cache = KVFile(location=str(Path(__file__).parent.parent.parent / 'cache' / 'embedding'))
+        embedding_cache = _open_embedding_cache()
         async_client = get_async_openai_client(self.environment)
 
         # Phase 1: prepare ES documents (embeddings in parallel).

--- a/tests/test_kvfile_cache_init.py
+++ b/tests/test_kvfile_cache_init.py
@@ -1,0 +1,61 @@
+"""Regression: opening a KVFile when its parent directory is missing
+raises ``sqlite3.OperationalError: unable to open database file``.
+
+Hit live in staging on 2026-05-10 when ``botnim sync ... --replace-context
+committee_decisions --force-rebuild`` ran in the botnim-api ECS task: the
+2026-05-09 entrypoint cleanup removed ``mkdir /srv/cache`` from
+api_server.sh under the (mistaken) belief that Aurora replaces the kvfile
+caches. ``collect_sources.py`` and ``vector_store_es.py`` still init
+sqlite-backed kvfiles under ``<repo_root>/cache/`` regardless of backend,
+so the wipe phase succeeded and the re-embed phase crashed — leaving the
+context empty in Aurora.
+
+The fix puts ``location.parent.mkdir(parents=True, exist_ok=True)`` next
+to each ``KVFile(location=...)`` call. These tests exercise the helpers
+that wrap that pattern.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_open_metadata_cache_creates_missing_parent_dir(tmp_path, monkeypatch):
+    """``collect_sources._open_metadata_cache`` must auto-create
+    ``<repo_root>/cache/`` if it doesn't exist, since the kvfile/sqlite3
+    layer won't and the dir is absent in the prod docker image."""
+    from botnim import collect_sources
+
+    fake_module_file = tmp_path / "no-cache-here" / "botnim" / "collect_sources.py"
+    monkeypatch.setattr(collect_sources, "__file__", str(fake_module_file))
+
+    expected_parent = fake_module_file.parent.parent / "cache"
+    assert not expected_parent.exists(), "precondition: cache dir does not yet exist"
+
+    cache = collect_sources._open_metadata_cache()
+
+    assert expected_parent.exists(), "helper should mkdir the parent"
+    cache.set("k", "v")
+    assert cache.get("k") == "v"
+
+
+def test_open_embedding_cache_creates_missing_parent_dir(tmp_path, monkeypatch):
+    """``vector_store_es._open_embedding_cache`` must auto-create
+    ``<repo_root>/cache/`` for the same reason — the embedding kvfile
+    sits next to the metadata kvfile under the repo's ``cache/`` dir."""
+    from botnim.vector_store import vector_store_es
+
+    fake_module_file = (
+        tmp_path / "no-cache-here" / "botnim" / "vector_store" / "vector_store_es.py"
+    )
+    monkeypatch.setattr(vector_store_es, "__file__", str(fake_module_file))
+
+    expected_parent = fake_module_file.parent.parent.parent / "cache"
+    assert not expected_parent.exists(), "precondition: cache dir does not yet exist"
+
+    cache = vector_store_es._open_embedding_cache()
+
+    assert expected_parent.exists(), "helper should mkdir the parent"
+    cache.set("k", "v")
+    assert cache.get("k") == "v"


### PR DESCRIPTION
## Summary

`botnim/collect_sources.py:307` and `botnim/vector_store/vector_store_es.py:478` open sqlite-backed `KVFile` instances under `<repo_root>/cache/` on every sync run. The directory is committed in the repo (`cache/metadata.sqlite` + `cache/embedding.sqlite`) but is **not copied into the prod docker image** (`backend/api/Dockerfile` has no `COPY cache/`). The 2026-05-09 entrypoint cleanup also removed `mkdir /srv/cache` from `backend/api/api_server.sh` under the (incorrect) belief that Aurora replaced both kvfile caches.

Net effect: any first-time `botnim sync` in a freshly-launched ECS task crashed at `kvfile_sqlite.py:16: sqlite3.connect(...)` with `OperationalError: unable to open database file`. **If the sync had already run its `--force-rebuild` wipe, the targeted context was left empty in Aurora** until a successful re-sync.

## Live impact

Hit on staging on 2026-05-10 during:

```
botnim sync staging unified --replace-context committee_decisions --force-rebuild
```

`committee_decisions` chunks went **528 → 0** before the crash; required manual `mkdir -p /srv/cache` and a retry to recover. The daily `/admin/refresh` Lambda path is presumably in a containerised flow that's hit this and silently fixed it (or never re-creates a fresh task), so this latent bug only bites operator-driven CLI syncs.

## Fix

Extract `_open_metadata_cache()` / `_open_embedding_cache()` helpers that `mkdir(parents=True, exist_ok=True)` the location's parent before instantiating `KVFile`. Drop-in replacement at the existing call sites.

Code-level fix preferred over a Dockerfile/entrypoint `mkdir` because the kvfile init runs from any caller — CLI sync via ECS Exec, one-shot ECS `run-task`, dev shell, CI — not just from under `api_server.sh`.

Also rewrote the misleading 2026-05-09 comment in `api_server.sh` so the next person doesn't repeat the same wrong assumption.

## Test plan

- [x] New regression tests `tests/test_kvfile_cache_init.py::test_open_{metadata,embedding}_cache_creates_missing_parent_dir` — RED before fix (helper doesn't exist), GREEN after.
- [x] Each test monkeypatches the module's `__file__` to a fresh `tmp_path`, asserts the helper auto-creates the missing parent and the returned KVFile is usable.
- [x] Full local non-DB regression suite shows **zero new failures** vs `origin/main` (29 pre-existing failures, identical names; +2 passing tests from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
