### PR TITLE
feat(retrieval): per-context use_lexical_search override for Hebrew title corpora

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -543,15 +543,32 @@ class VectorStoreAurora(VectorStoreBase):
         # leak into results. vector_store_es.py:165 had this; the Aurora port
         # dropped it, which silently turned SECTION_NUMBER into REGULAR.
         use_vector = bool(getattr(search_mode, "use_vector_search", True))
-        # Same gate for the lexical (BM25 / tsvector) branch. PG `simple` tsv
-        # config has no Hebrew analyzer; the prefix-OR fallback can't bridge
-        # construct-state morphology (`ועדה` / `ועדת` / `ועדות`); the noisy
-        # BM25 list dilutes the (correct) vector ranking under RRF. REGULAR
-        # and METADATA_BROWSE flip this to False (vector-only). SECTION_NUMBER
-        # / RELATED_RESOURCE keep it True because exact section-number lookup
-        # IS lexical. See A/B evidence on 2026-05-10 (row 0 of the goldset:
-        # raw cosine top-3 = expected docs, RRF top-3 = irrelevant chunks).
-        use_lexical = bool(getattr(search_mode, "use_lexical_search", True))
+        # Lexical (BM25 / tsvector) branch. Default lives on the search mode —
+        # REGULAR + METADATA_BROWSE ship with it OFF because the small,
+        # conversational `common_*_knowledge` corpora are noisy under BM25
+        # (PG `simple` tsv has no Hebrew analyzer; prefix-OR expansion
+        # surfaces too many low-quality hits and dilutes vector ranking
+        # under RRF — see A/B on 2026-05-10).
+        #
+        # Per-context override: long-document corpora where the title is
+        # the strongest signal (`government_decisions`, `legal_advisor_*`,
+        # `committee_decisions`, `ethics_decisions`, `legal_text`) are the
+        # opposite case — `text-embedding-3-small` cosine ranks verbatim-
+        # title queries deep in the corpus (rank #13,904 of 29,795 for the
+        # 2025-10-26 "פיתוח ושיקום תשתיות ביישובים מוחלשים" probe), while
+        # BM25 surfaces the same target at rank #1. Those contexts opt back
+        # in via `use_lexical_search: true` in `specs/<bot>/config.yaml`.
+        # An explicit context value (true OR false) always beats the mode default.
+        ctx_cfg = next(
+            (c for c in self.config.get('context', [])
+             if c.get('slug') == context_name),
+            None,
+        )
+        ctx_lex = ctx_cfg.get('use_lexical_search') if ctx_cfg else None
+        if ctx_lex is None:
+            use_lexical = bool(getattr(search_mode, "use_lexical_search", True))
+        else:
+            use_lexical = bool(ctx_lex)
 
         # Resolve context_id from (bot, name) — small extra round-trip but
         # keeps the search call self-contained and resilient to context
@@ -566,11 +583,6 @@ class VectorStoreAurora(VectorStoreBase):
             # Only set when we'll actually use the vector branch — saves a
             # no-op SET on BM25-only modes.
             if use_vector:
-                ctx_cfg = next(
-                    (c for c in self.config.get('context', [])
-                     if c.get('slug') == context_name),
-                    None,
-                )
                 ef = _resolve_int_setting(
                     ctx_cfg, 'hnsw_ef_search', _HNSW_EF_SEARCH_DEFAULT,
                     minimum=_HNSW_EF_SEARCH_MIN, maximum=_HNSW_EF_SEARCH_MAX,

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -36,6 +36,10 @@ context:
       input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%A4%D7%A8%D7%A9%D7%A0%D7%95%D7%AA
 - slug: legal_text
   name: Knesset Bylaws (תקנון הכנסת) and related laws
+  # Title-rich Hebrew document corpus — BM25 reliably outranks vector cosine
+  # for verbatim section / law name queries. See the per-context override
+  # rationale in botnim/vector_store/vector_store_aurora.py:search().
+  use_lexical_search: true
   sources:
   - type: split
     source: extraction/חוק_הכנסת_structure_content.json
@@ -82,6 +86,10 @@ context:
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal
     interpretations, formal legal guidance, precedents, legal analysis.'
   examples: חוות דעת על ניגוד עניינים, פרשנות משפטית, הנחיה פורמלית
+  # Title-rich Hebrew document corpus — BM25 ranks verbatim-title queries
+  # correctly where text-embedding-3-small cosine fails. Opt back into the
+  # lexical RRF branch; mode default (false) does not apply here.
+  use_lexical_search: true
   sources:
   - type: csv
     source: extraction/legal_advisor_opinions/index.csv
@@ -178,6 +186,8 @@ context:
   description: 'Search correspondence with the knesset legal advisor. Use for: informal
     inquiries, correspondence, questions and answers, clarifications.'
   examples: מכתב בעניין פנייה, תשובה על שאלה, בירור משפטי
+  # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
+  use_lexical_search: true
   sources:
   - type: csv
     source: extraction/legal_advisor_letters/index.csv
@@ -274,6 +284,8 @@ context:
   description: 'Search the knesset committee decisions. Use for: the knesset committee
     resolutions, procedural decisions, administrative committee matters.'
   examples: החלטת ועדת הכנסת על נוהל, החלטה פרוצדורלית, הסדר עבודה
+  # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
+  use_lexical_search: true
   sources:
   - type: csv
     source: extraction/committee_decisions/index.csv
@@ -349,6 +361,8 @@ context:
     עניינים), ethical violations, sanctions, complaints against MKs, outside employment
     restrictions, financial disclosure requirements.'
   examples: תרומה לחבר כנסת, ניגוד עניינים, הפרת כללי אתיקה, סנקציות
+  # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
+  use_lexical_search: true
   sources:
   - type: csv
     source: extraction/ethics_decisions/index.csv
@@ -475,6 +489,10 @@ context:
     bills (support/oppose at preliminary reading).'
   examples: החלטת ממשלה על תקציב, מינוי שר, אישור הצעת חוק בקריאה טרומית, החלטה
     בנושא בריאות
+  # Title-rich Hebrew document corpus — text-embedding-3-small ranks verbatim-
+  # title queries at rank #13,904 of 29,795 (probed 2026-05-12), while BM25
+  # surfaces the same target at #1. Opt back into the lexical RRF branch.
+  use_lexical_search: true
   # NOTE: write_decision() in aurora_writer.py calls _chunk_for_embedding()
   # with no max_tokens arg, so this value is currently unused — actual chunks
   # are 600 tokens (the code-level default). Set to 600 here to match reality.


### PR DESCRIPTION
## Summary
- Adds `use_lexical_search` as a per-context config override in `specs/<bot>/config.yaml`. Explicit context value (true OR false) wins over the search-mode default.
- Opts the six title-rich Hebrew document contexts back into BM25 alongside vector — `government_decisions`, `legal_advisor_letters`, `legal_advisor_opinions`, `committee_decisions`, `ethics_decisions`, `legal_text`. The short / conversational corpora (`common_*_knowledge`, `knesset_protocols`, `plenary_schedule`) keep the mode default (vector-only) — the original 2026-05-10 BM25-off rationale still applies there.

## Motivation
On staging a user asked "מתי היתה החלטת ממשלה זו: פיתוח ושיקום תשתיות ביישובים מוחלשים בנגב ובגליל ותיקון החלטת ממשלה?" and the bot returned wrong/unrelated decisions, concluding it couldn't find the exact title. The exact title IS in the data (gov 37, 26.10.2025).

Probing the retrieval layer:
- The target chunk's title appears verbatim at the start of chunk 0.
- Vector cosine ranks the target at **#13,904 of ~29,795** (median).
- A second random verbatim-title probe ranks **#8,895** (top-third — still terrible).
- The same top-5 garbage comes back regardless of query (verbatim title, keyword-only, even between different queries) — confirmed not an HNSW recall issue via `enable_indexscan=off` (sequential scan gives the same answers).
- BM25 with the existing tsv ranks the same two targets at **#1** and **#4**.

Root cause: `text-embedding-3-small` is essentially blind to topical signals on long Hebrew government-decision chunks — the body's bureaucratic jargon dominates the embedding, the unique title content gets compressed away. BM25 with `ts_rank_cd` has no such problem here.

## What this is not
- Not a global flip of `REGULAR.use_lexical_search`. The original decision to drop BM25 was correct for `common_*_knowledge` — small conversational corpora where BM25's prefix-OR expansion was noisy. This change only changes behavior for corpora that explicitly opt in.
- Not a new search mode. The LLM doesn't need to think about this — fix lives at the retrieval layer.
- Not an embedding model swap. That's still worth doing eventually, but BM25 solves ≥90% of the value at zero data-layer cost.

## Validation (local, before merging)
Probe set: 5 random verbatim-title queries × 6 contexts × doc-level matching (any chunk of the right document counts as a hit).

| context                  | top-5 hit rate |
|--------------------------|----------------|
| legal_advisor_letters    | 100% (5/5)     |
| legal_advisor_opinions   | 100% (5/5)    |
| ethics_decisions         | 100% (5/5)    |
| legal_text               | 100% (4/4)    |
| government_decisions     | 80% (4/5)     |
| committee_decisions      | 80% (4/5)     |
| **Overall**              | **93.1% (27/29)** |

Original failing user query → rank #1 (was #13,904).

## Test plan
- [ ] `pytest` in `rebuilding-bots/` (deploy.sh phase 2 runs this — do not `--skip-tests`).
- [ ] `./deploy.sh staging --auto-approve`.
- [ ] Re-ask the original failing question through the staging UI → expect the gov-37 / 26.10.2025 decision at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
