### PR TITLE
feat(retrieval): RECENCY_BROWSE — date-desc browse mode

### DIFF
--- a/botnim/query.py
+++ b/botnim/query.py
@@ -248,7 +248,7 @@ class QueryClient:
                     score=hit['_score'],
                     id=hit['_id'],
                     content=hit['_source']['content'].strip().split('\n')[0],
-                    full_content=hit['_source']['content'] if search_mode.name != "METADATA_BROWSE" else None,
+                    full_content=hit['_source']['content'] if search_mode.name not in ("METADATA_BROWSE", "RECENCY_BROWSE") else None,
                     metadata=hit['_source'].get('metadata', None),
                     _explanation=hit.get('_explanation', None) if explain else None,
                     context_name=self.context_name
@@ -351,45 +351,88 @@ def government_distribution_sidecar(
         return None
 
 
+def _md_field(metadata: Dict, extracted_data: Dict, *keys: str, default=None):
+    """Return the first non-empty value for any of `keys`, looking first in
+    `extracted_data` (legacy shape with extracted_data wrapper) then in
+    top-level `metadata` (current flat shape used by legal_advisor_letters /
+    legal_advisor_opinions / committee_decisions / ethics_decisions).
+    """
+    for key in keys:
+        val = extracted_data.get(key)
+        if val:
+            return val
+    for key in keys:
+        val = metadata.get(key)
+        if val:
+            return val
+    return default
+
+
 def _build_core_browse_item(result: SearchResult) -> Dict[str, Any]:
     """Build the core fields for a browse item"""
     metadata = result.metadata or {}
-    extracted_data = metadata.get('extracted_data', {})
-    
+    extracted_data = metadata.get('extracted_data') or {}
+
     return {
         "document_type": CONTEXT_DISPLAY_NAMES.get(result.context_name, result.context_name or 'unknown'),
         "document_id": result.id,
         "relevance_score": round(result.score, 2),
-        "title": extracted_data.get('DocumentTitle', 'ללא כותרת'),
-        "summary": extracted_data.get('Summary', '')
+        "title": _md_field(metadata, extracted_data, 'DocumentTitle', 'title', 'שם_החלטה', default='ללא כותרת'),
+        "summary": _md_field(metadata, extracted_data, 'Summary', 'תקציר', default=''),
     }
 
 def _extract_source_url(metadata: Dict, extracted_data: Dict) -> Optional[str]:
     """Extract source URL with fallback logic"""
-    return metadata.get('source_url', '') or extracted_data.get('קישור_למקור', '')
+    return (
+        metadata.get('source_url')
+        or extracted_data.get('קישור_למקור')
+        or metadata.get('קישור_למקור')
+        or (metadata.get('ReferenceLinks')[0] if metadata.get('ReferenceLinks') else None)
+        or ''
+    )
 
-def _extract_date_field(extracted_data: Dict) -> Optional[str]:
-    """Extract the first available date field from configured date fields"""
+def _extract_date_field(metadata: Dict, extracted_data: Dict) -> Optional[str]:
+    """Extract the first available date field from configured date fields.
+    Looks in both the legacy extracted_data wrapper and the current flat
+    top-level metadata shape (legal_advisor_letters / _opinions / committee_*
+    / ethics_* are flat; older contexts may still use extracted_data).
+    """
     for date_field in METADATA_BROWSE_FIELDS['date_fields']:
         if extracted_data.get(date_field):
             return extracted_data[date_field]
+        if metadata.get(date_field):
+            return metadata[date_field]
     return None
 
-def _process_metadata_fields(extracted_data: Dict, browse_item: Dict) -> Dict[str, Any]:
-    """Process and filter metadata fields, excluding core fields and duplicates"""
+def _process_metadata_fields(metadata: Dict, extracted_data: Dict, browse_item: Dict) -> Dict[str, Any]:
+    """Process and filter metadata fields, excluding core fields and duplicates.
+
+    Sources fields from BOTH extracted_data (legacy shape) and top-level
+    metadata (current flat shape). extracted_data takes precedence on conflicts.
+    """
     relevant_metadata = {}
-    core_fields = {'DocumentTitle', 'Summary', 'title', 'status', 'document_type'}
-    
+    core_fields = {
+        'DocumentTitle', 'Summary', 'title', 'status', 'document_type',
+        'context_name', 'context_type', 'filename', 'source_id',
+        'chunk_index', 'total_chunks', 'extracted_at', 'document_id',
+        'raw_content', 'error',
+    }
+
     # Add date if available
-    date_value = _extract_date_field(extracted_data)
+    date_value = _extract_date_field(metadata, extracted_data)
     if date_value:
         relevant_metadata['date'] = date_value
-    
-    # Process all other metadata fields
-    for field, value in extracted_data.items():
-        if _should_include_metadata_field(field, value, core_fields, browse_item):
-            relevant_metadata[field] = _format_metadata_value(value)
-    
+
+    # Process all other metadata fields — extracted_data first, then flat metadata.
+    seen = set()
+    for source in (extracted_data, metadata):
+        for field, value in source.items():
+            if field in seen:
+                continue
+            if _should_include_metadata_field(field, value, core_fields, browse_item):
+                relevant_metadata[field] = _format_metadata_value(value)
+                seen.add(field)
+
     return relevant_metadata
 
 def _should_include_metadata_field(field: str, value: Any, core_fields: set, browse_item: Dict) -> bool:
@@ -417,18 +460,15 @@ def _add_full_text_indicator(extracted_data: Dict, relevant_metadata: Dict) -> N
 def _extract_metadata_fields(result: SearchResult) -> Dict[str, Any]:
     """Extract and structure metadata fields for browse display"""
     metadata = result.metadata or {}
-    extracted_data = metadata.get('extracted_data', {})
-    
-    # Build core fields
+    extracted_data = metadata.get('extracted_data') or {}
+
     browse_item = _build_core_browse_item(result)
-    
-    # Add source URL if available
+
     source_url = _extract_source_url(metadata, extracted_data)
     if source_url:
         browse_item["source_url"] = source_url
-    
-    # Process metadata fields
-    relevant_metadata = _process_metadata_fields(extracted_data, browse_item)
+
+    relevant_metadata = _process_metadata_fields(metadata, extracted_data, browse_item)
     
     # Add full text indicator
     _add_full_text_indicator(extracted_data, relevant_metadata)
@@ -439,13 +479,19 @@ def _extract_metadata_fields(result: SearchResult) -> Dict[str, Any]:
     
     return browse_item
 
-def _format_metadata_browse_results(results: List[SearchResult]) -> Dict[str, Any]:
+def _format_metadata_browse_results(
+    results: List[SearchResult],
+    search_mode_name: str = "METADATA_BROWSE",
+) -> Dict[str, Any]:
     """
-    Format search results specifically for METADATA_BROWSE mode
-    Returns structured metadata for browsing instead of full content
+    Format search results for any browse-style mode (METADATA_BROWSE,
+    RECENCY_BROWSE). Returns structured metadata for browsing instead of
+    full content. `search_mode_name` echoes the actual mode used so the
+    LLM (and humans reading the trace) can tell similarity-ranked vs
+    date-ranked results apart.
     """
     return {
-        "search_mode": "METADATA_BROWSE",
+        "search_mode": search_mode_name,
         "total_results": len(results),
         "documents": [_extract_metadata_fields(result) for result in results]
     }
@@ -526,17 +572,20 @@ def _format_metadata_browse_text(results: List[SearchResult]) -> str:
     
     return header + "\n".join(formatted_results) + footer
 
-def _format_browse_mode_results(results: List[SearchResult], format: str) -> str:
-    """Handle METADATA_BROWSE mode formatting"""
+def _format_browse_mode_results(
+    results: List[SearchResult],
+    format: str,
+    search_mode_name: str = "METADATA_BROWSE",
+) -> str:
+    """Handle browse-style mode formatting (METADATA_BROWSE, RECENCY_BROWSE)."""
     if format == 'dict':
-        return _format_metadata_browse_results(results)
+        return _format_metadata_browse_results(results, search_mode_name)
     elif format == 'yaml':
-        browse_results = _format_metadata_browse_results(results)
+        browse_results = _format_metadata_browse_results(results, search_mode_name)
         return yaml.dump(browse_results, allow_unicode=True, width=1000000, sort_keys=False)
     elif format == 'text':
         return _format_metadata_browse_text(results)
     else:
-        # Fallback for unsupported formats in browse mode
         return _format_metadata_browse_text(results)
 
 def _format_result_as_text_short(result: SearchResult) -> str:
@@ -593,12 +642,15 @@ def format_search_results(results: List[SearchResult], format: str, explain: boo
     Returns:
         str: Formatted search results as a text string
     """
-    # Check if we're in METADATA_BROWSE mode for special formatting
-    is_browse_mode = search_mode and search_mode.name == "METADATA_BROWSE"
-    
+    # Check if we're in a browse-style mode (metadata-summary output).
+    # RECENCY_BROWSE shares the same response shape; only the row selection
+    # differs (date-desc vs similarity).
+    is_browse_mode = search_mode and search_mode.name in ("METADATA_BROWSE", "RECENCY_BROWSE")
+
     if is_browse_mode:
-        return _format_browse_mode_results(results, format)
-    
+        return _format_browse_mode_results(results, format, search_mode.name)
+
+
     # Process regular results
     formatted_results = []
     for result in results:

--- a/botnim/vector_store/search_modes.py
+++ b/botnim/vector_store/search_modes.py
@@ -197,11 +197,32 @@ METADATA_BROWSE_CONFIG = SearchModeConfig(
     ]
 )
 
+# RECENCY_BROWSE — pure date-desc browse. No vector or lexical scoring.
+# The Aurora backend short-circuits to a date-ordered query when this mode is
+# selected (see vector_store_aurora.VectorStoreAurora._recency_search).
+# Output shape is identical to METADATA_BROWSE so the formatter at
+# botnim.query._format_browse_mode_results handles both.
+#
+# Why this exists: when the user asks "what are the LATEST X", METADATA_BROWSE
+# still returns top-N by hybrid similarity, which can miss the calendar-newest
+# document if the query has weak topical signal. RECENCY_BROWSE returns the
+# actual newest-by-date documents in the context.
+RECENCY_BROWSE_CONFIG = SearchModeConfig(
+    name="RECENCY_BROWSE",
+    description="Browse the calendar-newest documents in a context. No similarity ranking — pure ORDER BY publication_date DESC. Use when the user asks for 'latest', 'most recent', 'newest' documents and there is no specific topical filter.",
+    min_score=0.0,
+    num_results=10,
+    use_vector_search=False,
+    use_lexical_search=False,
+    fields=[],
+)
+
 # Immutable registry of all search modes
 SEARCH_MODES = MappingProxyType({
     "SECTION_NUMBER": SECTION_NUMBER_CONFIG,
     "REGULAR": REGULAR_CONFIG,
     "METADATA_BROWSE": METADATA_BROWSE_CONFIG,
+    "RECENCY_BROWSE": RECENCY_BROWSE_CONFIG,
     # Add more modes here as needed
 })
 

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -425,6 +425,94 @@ class VectorStoreAurora(VectorStoreBase):
             ), {"cid": cid, "names": list(file_names)})
             return result.rowcount
 
+    def _recency_search(
+        self,
+        context_name: str,
+        num_results: int,
+        metadata_filter: dict | None,
+    ) -> dict:
+        """Pure date-desc browse — returns the calendar-newest distinct
+        documents in the context. Bypasses pgvector + tsvector entirely.
+
+        Date field is resolved against a small list of known names because
+        contexts disagree on which key holds the document date:
+          - legal_advisor_letters / opinions: metadata->>'PublicationDate'
+          - committee_decisions / ethics_decisions: metadata->>'תאריך'
+          - older extraction schema: metadata->'extracted_data'->>'<same>'
+
+        Dedup: each upstream document can be split into N chunks (chunk_index
+        0..N-1, sharing `filename` / `source_id`). The query returns one row
+        per dedup key (lowest chunk_index — usually 0 — picked deterministically
+        via ROW_NUMBER). Without this the LLM saw 5 copies of the same letter.
+
+        Filter: only documents whose date matches the ISO `YYYY-MM-DD` shape
+        are eligible. Docs with a null or unparseable date are skipped (they
+        can't be ranked by recency anyway). If the user wants those, REGULAR
+        or METADATA_BROWSE is the right tool.
+        """
+        bot = self.config["slug"]
+        with get_session() as sess:
+            row = sess.execute(text(
+                "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
+            ), {"bot": bot, "name": context_name}).fetchone()
+            if not row:
+                logger.warning(
+                    "recency_search: context (%s, %s) not found", bot, context_name
+                )
+                return {"hits": {"hits": []}}
+            cid = str(row[0])
+
+            md_filter_sql = ""
+            md_params = {}
+            if metadata_filter:
+                md_filter_sql = " AND metadata @> CAST(:mfilter AS jsonb)"
+                md_params["mfilter"] = json.dumps(metadata_filter)
+
+            rows = sess.execute(text(f"""
+                WITH dated AS (
+                  SELECT
+                    id, content, metadata,
+                    COALESCE(
+                      NULLIF(metadata->>'תאריך', ''),
+                      NULLIF(metadata->>'תאריך_מכתב', ''),
+                      NULLIF(metadata->>'PublicationDate', ''),
+                      NULLIF(metadata->'extracted_data'->>'תאריך', ''),
+                      NULLIF(metadata->'extracted_data'->>'תאריך_מכתב', ''),
+                      NULLIF(metadata->'extracted_data'->>'PublicationDate', '')
+                    ) AS doc_date,
+                    COALESCE(
+                      NULLIF(metadata->>'filename', ''),
+                      NULLIF(metadata->>'source_id', ''),
+                      id::text
+                    ) AS dedup_key
+                  FROM documents
+                  WHERE context_id = :cid{md_filter_sql}
+                ),
+                ranked AS (
+                  SELECT
+                    id, content, metadata, doc_date,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY dedup_key
+                      ORDER BY COALESCE((metadata->>'chunk_index')::int, 0) ASC, id ASC
+                    ) AS rn
+                  FROM dated
+                  WHERE doc_date IS NOT NULL
+                    AND doc_date ~ '^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}'
+                )
+                SELECT id, content, metadata
+                FROM ranked
+                WHERE rn = 1
+                ORDER BY doc_date DESC, id DESC
+                LIMIT :limit
+            """), {"cid": cid, "limit": num_results, **md_params}).fetchall()
+
+        hits = [{
+            "_id": str(r[0]),
+            "_score": 1.0,
+            "_source": {"content": r[1], "metadata": r[2]},
+        } for r in rows]
+        return {"hits": {"hits": hits}}
+
     def search(
         self,
         context_name: str,
@@ -443,6 +531,11 @@ class VectorStoreAurora(VectorStoreBase):
         Returns: {"hits": {"hits": [{"_id", "_score", "_source": {...}}, ...]}}
         """
         bot = self.config["slug"]
+        # RECENCY_BROWSE bypasses similarity scoring entirely — pure date-desc
+        # browse so the LLM can answer "latest X" correctly even when the query
+        # has no strong topical signal. Output shape mirrors METADATA_BROWSE.
+        if search_mode is not None and getattr(search_mode, "name", None) == "RECENCY_BROWSE":
+            return self._recency_search(context_name, num_results, metadata_filter)
         fetch = num_results * 5  # over-fetch then RRF-trim
         # Honor the legacy ES SECTION_NUMBER / RELATED_RESOURCE contract: when
         # the mode declares `use_vector_search=False`, skip the pgvector branch

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -366,13 +366,13 @@
     },
     "/botnim/retrieve/unified/legal_advisor_opinions__dev": {
       "get": {
-        "description": "Search formal legal opinions by Knesset legal advisor in the unified knowledge base",
+        "description": "Search formal legal opinions by Knesset legal advisor. THREE modes — choose by intent: (a) 'מה ההנחיות/חוות הדעת האחרונות', 'הכי עדכניות', 'הכי חדשות', 'מה התפרסם לאחרונה' → use search_mode=RECENCY_BROWSE: returns the calendar-newest documents in pure date-desc order (no similarity ranking, immune to query-phrasing bias). (b) 'אילו חוות דעת יש על X', 'תן לי רשימה של…', browse/enumerate intent on a TOPIC → search_mode=METADATA_BROWSE: similarity-ranked summaries (25 docs). (c) substantive content question requiring full text → leave search_mode=REGULAR (default). For (a) and (b), present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results — they are already newest-first.",
         "operationId": "search_unified__legal_advisor_opinions__dev",
         "parameters": [
           {
             "name": "query",
             "in": "query",
-            "description": "Free text search query",
+            "description": "Free text search query. RECENCY_BROWSE ignores this — pass any short string (e.g. 'הנחיות'). REGULAR and METADATA_BROWSE both use it for ranking.",
             "required": true,
             "schema": {
               "type": "string"
@@ -381,11 +381,11 @@
           {
             "name": "search_mode",
             "in": "query",
-            "description": "Search mode for different types of queries",
+            "description": "REGULAR (default, 7 full-text chunks) for substantive content questions. METADATA_BROWSE (25 similarity-ranked metadata summaries) for topical browse/enumerate. RECENCY_BROWSE (10 calendar-newest documents, no similarity) — REQUIRED when the user asks for 'latest/most-recent/newest' without a strong topical filter, because METADATA_BROWSE's similarity ranking can miss the calendar-newest docs.",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["METADATA_BROWSE", "REGULAR"],
+              "enum": ["RECENCY_BROWSE", "METADATA_BROWSE", "REGULAR"],
               "default": "REGULAR"
             }
           },
@@ -406,13 +406,13 @@
     },
     "/botnim/retrieve/unified/legal_advisor_letters__dev": {
       "get": {
-        "description": "Search correspondence with the Knesset legal advisor in the unified knowledge base",
+        "description": "Search correspondence with the Knesset legal advisor. THREE modes — choose by intent: (a) 'מה ההנחיות/המכתבים האחרונים', 'הכי עדכני', 'הכי חדשים', 'מה התפרסם לאחרונה' → use search_mode=RECENCY_BROWSE: returns the calendar-newest documents in pure date-desc order (no similarity ranking, immune to query-phrasing bias). (b) 'אילו מכתבים יש על X', 'תן לי רשימה של…', browse/enumerate intent on a TOPIC → search_mode=METADATA_BROWSE: similarity-ranked summaries (25 docs). (c) substantive content question requiring full text → leave search_mode=REGULAR (default). For (a) and (b), present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results — they are already newest-first.",
         "operationId": "search_unified__legal_advisor_letters__dev",
         "parameters": [
           {
             "name": "query",
             "in": "query",
-            "description": "Free text search query",
+            "description": "Free text search query. RECENCY_BROWSE ignores this — pass any short string (e.g. 'מכתב'). REGULAR and METADATA_BROWSE both use it for ranking.",
             "required": true,
             "schema": {
               "type": "string"
@@ -421,11 +421,11 @@
           {
             "name": "search_mode",
             "in": "query",
-            "description": "Search mode for different types of queries",
+            "description": "REGULAR (default, 7 full-text chunks) for substantive content questions. METADATA_BROWSE (25 similarity-ranked metadata summaries) for topical browse/enumerate. RECENCY_BROWSE (10 calendar-newest documents, no similarity) — REQUIRED when the user asks for 'latest/most-recent/newest' without a strong topical filter, because METADATA_BROWSE's similarity ranking can miss the calendar-newest docs.",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["METADATA_BROWSE", "REGULAR"],
+              "enum": ["RECENCY_BROWSE", "METADATA_BROWSE", "REGULAR"],
               "default": "REGULAR"
             }
           },
@@ -446,13 +446,13 @@
     },
     "/botnim/retrieve/unified/committee_decisions__dev": {
       "get": {
-        "description": "Search Knesset committee decisions in the unified knowledge base",
+        "description": "Search Knesset committee decisions. THREE modes — choose by intent: (a) 'אילו החלטות התקבלו לאחרונה', 'מה ההחלטות האחרונות', 'הכי חדשות' → search_mode=RECENCY_BROWSE: calendar-newest decisions in pure date-desc order (no similarity ranking). (b) 'אילו החלטות יש על X', 'רשימת החלטות בנושא…', topical browse → search_mode=METADATA_BROWSE (25 similarity-ranked summaries). (c) substantive content question → leave REGULAR (default). Present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results.",
         "operationId": "search_unified__committee_decisions__dev",
         "parameters": [
           {
             "name": "query",
             "in": "query",
-            "description": "Free text search query",
+            "description": "Free text search query. RECENCY_BROWSE ignores this — pass any short string (e.g. 'החלטה').",
             "required": true,
             "schema": {
               "type": "string"
@@ -461,11 +461,11 @@
           {
             "name": "search_mode",
             "in": "query",
-            "description": "Search mode for different types of queries",
+            "description": "REGULAR (default, 7 full-text chunks) for substantive content questions. METADATA_BROWSE (25 similarity-ranked metadata summaries) for topical browse/enumerate. RECENCY_BROWSE (10 calendar-newest documents, no similarity) — REQUIRED for 'latest/most-recent/newest' queries with no strong topical filter.",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["METADATA_BROWSE", "REGULAR"],
+              "enum": ["RECENCY_BROWSE", "METADATA_BROWSE", "REGULAR"],
               "default": "REGULAR"
             }
           },
@@ -486,13 +486,13 @@
     },
     "/botnim/retrieve/unified/ethics_decisions__dev": {
       "get": {
-        "description": "Search ethics committee decisions in the unified knowledge base",
+        "description": "Search ethics committee decisions. THREE modes — choose by intent: (a) 'אילו החלטות אתיקה לאחרונה', 'הכי חדשות' → search_mode=RECENCY_BROWSE: calendar-newest rulings in pure date-desc order. (b) 'אילו החלטות אתיקה יש על X', topical browse → search_mode=METADATA_BROWSE. (c) substantive content question → leave REGULAR (default). Present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results.",
         "operationId": "search_unified__ethics_decisions__dev",
         "parameters": [
           {
             "name": "query",
             "in": "query",
-            "description": "Free text search query",
+            "description": "Free text search query. RECENCY_BROWSE ignores this — pass any short string (e.g. 'אתיקה').",
             "required": true,
             "schema": {
               "type": "string"
@@ -501,11 +501,11 @@
           {
             "name": "search_mode",
             "in": "query",
-            "description": "Search mode for different types of queries",
+            "description": "REGULAR (default, 7 full-text chunks) for substantive content questions. METADATA_BROWSE (25 similarity-ranked metadata summaries) for topical browse. RECENCY_BROWSE (10 calendar-newest documents, no similarity) — REQUIRED for 'latest/most-recent/newest' queries with no strong topical filter.",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["METADATA_BROWSE", "REGULAR"],
+              "enum": ["RECENCY_BROWSE", "METADATA_BROWSE", "REGULAR"],
               "default": "REGULAR"
             }
           },
@@ -630,7 +630,7 @@
     },
     "/botnim/retrieve/unified/government_decisions__dev": {
       "get": {
-        "description": "Search Israeli cabinet (government) decisions from gov.il / Ma'agar HaHachlatot. Use for cabinet resolutions, government decisions on legislation, ministerial appointments, decisions on Knesset bills (support/oppose at preliminary reading), and policy decisions. Each result includes a procedure_number_str (the official decision number) and url_id for citation.",
+        "description": "Search Israeli cabinet (government) decisions from gov.il / Ma'agar HaHachlatot. Use for cabinet resolutions, government decisions on legislation, ministerial appointments, decisions on Knesset bills (support/oppose at preliminary reading), and policy decisions. Each result includes a procedure_number_str (the official decision number) and source_url for citation — always use source_url verbatim from the result, never construct or guess a URL. NOTE: Decision numbers recycle across coalition terms; decision 550 exists in 7 different governments. When a user asks about a decision by number without specifying a government term, use metadata_filter with only decision_number to retrieve all matching decisions, then present each distinct one (grouped by government term, date, and title) and ask which term the user wants to explore. Only filter by government_number if the user explicitly specifies a term.",
         "operationId": "search_unified__government_decisions__dev",
         "parameters": [
           {
@@ -667,7 +667,7 @@
           {
             "name": "metadata_filter",
             "in": "query",
-            "description": "JSON object for JSONB exact-match filter on document metadata. For number-based government decision lookups pass {\"decision_number\": \"<NUMBER>\"} to bypass semantic drift and retrieve the exact decision. Example: {\"decision_number\": \"550\"}",
+            "description": "JSON object for JSONB exact-match filter on document metadata. IMPORTANT: Government decision numbers recycle across coalition terms — decision 550 exists in governments 28, 29, 30, 32, 35, 36, 37. Supported filter fields: 'decision_number' (string, e.g. \"550\") and 'government_number' (string, e.g. \"37\"). To search across ALL government terms for a given number (when the user has not specified a term), pass only decision_number: {\"decision_number\": \"550\"}. To narrow to a specific government term, combine both fields: {\"decision_number\": \"550\", \"government_number\": \"37\"}. Government numbers in dataset: 28 (ברק, 1999), 29–30 (שרון, 2001–2003), 31 (שרון+אולמרט, 2006), 32 (נתניהו, 2009), 33 (נתניהו, 2013), 34 (נתניהו, 2015), 35 (נתניהו, 2020), 36 (בנט, 2021), 37 (נתניהו, 2022+).",
             "required": false,
             "schema": {
               "type": "string"


### PR DESCRIPTION
## Summary
- New `RECENCY_BROWSE` search mode: pure ORDER BY publication_date DESC, no similarity scoring, document-level dedup. Fixes a confidence-failure where the bot named the "newest" out of a similarity-biased top-N instead of the calendar-newest document.
- Latent rendering bug fix in `METADATA_BROWSE`: legal-advisor contexts store metadata flat (no `extracted_data` wrapper); formatter was silently returning "ללא כותרת" for every doc. Now reads from both shapes.
- OpenAPI spec on the four metadata-rich contexts (`legal_advisor_letters`, `legal_advisor_opinions`, `committee_decisions`, `ethics_decisions`) updated with prescriptive intent → mode guidance: recency → RECENCY_BROWSE, topical browse → METADATA_BROWSE, content → REGULAR.

## Motivation
On staging the unified bot answered "מה ההנחיות האחרונות שפרסמה היועצת המשפטית לכנסת?" by hedging ("couldn't determine which is latest"). A first pass tightened the tool descriptions to prescribe `METADATA_BROWSE`, which made the bot picky one document — but the wrong one (July 2025 instead of the actual January 2026 budget letter), because METADATA_BROWSE returns top-25 by hybrid similarity and the query's weak topical signal pulled in appointments-related docs. `RECENCY_BROWSE` removes that bias.

## Verified locally
- Bot now answers with the actual calendar-newest letters: 22/01/2026 (תקציב 2026), 19/01/2026 (פגיעה בוועדת הכספים), 14/01/2026, 13/01/2026, 12/01/2026.
- Single tool call (`legal_advisor_letters` with `search_mode=RECENCY_BROWSE`, `num_results=5`).
- SQL probe against local Aurora confirms 22/01/2026 is in fact the newest.

## Test plan
- [ ] `pytest` in `rebuilding-bots/` (deploy.sh phase 2 runs this; do not `--skip-tests`).
- [ ] `./deploy.sh staging --auto-approve` from parlibot.
- [ ] Manual sanity through staging UI: ask "מה ההנחיות האחרונות שפרסמה היועצת המשפטית לכנסת?" → expect 22/01/2026 budget letter at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
