### PR TITLE
feat(retrieval): perf cap on prefix-OR + metadata fields in REGULAR yaml

### DIFF
--- a/botnim/query.py
+++ b/botnim/query.py
@@ -622,13 +622,73 @@ def _format_result_as_dict(result: SearchResult, explain: bool) -> Dict[str, Any
         result_dict['_explanation'] = result._explanation
     return result_dict
 
-def _format_result_as_yaml_entry(result: SearchResult) -> Dict[str, str]:
-    """Format a single result for YAML output"""
+# Fields surfaced in the REGULAR-mode yaml entry alongside the body
+# chunk content. Without this, the LLM has only the chunk body to ground
+# its answer — and a chunk body often mentions OTHER documents by number /
+# date (e.g. a decision that AMENDS prior decisions), which the LLM then
+# confuses with the current document's identity. Probed 2026-05-12: bot
+# returned `החלטה 3327 / 19.08.2025` for the verbatim-title query when
+# the correct answer (`publish_date: 2026-10-26`, gov 37) only existed
+# in metadata, not in the body. Surfacing date/title/source_url/identifier
+# from metadata gives the LLM a deterministic source for those facts.
+#
+# Allowlist (NOT the whole metadata dict) to keep yaml output bounded and
+# avoid leaking internal pipeline state (`chunk_index`, `extracted_at`,
+# `status`, `filename`, etc.) to the LLM. Different contexts use different
+# field names for the same concept; the first non-empty value wins per key.
+_REGULAR_METADATA_SURFACE = {
+    "date": (
+        "publish_date", "PublicationDate", "תאריך", "תאריך_מכתב", "session_date",
+    ),
+    "title": (
+        "DocumentTitle", "title", "שם_החלטה",
+    ),
+    "source_url": (
+        "source_url", "קישור_למקור", "file_url",
+    ),
+    "official_source": ("OfficialSource",),
+    "decision_number": ("procedure_number_str", "מספר_מסמך", "מספר_החלטה"),
+    "government_number": ("government_number",),
+    "subject": ("נושא_כללי", "נושא_ספציפי", "agenda_item"),
+    "speaker": ("speaker_name", "שולח"),
+}
+
+
+def _surface_metadata(metadata: Dict) -> Dict[str, Any]:
+    """Pull the allowlisted fields out of metadata + extracted_data
+    (whichever shape this context uses). Returns only fields with a
+    non-empty value, so the yaml output stays small for contexts that
+    don't have rich metadata."""
+    if not metadata:
+        return {}
+    extracted = metadata.get('extracted_data') or {}
+    out: Dict[str, Any] = {}
+    for canonical, candidates in _REGULAR_METADATA_SURFACE.items():
+        for key in candidates:
+            val = extracted.get(key) or metadata.get(key)
+            if val:
+                # Truncate long strings (e.g. official_source can be a paragraph)
+                if isinstance(val, str) and len(val) > 200:
+                    val = val[:200] + "..."
+                out[canonical] = val
+                break
+    return out
+
+
+def _format_result_as_yaml_entry(result: SearchResult) -> Dict[str, Any]:
+    """Format a single REGULAR-mode result for YAML output. Surfaces a
+    small allowlist of metadata fields alongside the body content so the
+    LLM can cite date/title/source from metadata rather than guessing
+    from intra-body references to other documents."""
     parts = result.full_content.split('\n\n', 1)
-    return dict(
+    entry: Dict[str, Any] = dict(
         header=parts[0].strip(),
         text=parts[1].strip() if len(parts) > 1 else '',
     )
+    surfaced = _surface_metadata(result.metadata or {})
+    if surfaced:
+        entry['metadata'] = surfaced
+    return entry
 
 def format_search_results(results: List[SearchResult], format: str, explain: bool, search_mode: SearchModeConfig = None) -> str:
     """

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -776,6 +776,12 @@ _TS_QUERY_DROP = frozenset({
     "how", "why", "when", "where", "who", "which",
 })
 
+# Token-count threshold for _build_prefix_or_tsquery's long-query
+# fallback. Queries with more than this many post-filter tokens skip
+# the prefix-OR + stem-variant expansion and use AND-only on bare
+# tokens instead — see the rationale block in _build_prefix_or_tsquery.
+_MAX_PREFIX_TOKENS = 6
+
 
 def _build_prefix_or_tsquery(query_text: str) -> str:
     """Turn a user query into a tsquery string with OR + prefix semantics.
@@ -808,6 +814,33 @@ def _build_prefix_or_tsquery(query_text: str) -> str:
     tokens = [t for t in cleaned.split() if _ok(t)]
     if not tokens:
         return ""
+
+    # Long-query fallback: a 10-term prefix-OR (~20-way after the
+    # stem-variant expansion below) blew past the 12s RETRIEVE_TIMEOUT
+    # on staging Aurora against the ~30k-row government_decisions
+    # corpus (verbatim-title query, probed 2026-05-12).
+    #
+    # For long queries we switch from prefix-OR to AND-with-prefix:
+    #   - AND is naturally selective — Postgres picks the most-
+    #     selective prefix match first, so the overall scan stays
+    #     cheap even on large corpora (a single distinctive term
+    #     narrows the candidate set to a handful of rows).
+    #   - Keeping the `:*` prefix on each term preserves morphology
+    #     coverage (Hebrew construct/absolute alternation, plural
+    #     suffixes, etc.) — pure AND-on-bare-tokens regressed
+    #     government_decisions on the local probe (5 random titles:
+    #     80% → 40%) because some title tokens had inflected forms
+    #     in the doc that exact-match couldn't catch.
+    #   - Skipping the stem-variant expansion (the second `:*` per
+    #     token) keeps the plan width bounded.
+    # A cap-and-truncate alternative (keep top-N tokens by length)
+    # was tested first and regressed local probe set 93% → 72% —
+    # it dropped distinctive short proper-noun tokens (e.g. MK names
+    # in ethics-decisions titles) that BM25 needed to rank correctly.
+    # AND-with-prefix below keeps every token.
+    if len(tokens) > _MAX_PREFIX_TOKENS:
+        return " & ".join(f"{t}:*" for t in tokens)
+
     # For each token emit prefix variants:
     #   - the token itself with `:*` (matches the exact form + suffixes)
     #   - for non-numeric tokens with len >= 5, the token minus its last


### PR DESCRIPTION
## Summary
Two coupled fixes surfaced by E2E testing PR #145 on staging:

1. **Perf cap on `_build_prefix_or_tsquery`**. The 10-token verbatim-title query that #145 was meant to fix actually timed out (12s `RETRIEVE_TIMEOUT`) on the ~30k-row `government_decisions` corpus — prefix-OR + stem-variant expansion = ~20-way OR scan, too wide. When tokens > 6, switch to AND-with-prefix (keeps Hebrew morphology coverage via `:*`, drops stem-variant doubling, AND is naturally selective).
2. **Metadata in REGULAR yaml**. Previously the bot got only `{header, text}` per chunk, hallucinated `date` / `decision_number` from intra-body references to amended decisions. Now an allowlisted `metadata:` block (date, title, source_url, official_source, decision_number, government_number, subject, speaker) is surfaced — deterministic source for those facts.

## Validation (local)
- Probe set (5 random titles × 6 BM25 contexts, doc-level matching): **93.1% top-5** (27/29) — matches the no-bug baseline, no regression from #145.
- 10-term verbatim-title query: **0.5s** locally (was 12s timeout on staging).
- Playwright through local LibreChat UI: bot now answers "Decision 3418, 26.10.2025, government 37, gov.il/he/pages/dec3418-2025" for the user's original failing query — derived from metadata, not body.
- Tried-and-rejected alternatives are documented in the commit message.

## Test plan
- [ ] `pytest` in rebuilding-bots (deploy.sh phase 2; do not `--skip-tests`).
- [ ] `./deploy.sh staging --auto-approve`.
- [ ] Re-run the 11 staging conversation URLs the operator collected; compare bot answers pre/post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
