### PR TITLE
test: mock botnim.observability submodules in query error-handling test

### DIFF
--- a/tests/test_query_error_handling.py
+++ b/tests/test_query_error_handling.py
@@ -29,8 +29,15 @@ for mod in [
     "botnim.bot_config", "botnim.config",
     "botnim.fetch_and_process", "botnim.sync",
     "botnim.db", "botnim.db.session",
+    "botnim.observability", "botnim.observability.tracing",
+    "botnim.observability.middleware",
 ]:
     sys.modules[mod] = MagicMock()
+
+# server.py invokes these at startup; make them no-op callables so the
+# FastAPI import doesn't blow up when the module-level calls run.
+sys.modules["botnim.observability.tracing"].init_tracing = MagicMock(return_value=None)
+sys.modules["botnim.observability.middleware"].install_trace_middleware = MagicMock(return_value=None)
 
 # server.py uses a few names from botnim.config as plain values (not callables);
 # make them concrete so module-load-time references behave.


### PR DESCRIPTION
## Summary
- server.py now imports two functions from new submodules (`botnim.observability.tracing.init_tracing` and `botnim.observability.middleware.install_trace_middleware`) introduced by the phoenix LLM-loop tracing commit.
- The existing test `tests/test_query_error_handling.py` MagicMocks the whole `botnim` package; MagicMock doesn't resolve submodules, so the test fails at collection with `ModuleNotFoundError: No module named 'botnim.observability'`. This blocked `./deploy.sh staging` phase 2.
- Add the two new submodules to the existing sys.modules mock list and stub the entry points as no-op callables so FastAPI startup succeeds in the test.

## Test plan
- [x] `PYTHONPATH=. .venv/bin/python -m pytest tests/test_query_error_handling.py -q` → 10 passed.
- [x] This is exactly the command `deploy.sh` runs in phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
