### PR TITLE
fix(retrieval): stop emitting fabricated source URLs

### DIFF
--- a/botnim/query.py
+++ b/botnim/query.py
@@ -660,6 +660,21 @@ _REGULAR_METADATA_SURFACE = {
 }
 
 
+# Known-fabricated URL patterns produced by the pre-2026-05-12 extraction
+# pipeline when it couldn't find a real source URL in the PDF body and
+# interpolated the (now-removed) `example:` template from config.yaml's
+# `קישור_למקור` field. Filtered out at surface time so the bot doesn't
+# hand the user a fabricated `gov.il/...decision_YYYY_NN.pdf` link.
+# Backfill plan: bump EXTRACTION_VERSION + re-sync the four affected
+# contexts (committee_decisions, ethics_decisions, legal_advisor_letters,
+# legal_advisor_opinions) and remove this filter once verified.
+_FABRICATED_SOURCE_URL_RE = re.compile(
+    r"^https?://(?:www\.)?knesset\.gov\.il/"
+    r"(?:committee/decisions/decision_\d{4}_\d+\.pdf"
+    r"|legal/opinions/opinion_\d{4}_\d+\.pdf)$"
+)
+
+
 def _surface_metadata(metadata: Dict) -> Dict[str, Any]:
     """Pull the allowlisted fields out of metadata + extracted_data
     (whichever shape this context uses). Returns only fields with a
@@ -684,6 +699,12 @@ def _surface_metadata(metadata: Dict) -> Dict[str, Any]:
                 val = val[0] if val else None
                 if not val:
                     continue
+            # Drop known-fabricated source URLs (see _FABRICATED_SOURCE_URL_RE).
+            # Letting the loop fall through to the next candidate gives
+            # ReferenceLinks → file_url → etc. a chance to win if any of
+            # them holds a real URL for this row.
+            if canonical == "source_url" and isinstance(val, str) and _FABRICATED_SOURCE_URL_RE.match(val):
+                continue
             # Truncate long strings (e.g. official_source can be a paragraph)
             if isinstance(val, str) and len(val) > 200:
                 val = val[:200] + "..."

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -148,8 +148,13 @@ context:
         example: המסמך הופץ לכל חברי הכנסת
         hint: הוסף הערות או פרטים חשובים נוספים
       - name: קישור_למקור
-        description: קישור ישיר לקובץ ה-PDF
-        example: https://knesset.gov.il/legal/opinions/opinion_2024_01.pdf
+        # No example URL: when the extractor couldn't find a real URL
+        # in the PDF body it used to interpolate this template into a
+        # fabricated URL (e.g. opinion_2026_99.pdf). Without the example
+        # the LLM falls back to leaving the field empty (per dynamic_
+        # extraction prompt rule 6) — and the canonical URL still
+        # reaches the doc via the index CSV's `url` column → metadata.
+        description: 'קישור ישיר לקובץ ה-PDF — השאר ריק אם אינו מופיע במפורש בטקסט המסמך.'
       - name: טקסט_מלא
         description: תוכן מלא של המסמך
         hint: תמיד כלול את כל הטקסט של מסמך כפי שהופק מה-PDF, בעברית.
@@ -246,8 +251,13 @@ context:
         example: המסמך הופץ לכל חברי הכנסת
         hint: הוסף הערות או פרטים חשובים נוספים
       - name: קישור_למקור
-        description: קישור ישיר לקובץ ה-PDF
-        example: https://knesset.gov.il/legal/opinions/opinion_2024_01.pdf
+        # No example URL: when the extractor couldn't find a real URL
+        # in the PDF body it used to interpolate this template into a
+        # fabricated URL (e.g. opinion_2026_99.pdf). Without the example
+        # the LLM falls back to leaving the field empty (per dynamic_
+        # extraction prompt rule 6) — and the canonical URL still
+        # reaches the doc via the index CSV's `url` column → metadata.
+        description: 'קישור ישיר לקובץ ה-PDF — השאר ריק אם אינו מופיע במפורש בטקסט המסמך.'
       - name: טקסט_מלא
         description: תוכן מלא של המסמך
         hint: תמיד כלול את כל הטקסט של מסמך כפי שהופק מה-PDF, בעברית.
@@ -337,8 +347,11 @@ context:
         example: ההחלטה התקבלה פה אחד
         hint: הוסף הערות או הסתייגויות אם קיימות
       - name: קישור_למקור
-        description: קישור ישיר לקובץ ה-PDF
-        example: https://knesset.gov.il/committee/decisions/decision_2024_12.pdf
+        # No example URL: see same-name fields above. The committee
+        # variant template was producing fabricated decision_YYYY_NN.pdf
+        # URLs on ~14% of rows where the extractor couldn't find a real
+        # URL in the PDF body.
+        description: 'קישור ישיר לקובץ ה-PDF — השאר ריק אם אינו מופיע במפורש בטקסט המסמך.'
       - name: טקסט_מלא
         description: תוכן מלא של ההחלטה
         hint: תמיד כלול את כל הטקסט של מסמך כפי שהופק מה-PDF, בעברית.


### PR DESCRIPTION
## Summary
Stop the bot from citing fabricated `knesset.gov.il/committee/decisions/decision_YYYY_NN.pdf` and `knesset.gov.il/legal/opinions/opinion_YYYY_NN.pdf` URLs.

Two coupled changes:
1. **Remove `example:` URL** from `קישור_למקור` field config in 3 contexts (legal_advisor_opinions, legal_advisor_letters, committee_decisions). The example URL was being fed to the per-PDF GPT extractor's prompt; when the PDF body lacked a URL, the extractor interpolated the template into a fake. Description now explicitly says "leave empty if not in the document body".
2. **Runtime filter** (`_FABRICATED_SOURCE_URL_RE`) in `_surface_metadata`: a surfaced `source_url` matching the known fabricated patterns is dropped, the loop falls through to the next allowlist candidate. Existing bad data in Aurora gets filtered without a re-sync.

## Why not "just drop the field"
Initial proposal was to drop `קישור_למקור` entirely from the extraction fields. Evidence killed it: `metadata.source_url` is currently 0/548 populated for committee_decisions (and 0% for all the other affected contexts) — the only working source-URL path on this corpus is via `ReferenceLinks`, which is populated by the dynamic_extraction stage reading the markdown content's `קישור_למקור:` line. Dropping the field would have lost the 82% real URLs along with the 14% fakes.

## Local validation
- Bad-URL row → `source_url` filtered out, no fake link surfaced.
- Good-URL row → real URL `fs.knesset.gov.il/25/Committees/25_cs_dec_4209945.pdf` still surfaced correctly.

## Follow-up (separate PR)
Bump `EXTRACTION_VERSION` + re-sync the four affected contexts with `--force-rebuild`. Once verified clean, the runtime filter can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
