### PR TITLE
feat(search): government_distribution sidecar for multi-term decision disambiguation

### DIFF
--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -140,6 +140,8 @@ def _inject_distribution(results, distribution: list[dict], fmt: str):
         fmt: the ``format`` query param the caller passed (defaults to
             ``yaml`` upstream).
     """
+    # TODO: 'dict' branch is currently dead on the wire — handler returns text/plain.
+    # Wire up JSONResponse in the handler if dict format over HTTP is ever needed.
     if fmt == 'dict':
         return {"government_distribution": distribution, "results": results}
     if fmt == 'yaml':
@@ -248,7 +250,7 @@ async def search_datasets_handler(
     # the same wait_for deadline as run_query — the probe is cheap and a
     # rare slow query here shouldn't 504 the whole retrieve.
     decision_number = (parsed_filter or {}).get("decision_number")
-    if decision_number and "government_decisions" in context:
+    if decision_number and context.startswith("government_decisions"):
         try:
             distribution = await asyncio.to_thread(
                 government_distribution_sidecar,

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -5,6 +5,7 @@ import logging
 import os
 import threading
 import requests
+import yaml as _yaml
 from fastapi import APIRouter, FastAPI, HTTPException, Response, Query, Body, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
@@ -16,7 +17,7 @@ from pydantic import BaseModel
 from resolve_firebase_user import FireBaseUser
 from refresh_auth import require_refresh_api_key
 from sanity_auth import require_sanity_api_key
-from botnim.query import run_query
+from botnim.query import run_query, government_distribution_sidecar
 from botnim.vector_store.search_modes import SEARCH_MODES, DEFAULT_SEARCH_MODE
 from botnim.bot_config import load_bot_config
 from botnim.config import AVAILABLE_BOTS, VALID_ENVIRONMENTS, DEFAULT_ENVIRONMENT
@@ -121,6 +122,48 @@ async def get_bot_config(
 RETRIEVE_TIMEOUT_SECONDS = float(os.getenv("BOTNIM_RETRIEVE_TIMEOUT_SECONDS", "12"))
 
 
+def _inject_distribution(results, distribution: list[dict], fmt: str):
+    """Wrap retrieve results with a government_distribution sidecar.
+
+    Called only when ``distribution`` has >= 2 entries (the
+    ``government_distribution_sidecar`` helper returns ``None`` otherwise,
+    and we skip injection on its falsy return). The wrapping is format-aware
+    so the LLM sees both the sidecar (which governments are represented in
+    the corpus for this decision_number) and the actual retrieve results.
+
+    Args:
+        results: whatever ``run_query`` returned (string for text/text-short/
+            yaml formats; list[dict] for dict).
+        distribution: rows from ``government_distribution_sidecar`` — each
+            row carries at minimum ``government_number``, plus best-effort
+            ``government`` (cabinet name) and ``doc_count``.
+        fmt: the ``format`` query param the caller passed (defaults to
+            ``yaml`` upstream).
+    """
+    if fmt == 'dict':
+        return {"government_distribution": distribution, "results": results}
+    if fmt == 'yaml':
+        sidecar = _yaml.dump(
+            {"government_distribution": distribution},
+            allow_unicode=True, default_flow_style=False,
+        )
+        results_str = results if isinstance(results, str) else _yaml.dump(
+            results, allow_unicode=True, default_flow_style=False,
+        )
+        return sidecar + "results:\n" + "".join(
+            "  " + line + "\n" for line in results_str.splitlines()
+        )
+    # text / text-short
+    lines = ["[government_distribution]"]
+    for d in distribution:
+        lines.append(
+            f"  ממשלה {d['government_number']} — {d.get('government', '')} "
+            f"({d.get('doc_count', '')} מסמכים)"
+        )
+    lines.append("")
+    return "\n".join(lines) + "\n\n" + (results or "")
+
+
 @app.get("/retrieve/{bot}/{context}")
 @app.get("/botnim/retrieve/{bot}/{context}")
 async def search_datasets_handler(
@@ -196,6 +239,31 @@ async def search_datasets_handler(
             status_code=500,
             content={"error": "search_error", "detail": str(e), "store_id": store_id},
         )
+
+    # Government-decisions multi-term sidecar: a ~3ms GROUP BY on indexed
+    # jsonb. Only fires when the caller filtered by decision_number AND the
+    # request targeted a government_decisions context. The sidecar helper
+    # is sync (sqlalchemy under the hood), so dispatch it via to_thread to
+    # avoid blocking the event loop. We deliberately do NOT put this under
+    # the same wait_for deadline as run_query — the probe is cheap and a
+    # rare slow query here shouldn't 504 the whole retrieve.
+    decision_number = (parsed_filter or {}).get("decision_number")
+    if decision_number and "government_decisions" in context:
+        try:
+            distribution = await asyncio.to_thread(
+                government_distribution_sidecar,
+                store_id,
+                decision_number,
+            )
+        except Exception:
+            # Sidecar must never fail the parent retrieve. The helper itself
+            # already swallows exceptions and returns None, so this is a
+            # belt-and-braces guard.
+            logger.warning("government_distribution_sidecar raised; ignoring", exc_info=True)
+            distribution = None
+        if distribution:
+            results = _inject_distribution(results, distribution, format or 'yaml')
+
     if format == 'yaml':
         return Response(content=results, media_type="application/x-yaml")
     return Response(content=results, media_type="text/plain")

--- a/botnim/query.py
+++ b/botnim/query.py
@@ -323,24 +323,32 @@ def government_distribution_sidecar(
 ) -> list[dict] | None:
     """Return government distribution for a decision number, or None.
 
-    Returns None when: the backend is ES (not Aurora), or fewer than 2
-    distinct government_number values match. Callers inject the result
-    into the retrieve response only when this returns a non-None list.
+    Returns None when: the backend is ES (not Aurora), fewer than 2
+    distinct government_number values match, or any error occurs.
+    Callers inject the result into the retrieve response only when
+    this returns a non-None list.
 
     Args:
-        store_id: e.g. "unified__government_decisions__dev"
+        store_id: e.g. "unified__government_decisions"
         decision_number: the bare decision number string, e.g. "550"
     """
-    client = QueryClient(store_id)
-    if not isinstance(client.vector_store, VectorStoreAurora):
-        logger.debug(
-            "government_distribution_sidecar: backend is not Aurora, skipping"
+    try:
+        client = QueryClient(store_id)
+        if not isinstance(client.vector_store, VectorStoreAurora):
+            logger.debug(
+                "government_distribution_sidecar: backend is not Aurora, skipping"
+            )
+            return None
+        dist = client.vector_store.government_distribution(
+            client.context_name, decision_number
+        )
+        return dist if dist else None
+    except Exception:
+        logger.warning(
+            "government_distribution_sidecar failed; returning None",
+            exc_info=True,
         )
         return None
-    dist = client.vector_store.government_distribution(
-        client.context_name, decision_number
-    )
-    return dist if dist else None
 
 
 def _build_core_browse_item(result: SearchResult) -> Dict[str, Any]:

--- a/botnim/query.py
+++ b/botnim/query.py
@@ -316,6 +316,33 @@ def run_query(*, store_id: str, query_text: str, num_results: int=DEFAULT_NUM_RE
         logger.info(f"Formatted results: {formatted_results}")
     return formatted_results
 
+
+def government_distribution_sidecar(
+    store_id: str,
+    decision_number: str,
+) -> list[dict] | None:
+    """Return government distribution for a decision number, or None.
+
+    Returns None when: the backend is ES (not Aurora), or fewer than 2
+    distinct government_number values match. Callers inject the result
+    into the retrieve response only when this returns a non-None list.
+
+    Args:
+        store_id: e.g. "unified__government_decisions__dev"
+        decision_number: the bare decision number string, e.g. "550"
+    """
+    client = QueryClient(store_id)
+    if not isinstance(client.vector_store, VectorStoreAurora):
+        logger.debug(
+            "government_distribution_sidecar: backend is not Aurora, skipping"
+        )
+        return None
+    dist = client.vector_store.government_distribution(
+        client.context_name, decision_number
+    )
+    return dist if dist else None
+
+
 def _build_core_browse_item(result: SearchResult) -> Dict[str, Any]:
     """Build the core fields for a browse item"""
     metadata = result.metadata or {}

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -559,7 +559,7 @@ class VectorStoreAurora(VectorStoreBase):
                     metadata->>'government_number'          AS government_number,
                     metadata->>'government'                 AS government,
                     COUNT(*)                                AS doc_count,
-                    MAX((metadata->>'publish_date')::date)  AS latest_publish_date
+                    MAX(to_date(metadata->>'publish_date', 'DD.MM.YYYY')) AS latest_publish_date
                 FROM documents
                 WHERE context_id = :cid
                   AND metadata @> CAST(:mfilter AS jsonb)

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -541,6 +541,37 @@ class VectorStoreAurora(VectorStoreBase):
 
         return _rrf_fuse(vector_rows, bm25_rows, num_results)
 
+    def government_distribution(self, context_name: str, decision_number: str) -> list[dict]:
+        """One entry per distinct government_number with the given decision_number.
+        Returns [] when <2 governments match — callers skip injection in that case.
+        """
+        bot = self.config["slug"]
+        with get_session() as sess:
+            row = sess.execute(text(
+                "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
+            ), {"bot": bot, "name": context_name}).fetchone()
+            if not row:
+                logger.warning("government_distribution: context (%s, %s) not found", bot, context_name)
+                return []
+            cid = str(row[0])
+            rows = sess.execute(text("""
+                SELECT
+                    metadata->>'government_number'  AS government_number,
+                    metadata->>'government'         AS government,
+                    COUNT(*)                        AS doc_count,
+                    MAX(metadata->>'publish_date')  AS latest_date
+                FROM documents
+                WHERE context_id = :cid
+                  AND metadata @> CAST(:mfilter AS jsonb)
+                  AND metadata->>'government_number' IS NOT NULL
+                GROUP BY metadata->>'government_number', metadata->>'government'
+                ORDER BY (metadata->>'government_number')::int
+            """), {"cid": cid, "mfilter": json.dumps({"decision_number": decision_number})}).fetchall()
+        if len(rows) < 2:
+            return []
+        return [{"government_number": r[0], "government": r[1],
+                 "doc_count": r[2], "latest_publish_date": r[3]} for r in rows]
+
     def update_tools(self, context_, vector_store):
         """Emit an OpenAI function-tool definition for this context.
         Uses the context_name (not the uuid) as the tool-name suffix so

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -545,7 +545,7 @@ class VectorStoreAurora(VectorStoreBase):
         """One entry per distinct government_number with the given decision_number.
         Returns [] when <2 governments match — callers skip injection in that case.
         """
-        bot = self.config["slug"]
+        bot = self.config.get("slug")
         with get_session() as sess:
             row = sess.execute(text(
                 "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
@@ -554,18 +554,19 @@ class VectorStoreAurora(VectorStoreBase):
                 logger.warning("government_distribution: context (%s, %s) not found", bot, context_name)
                 return []
             cid = str(row[0])
-            rows = sess.execute(text("""
+            rows = sess.execute(text(r"""
                 SELECT
-                    metadata->>'government_number'  AS government_number,
-                    metadata->>'government'         AS government,
-                    COUNT(*)                        AS doc_count,
-                    MAX(metadata->>'publish_date')  AS latest_date
+                    metadata->>'government_number'          AS government_number,
+                    metadata->>'government'                 AS government,
+                    COUNT(*)                                AS doc_count,
+                    MAX((metadata->>'publish_date')::date)  AS latest_publish_date
                 FROM documents
                 WHERE context_id = :cid
                   AND metadata @> CAST(:mfilter AS jsonb)
                   AND metadata->>'government_number' IS NOT NULL
                 GROUP BY metadata->>'government_number', metadata->>'government'
-                ORDER BY (metadata->>'government_number')::int
+                ORDER BY CASE WHEN metadata->>'government_number' ~ '^\d+$'
+                              THEN (metadata->>'government_number')::int END NULLS LAST
             """), {"cid": cid, "mfilter": json.dumps({"decision_number": decision_number})}).fetchall()
         if len(rows) < 2:
             return []

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -559,7 +559,12 @@ class VectorStoreAurora(VectorStoreBase):
                     metadata->>'government_number'          AS government_number,
                     metadata->>'government'                 AS government,
                     COUNT(*)                                AS doc_count,
-                    MAX(to_date(metadata->>'publish_date', 'DD.MM.YYYY')) AS latest_publish_date
+                    MAX(CASE
+                        WHEN metadata->>'publish_date' ~ E'^\\d{2}\\.\\d{2}\\.\\d{4}$'
+                            THEN to_date(metadata->>'publish_date', 'DD.MM.YYYY')
+                        WHEN metadata->>'publish_date' ~ E'^\\d{4}-\\d{2}-\\d{2}'
+                            THEN (metadata->>'publish_date')::date
+                        END)                                    AS latest_publish_date
                 FROM documents
                 WHERE context_id = :cid
                   AND metadata @> CAST(:mfilter AS jsonb)

--- a/tests/backend/test_gov_distribution_endpoint.py
+++ b/tests/backend/test_gov_distribution_endpoint.py
@@ -1,15 +1,15 @@
-"""Test that the /retrieve endpoint surfaces a ``metadata_filter`` query
-parameter and forwards it to ``run_query`` as a parsed dict.
+"""Test that the /retrieve endpoint injects a ``government_distribution``
+sidecar onto the response when:
 
-These tests exercise only the HTTP-layer plumbing (param parsing,
-JSON decoding, error handling). ``run_query`` itself is patched out
-- the underlying filter behavior is covered separately by the
-QueryClient.search tests in task 1.
+  * the caller filtered by ``decision_number`` in ``metadata_filter``, AND
+  * the request targeted a ``government_decisions`` context, AND
+  * the sidecar SQL probe returned >= 2 distinct governments.
 
-The mock scaffolding at the top mirrors ``tests/test_query_error_handling.py``:
-all heavy botnim dependencies must be mocked in ``sys.modules`` before
-``backend.api.server`` is imported, otherwise the FastAPI module-load
-fails outside the Docker container.
+The mock scaffolding at the top mirrors
+``tests/backend/test_metadata_filter_endpoint.py``: all heavy botnim
+dependencies must be mocked in ``sys.modules`` before ``backend.api.server``
+is imported, otherwise the FastAPI module-load fails outside the Docker
+container.
 """
 import sys
 import types
@@ -122,13 +122,7 @@ mock_search_modes.DEFAULT_SEARCH_MODE = MagicMock(num_results=5)
 # And mock run_query as a proper function we can patch
 mock_run_query = MagicMock(return_value="mock results")
 sys.modules["botnim.query"].run_query = mock_run_query
-# The retrieve handler now dispatches `government_distribution_sidecar` when
-# the request filters by decision_number on a government_decisions context;
-# without an explicit MagicMock here, auto-attribute access on the
-# sys.modules["botnim.query"] MagicMock returns a sub-MagicMock that yields a
-# truthy MagicMock when called, which the handler then tries to yaml.dump
-# and crashes. Pinning return_value=None keeps the sidecar branch inert for
-# these metadata-filter routing tests.
+# Gov-distribution sidecar: same MagicMock-on-the-module pattern as run_query.
 sys.modules["botnim.query"].government_distribution_sidecar = MagicMock(return_value=None)
 
 from unittest.mock import patch
@@ -138,52 +132,75 @@ from fastapi.testclient import TestClient
 from backend.api.server import app
 
 client = TestClient(app)
+ENDPOINT = "/retrieve/unified/government_decisions__dev"
+
+FAKE_DISTRIBUTION = [
+    {"government_number": "36", "government": "ממשלת בנט", "doc_count": 12, "latest_publish_date": "2022-06-13"},
+    {"government_number": "37", "government": "ממשלת נתניהו", "doc_count": 8, "latest_publish_date": "2023-11-19"},
+]
 
 
-class TestMetadataFilterEndpoint:
+# We patch `backend.api.server.run_query` and `.government_distribution_sidecar`
+# directly (rather than reaching into `sys.modules["botnim.query"]` and mutating
+# its attributes) because server.py captured both names at module-load time via
+# `from botnim.query import ...`. Replacing the attribute on the sys.modules
+# entry after server.py is imported no longer affects what server.py calls —
+# but `patch("backend.api.server.X", ...)` does, and it auto-reverts at test
+# exit so cross-test pollution stays out.
+class TestGovernmentDistributionEndpoint:
+    def test_sidecar_injected_into_yaml_when_multi_government(self):
+        with patch("backend.api.server.run_query", return_value="- header: some result\n  text: content\n"), \
+             patch("backend.api.server.government_distribution_sidecar",
+                   return_value=FAKE_DISTRIBUTION):
+            resp = client.get(ENDPOINT, params={
+                "query": "החלטה 550",
+                "metadata_filter": '{"decision_number": "550"}',
+                "format": "yaml",
+            })
 
-    def test_valid_json_metadata_filter_forwarded(self):
-        """Valid JSON metadata_filter is parsed and forwarded to run_query."""
-        import json as json_lib
-        mf = json_lib.dumps({"decision_number": "550"})
-        with patch("backend.api.server.run_query", return_value="results") as mock_rq:
-            r = client.get(
-                "/retrieve/unified/government_decisions__dev",
-                params={"query": "החלטה 550", "metadata_filter": mf},
-            )
-        assert r.status_code == 200
-        _, kwargs = mock_rq.call_args
-        assert kwargs["metadata_filter"] == {"decision_number": "550"}
+        assert resp.status_code == 200
+        body = resp.text
+        assert "government_distribution" in body
+        assert "36" in body
 
-    def test_missing_metadata_filter_passes_none(self):
-        """When metadata_filter is absent, run_query receives metadata_filter=None."""
-        with patch("backend.api.server.run_query", return_value="results") as mock_rq:
-            r = client.get(
-                "/retrieve/unified/government_decisions__dev",
-                params={"query": "החלטה 550"},
-            )
-        assert r.status_code == 200
-        _, kwargs = mock_rq.call_args
-        assert kwargs["metadata_filter"] is None
+    def test_sidecar_not_injected_when_single_government(self):
+        with patch("backend.api.server.run_query", return_value="- header: result\n  text: content\n"), \
+             patch("backend.api.server.government_distribution_sidecar",
+                   return_value=None):
+            resp = client.get(ENDPOINT, params={
+                "query": "החלטה 999",
+                "metadata_filter": '{"decision_number": "999"}',
+                "format": "yaml",
+            })
 
-    def test_malformed_json_returns_400(self):
-        """Non-JSON metadata_filter value must return HTTP 400 with structured error."""
-        with patch("backend.api.server.run_query", return_value="results"):
-            r = client.get(
-                "/retrieve/unified/government_decisions__dev",
-                params={"query": "test", "metadata_filter": "not-valid-json"},
-            )
-        assert r.status_code == 400
-        body = r.json()
-        assert body["error"] == "invalid_metadata_filter"
+        assert resp.status_code == 200
+        assert "government_distribution" not in resp.text
 
-    def test_empty_string_metadata_filter_passes_none(self):
-        """Empty string metadata_filter is treated the same as absent (None)."""
-        with patch("backend.api.server.run_query", return_value="results") as mock_rq:
-            r = client.get(
-                "/retrieve/unified/government_decisions__dev",
-                params={"query": "test", "metadata_filter": ""},
-            )
-        assert r.status_code == 200
-        _, kwargs = mock_rq.call_args
-        assert kwargs["metadata_filter"] is None
+    def test_sidecar_not_called_without_decision_number_filter(self):
+        # run_query returns a string here because the /retrieve handler wraps
+        # the result in starlette Response(content=...), which requires
+        # bytes/str — list payloads (dict format pre-serialization) crash
+        # render(). The semantic point of this test is the sidecar dispatch
+        # decision, not the run_query payload shape.
+        with patch("backend.api.server.run_query", return_value="- header: result\n"), \
+             patch("backend.api.server.government_distribution_sidecar") as mock_sidecar:
+            resp = client.get(ENDPOINT, params={
+                "query": "מה המדיניות",
+                "format": "dict",
+            })
+
+            assert resp.status_code == 200
+            mock_sidecar.assert_not_called()
+
+    def test_sidecar_not_called_for_non_gov_decisions_context(self):
+        # See test_sidecar_not_called_without_decision_number_filter for why
+        # we return a string here rather than [].
+        with patch("backend.api.server.run_query", return_value="- header: result\n"), \
+             patch("backend.api.server.government_distribution_sidecar") as mock_sidecar:
+            resp = client.get("/retrieve/unified/common_knowledge__dev", params={
+                "query": "מסמך",
+                "metadata_filter": '{"decision_number": "550"}',
+            })
+
+            assert resp.status_code == 200
+            mock_sidecar.assert_not_called()

--- a/tests/test_gov_distribution.py
+++ b/tests/test_gov_distribution.py
@@ -1,9 +1,40 @@
 """Unit tests for VectorStoreAurora.government_distribution()."""
+import sys
 import json
 from unittest.mock import MagicMock, patch
 import pytest
+import botnim.query as _real_botnim_query
 from botnim.query import government_distribution_sidecar
 from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_botnim_query():
+    """Ensure sys.modules['botnim.query'] is the real module for each test.
+
+    tests/backend/test_metadata_filter_endpoint.py and
+    tests/backend/test_gov_distribution_endpoint.py both replace
+    sys.modules['botnim.query'] with a MagicMock at module-import
+    time (and never restore it). Because pytest collection order is
+    not guaranteed and any later sibling test that imports either of
+    those endpoint files first will poison sys.modules globally,
+    `patch("botnim.query.QueryClient", ...)` in this file then
+    silently patches an attribute on the MagicMock instead of the
+    real module — letting the production code call the real
+    QueryClient and trip over OPENAI_API_KEY at runtime.
+
+    Restoring the real module before each test in this file makes
+    these tests order-independent.
+    """
+    saved = sys.modules.get("botnim.query")
+    sys.modules["botnim.query"] = _real_botnim_query
+    try:
+        yield
+    finally:
+        if saved is None:
+            sys.modules.pop("botnim.query", None)
+        else:
+            sys.modules["botnim.query"] = saved
 
 
 def _make_store():

--- a/tests/test_gov_distribution.py
+++ b/tests/test_gov_distribution.py
@@ -89,3 +89,55 @@ class TestGovernmentDistribution:
         assert set(entry.keys()) == {"government_number", "government", "doc_count", "latest_publish_date"}
         assert entry["government_number"] == "28"
         assert entry["latest_publish_date"] == "2000-05-10"
+
+
+from botnim.query import government_distribution_sidecar
+
+
+class TestGovernmentDistributionSidecar:
+    def test_calls_through_to_aurora(self):
+        fake_dist = [
+            {"government_number": "36", "government": "ממשלת בנט", "doc_count": 12, "latest_publish_date": "2022-06-13"},
+            {"government_number": "37", "government": "ממשלת נתניהו", "doc_count": 8, "latest_publish_date": "2023-11-19"},
+        ]
+        with patch("botnim.query.QueryClient") as MockClient:
+            instance = MockClient.return_value
+            instance.vector_store = MagicMock(spec=VectorStoreAurora)
+            instance.vector_store.government_distribution.return_value = fake_dist
+            instance.context_name = "government_decisions"
+
+            result = government_distribution_sidecar(
+                "unified__government_decisions__dev", "550"
+            )
+
+        instance.vector_store.government_distribution.assert_called_once_with(
+            "government_decisions", "550"
+        )
+        assert len(result) == 2
+        assert result[0]["government_number"] == "36"
+
+    def test_returns_none_for_non_aurora_backend(self):
+        with patch("botnim.query.QueryClient") as MockClient:
+            instance = MockClient.return_value
+            instance.vector_store = MagicMock()
+            instance.vector_store.__class__ = object  # not VectorStoreAurora
+            instance.context_name = "government_decisions"
+
+            result = government_distribution_sidecar(
+                "unified__government_decisions__dev", "550"
+            )
+
+        assert result is None
+
+    def test_returns_none_when_single_government(self):
+        with patch("botnim.query.QueryClient") as MockClient:
+            instance = MockClient.return_value
+            instance.vector_store = MagicMock(spec=VectorStoreAurora)
+            instance.vector_store.government_distribution.return_value = []
+            instance.context_name = "government_decisions"
+
+            result = government_distribution_sidecar(
+                "unified__government_decisions__dev", "999"
+            )
+
+        assert result is None

--- a/tests/test_gov_distribution.py
+++ b/tests/test_gov_distribution.py
@@ -1,0 +1,74 @@
+"""Unit tests for VectorStoreAurora.government_distribution()."""
+import json
+from unittest.mock import MagicMock, patch
+import pytest
+from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+
+def _make_store():
+    with patch.object(VectorStoreAurora, "__init__", lambda self, *a, **kw: None):
+        store = VectorStoreAurora.__new__(VectorStoreAurora)
+        store.config = {"slug": "unified", "context": []}
+        store.environment = "staging"
+    return store
+
+
+def _mock_session(fetchone_result, fetchall_result):
+    mock_conn = MagicMock()
+    # First execute call → fetchone (context lookup)
+    # Second execute call → fetchall (distribution query)
+    mock_conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=fetchone_result)),
+        MagicMock(fetchall=MagicMock(return_value=fetchall_result)),
+    ]
+    mock_sess = MagicMock()
+    mock_sess.__enter__ = MagicMock(return_value=mock_conn)
+    mock_sess.__exit__ = MagicMock(return_value=False)
+    return mock_sess
+
+
+class TestGovernmentDistribution:
+    def test_returns_multiple_governments(self):
+        store = _make_store()
+        fake_rows = [
+            ("36", "ממשלת בנט, 2021-2022", 12, "2022-06-13"),
+            ("37", "ממשלת נתניהו, 2022-", 8, "2023-11-19"),
+        ]
+        with patch("botnim.vector_store.vector_store_aurora.get_session",
+                   return_value=_mock_session(("ctx-id",), fake_rows)):
+            result = store.government_distribution("government_decisions", "550")
+
+        assert len(result) == 2
+        assert result[0]["government_number"] == "36"
+        assert result[0]["doc_count"] == 12
+        assert result[1]["government_number"] == "37"
+
+    def test_returns_empty_when_single_government(self):
+        store = _make_store()
+        fake_rows = [("37", "ממשלת נתניהו", 5, "2023-01-01")]
+        with patch("botnim.vector_store.vector_store_aurora.get_session",
+                   return_value=_mock_session(("ctx-id",), fake_rows)):
+            result = store.government_distribution("government_decisions", "999")
+        assert result == []
+
+    def test_returns_empty_when_context_not_found(self):
+        store = _make_store()
+        with patch("botnim.vector_store.vector_store_aurora.get_session",
+                   return_value=_mock_session(None, [])):
+            result = store.government_distribution("government_decisions", "550")
+        assert result == []
+
+    def test_result_shape(self):
+        store = _make_store()
+        fake_rows = [
+            ("28", "ממשלת ברק, 1999-2001", 3, "2000-05-10"),
+            ("37", "ממשלת נתניהו, 2022-", 8, "2023-11-19"),
+        ]
+        with patch("botnim.vector_store.vector_store_aurora.get_session",
+                   return_value=_mock_session(("ctx-id",), fake_rows)):
+            result = store.government_distribution("government_decisions", "550")
+
+        entry = result[0]
+        assert set(entry.keys()) == {"government_number", "government", "doc_count", "latest_publish_date"}
+        assert entry["government_number"] == "28"
+        assert entry["latest_publish_date"] == "2000-05-10"

--- a/tests/test_gov_distribution.py
+++ b/tests/test_gov_distribution.py
@@ -24,6 +24,8 @@ def _mock_session(fetchone_result, fetchall_result):
     mock_sess = MagicMock()
     mock_sess.__enter__ = MagicMock(return_value=mock_conn)
     mock_sess.__exit__ = MagicMock(return_value=False)
+    # Expose the inner conn so tests can inspect call args
+    mock_sess._mock_conn = mock_conn
     return mock_sess
 
 
@@ -34,14 +36,29 @@ class TestGovernmentDistribution:
             ("36", "ממשלת בנט, 2021-2022", 12, "2022-06-13"),
             ("37", "ממשלת נתניהו, 2022-", 8, "2023-11-19"),
         ]
+        mock_sess = _mock_session(("ctx-id",), fake_rows)
         with patch("botnim.vector_store.vector_store_aurora.get_session",
-                   return_value=_mock_session(("ctx-id",), fake_rows)):
+                   return_value=mock_sess):
             result = store.government_distribution("government_decisions", "550")
 
         assert len(result) == 2
         assert result[0]["government_number"] == "36"
         assert result[0]["doc_count"] == 12
         assert result[1]["government_number"] == "37"
+
+        # Verify mfilter was passed as JSON string, not a raw dict
+        mock_conn = mock_sess._mock_conn
+        call_args = mock_conn.execute.call_args_list[1]
+        params = call_args[0][1]
+        assert params["mfilter"] == json.dumps({"decision_number": "550"})
+
+    def test_returns_empty_when_group_by_yields_zero_rows(self):
+        """Context exists but the GROUP BY returns 0 rows (no matching decision_number)."""
+        store = _make_store()
+        with patch("botnim.vector_store.vector_store_aurora.get_session",
+                   return_value=_mock_session(("ctx-id",), [])):
+            result = store.government_distribution("government_decisions", "nonexistent")
+        assert result == []
 
     def test_returns_empty_when_single_government(self):
         store = _make_store()

--- a/tests/test_gov_distribution.py
+++ b/tests/test_gov_distribution.py
@@ -2,6 +2,7 @@
 import json
 from unittest.mock import MagicMock, patch
 import pytest
+from botnim.query import government_distribution_sidecar
 from botnim.vector_store.vector_store_aurora import VectorStoreAurora
 
 
@@ -91,9 +92,6 @@ class TestGovernmentDistribution:
         assert entry["latest_publish_date"] == "2000-05-10"
 
 
-from botnim.query import government_distribution_sidecar
-
-
 class TestGovernmentDistributionSidecar:
     def test_calls_through_to_aurora(self):
         fake_dist = [
@@ -110,6 +108,7 @@ class TestGovernmentDistributionSidecar:
                 "unified__government_decisions__dev", "550"
             )
 
+        MockClient.assert_called_once_with("unified__government_decisions__dev")
         instance.vector_store.government_distribution.assert_called_once_with(
             "government_decisions", "550"
         )
@@ -129,7 +128,7 @@ class TestGovernmentDistributionSidecar:
 
         assert result is None
 
-    def test_returns_none_when_single_government(self):
+    def test_returns_none_when_aurora_returns_empty(self):
         with patch("botnim.query.QueryClient") as MockClient:
             instance = MockClient.return_value
             instance.vector_store = MagicMock(spec=VectorStoreAurora)
@@ -138,6 +137,19 @@ class TestGovernmentDistributionSidecar:
 
             result = government_distribution_sidecar(
                 "unified__government_decisions__dev", "999"
+            )
+
+        assert result is None
+
+    def test_returns_none_on_db_error(self):
+        with patch("botnim.query.QueryClient") as MockClient:
+            instance = MockClient.return_value
+            instance.vector_store = MagicMock(spec=VectorStoreAurora)
+            instance.vector_store.government_distribution.side_effect = Exception("DB connection refused")
+            instance.context_name = "government_decisions"
+
+            result = government_distribution_sidecar(
+                "unified__government_decisions", "550"
             )
 
         assert result is None


### PR DESCRIPTION
## Problem

When LibreChat hits `/retrieve` with `metadata_filter={"decision_number":"550"}` on the `government_decisions` context, that filter matches ~235 chunks spread across 7 different governments (the same decision number is reused across cabinets). Top-k vector search then returns chunks from whichever single government happens to score highest on the query text. The LLM faithfully reads those chunks and answers — but never learns that the same `decision_number` denotes six other unrelated decisions in other governments. End user gets one answer, confidently, with no signal that the term is ambiguous.

## Solution

After `run_query()` returns, run a cheap side-query that answers a different question: "of the chunks matching this `metadata_filter`, how many distinct `government_number` values are there, and what are they?" If the answer is two or more, inject the grouped distribution into the `/retrieve` response under a new `government_distribution` key. The LLM now sees the ambiguity in its tool result on the same turn and can present all matching governments to the user before answering.

Design choices:

- **No new search mode.** The retrieval mode (semantic / lexical / hybrid) is unchanged. The sidecar is a separate `GROUP BY` query against the existing Aurora indices.
- **No two-step LLM flow.** Everything happens inside one `/retrieve` call; the LLM still sees a single tool result.
- **Belt-and-braces.** The sidecar is wrapped in `try/except` and runs via `to_thread`. Any failure (DB hiccup, Aurora missing, etc.) returns `None` and the retrieve response is unaffected.
- **Cost.** ~3ms of additional DB time per qualifying request. Triggers only for `government_decisions` contexts with a `decision_number` filter — nothing else pays for it.

## Commits

- `feat(search): VectorStoreAurora.government_distribution()` — `GROUP BY government_number` SQL probe
- `fix(search): harden government_distribution() SQL casts + test coverage`
- `feat(search): government_distribution_sidecar()` — wraps Aurora group-by for `query.py` callers
- `fix(search): government_distribution_sidecar — swallow exceptions + test coverage`
- `feat(api): inject government_distribution sidecar into retrieve response` — `server.py` injection + format-aware `_inject_distribution()`
- `fix(api): tighten government_decisions context guard + document dead dict branch`
- `test(gov-distribution): restore real botnim.query module to fix test-order coupling` (autouse fixture so the sidecar unit tests survive being co-collected with the endpoint test files that stomp `sys.modules["botnim.query"]`)

## Test coverage

17 tests across two layers:

- `tests/test_gov_distribution.py` (9) — `VectorStoreAurora.government_distribution()` unit + `government_distribution_sidecar()` wrapper
- `tests/backend/test_gov_distribution_endpoint.py` (4) — `/retrieve` sidecar injection (multi-gov vs single-gov, no-filter, wrong-context guards)
- `tests/backend/test_metadata_filter_endpoint.py` (4) — `metadata_filter` query-param plumbing

All 17 pass locally in the combined `pytest` invocation the deploy gate runs.

## Still needed after merge

- **System prompt update**: instruct the unified bot that when `government_distribution` is present in a tool result, it should present *all* matching governments to the user and ask which one they meant before answering with the search hits. This PR ships the data path; the prompt change ships separately so the bot operators can iterate on the wording without retouching the search layer.
- **Deploy + smoke test**: after merge → `./deploy.sh staging` → confirm `curl ".../retrieve/unified/government_decisions__dev?query=...&metadata_filter=%7B%22decision_number%22%3A%22550%22%7D"` returns a YAML payload with a `government_distribution:` block listing the seven matching governments.

## Test plan

- [ ] Combined pytest (`tests/test_gov_distribution.py` + both endpoint files): 17 passing
- [ ] Deploy to staging via `./deploy.sh staging` succeeds end-to-end
- [ ] `curl` against staging `/retrieve` with `decision_number=550` returns `government_distribution` block with >= 2 entries
- [ ] LibreChat staging UI: ask "מה החליטה הממשלה בהחלטה 550?" — observe whether the bot acknowledges the ambiguity (will improve dramatically once the prompt update lands)

Generated with [Claude Code](https://claude.com/claude-code)
