### PR TITLE
fix(extraction): unwrap single-key dict-of-list LLM responses

### DIFF
--- a/botnim/document_parser/pdfs/field_extraction.py
+++ b/botnim/document_parser/pdfs/field_extraction.py
@@ -158,14 +158,14 @@ def validate_extracted_data(data: Any, schema: Dict[str, Any], config: SourceCon
     if not isinstance(data, (dict, list)):
         raise PDFValidationError(f"LLM returned invalid data type: {type(data)}. Expected dict or list.")
 
-    # Recovery: ``response_format={"type":"json_object"}`` (see
-    # field_extraction.py:74) forbids a top-level JSON array. When the
-    # extraction prompt asks the LLM for "an array of objects" (multi-item
-    # PDFs like ethics committee summaries that bundle several decisions),
-    # the LLM wraps under a single key: ``{"decisions": [{...}, {...}]}``.
-    # Unwrap that shape so the existing list path handles it. The wrap key
-    # name is LLM-chosen (typically the entity plural — "decisions",
-    # "items", "results"); we don't hard-code it.
+    # Recovery: the OpenAI call above sets
+    # ``response_format={"type":"json_object"}``, which forbids a top-level
+    # JSON array. When the extraction prompt asks the LLM for "an array of
+    # objects" (multi-item PDFs like ethics committee summaries that bundle
+    # several decisions), the LLM wraps under a single key:
+    # ``{"decisions": [{...}, {...}]}``. Unwrap that shape so the existing
+    # list path handles it. The wrap key name is LLM-chosen (typically the
+    # entity plural — "decisions", "items", "results"); we don't hard-code it.
     #
     # Guardrails:
     #   - len == 1: only unwrap a SINGLE-key dict so a legitimate multi-
@@ -174,11 +174,11 @@ def validate_extracted_data(data: Any, schema: Dict[str, Any], config: SourceCon
     #   - all dicts: the value must be a list of dicts. Lists of strings
     #     or scalars are not what the extraction schema expects.
     if isinstance(data, dict) and len(data) == 1:
-        only_val = next(iter(data.values()))
+        only_key, only_val = next(iter(data.items()))
         if isinstance(only_val, list) and all(isinstance(x, dict) for x in only_val):
             logger.info(
                 "Unwrapping single-key wrapper dict (key=%r, %d items)",
-                next(iter(data.keys())),
+                only_key,
                 len(only_val),
             )
             data = only_val

--- a/botnim/document_parser/pdfs/field_extraction.py
+++ b/botnim/document_parser/pdfs/field_extraction.py
@@ -158,6 +158,31 @@ def validate_extracted_data(data: Any, schema: Dict[str, Any], config: SourceCon
     if not isinstance(data, (dict, list)):
         raise PDFValidationError(f"LLM returned invalid data type: {type(data)}. Expected dict or list.")
 
+    # Recovery: ``response_format={"type":"json_object"}`` (see
+    # field_extraction.py:74) forbids a top-level JSON array. When the
+    # extraction prompt asks the LLM for "an array of objects" (multi-item
+    # PDFs like ethics committee summaries that bundle several decisions),
+    # the LLM wraps under a single key: ``{"decisions": [{...}, {...}]}``.
+    # Unwrap that shape so the existing list path handles it. The wrap key
+    # name is LLM-chosen (typically the entity plural — "decisions",
+    # "items", "results"); we don't hard-code it.
+    #
+    # Guardrails:
+    #   - len == 1: only unwrap a SINGLE-key dict so a legitimate multi-
+    #     field item (e.g. {"title": "...", "summary": "..."}) is not
+    #     silently flattened away.
+    #   - all dicts: the value must be a list of dicts. Lists of strings
+    #     or scalars are not what the extraction schema expects.
+    if isinstance(data, dict) and len(data) == 1:
+        only_val = next(iter(data.values()))
+        if isinstance(only_val, list) and all(isinstance(x, dict) for x in only_val):
+            logger.info(
+                "Unwrapping single-key wrapper dict (key=%r, %d items)",
+                next(iter(data.keys())),
+                len(only_val),
+            )
+            data = only_val
+
     # Handle both single object and array of objects
     if not isinstance(data, list):
         data = [data]

--- a/tests/document_parser/pdfs/test_field_extraction.py
+++ b/tests/document_parser/pdfs/test_field_extraction.py
@@ -1,0 +1,91 @@
+"""Unit tests for validate_extracted_data — wrapper-dict unwrap behaviour.
+
+Background: response_format={"type":"json_object"} forbids a top-level JSON
+array, so the LLM wraps multi-item responses under a single key:
+``{"decisions": [{...}, {...}]}``. Without the unwrap, the validator
+treats the wrapper as the single item and every required field is "missing".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from botnim.document_parser.pdfs.field_extraction import validate_extracted_data
+from botnim.document_parser.pdfs.exceptions import ValidationError as PDFValidationError
+from botnim.document_parser.pdfs.pdf_extraction_config import SourceConfig, FieldConfig
+
+
+def _minimal_config() -> SourceConfig:
+    """Smallest SourceConfig that exercises the schema path.
+
+    We only need one required field for these tests — the unwrap behaviour
+    is structural and doesn't depend on the field set.
+    """
+    return SourceConfig(
+        output_csv_path=Path("/tmp/out.csv"),
+        external_source_url="https://example.invalid/dummy",
+        fields=[
+            FieldConfig(name="title", description="doc title"),
+        ],
+    )
+
+
+def _schema(required_fields: list[str]) -> dict:
+    return {
+        "type": "object",
+        "properties": {name: {"type": "string"} for name in required_fields},
+        "required": required_fields,
+    }
+
+
+def test_flat_dict_validates_as_single_item():
+    """Single-item PDFs (the LLM returns a flat dict): no unwrap, pass-through."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = {"title": "Single decision"}
+    out = validate_extracted_data(data, schema, cfg)
+    assert out == [{"title": "Single decision"}]
+
+
+def test_list_of_dicts_validates_as_array():
+    """Pre-existing path: LLM somehow returned a bare list (rare under
+    json_object) — still validates each element."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = [{"title": "A"}, {"title": "B"}]
+    out = validate_extracted_data(data, schema, cfg)
+    assert out == [{"title": "A"}, {"title": "B"}]
+
+
+def test_single_key_wrapper_dict_is_unwrapped():
+    """Multi-item PDFs (json_object forces wrap): the single-key wrapper
+    around a list of dicts must be unwrapped, not validated as a unit."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = {"decisions": [{"title": "A"}, {"title": "B"}]}
+    out = validate_extracted_data(data, schema, cfg)
+    assert out == [{"title": "A"}, {"title": "B"}]
+
+
+def test_single_key_wrapper_with_non_dict_list_is_not_unwrapped():
+    """Don't unwrap if the wrapper's value is a list of non-dicts — that's
+    a different shape we don't want to swallow silently. Should raise."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = {"items": ["just", "strings"]}
+    with pytest.raises(PDFValidationError):
+        validate_extracted_data(data, schema, cfg)
+
+
+def test_multi_key_dict_is_not_unwrapped():
+    """A dict with multiple keys must NOT be unwrapped — that's a single
+    item that genuinely has multiple fields. Validate as one item."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    # 'title' IS present, plus an extra 'summary' field. The validator
+    # should treat this as a single item (NOT unwrap "summary" as a list)
+    # and pass it through unchanged.
+    data = {"title": "ok", "summary": "extra detail"}
+    out = validate_extracted_data(data, schema, cfg)
+    assert out == [{"title": "ok", "summary": "extra detail"}]

--- a/tests/document_parser/pdfs/test_field_extraction.py
+++ b/tests/document_parser/pdfs/test_field_extraction.py
@@ -89,3 +89,26 @@ def test_multi_key_dict_is_not_unwrapped():
     data = {"title": "ok", "summary": "extra detail"}
     out = validate_extracted_data(data, schema, cfg)
     assert out == [{"title": "ok", "summary": "extra detail"}]
+
+
+def test_single_key_wrapper_with_empty_list_unwraps_to_empty():
+    """``{"decisions": []}`` is a legitimate "no items found" response —
+    unwrap to [] so the validator's existing list path produces an empty
+    result, not validates the wrapper as a single (invalid) item."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = {"items": []}
+    out = validate_extracted_data(data, schema, cfg)
+    assert out == []
+
+
+def test_single_key_wrapper_with_mixed_list_is_not_unwrapped():
+    """If the wrapper's value contains anything other than dicts, the
+    guardrail must refuse to unwrap. The validator then attempts to
+    validate the wrapper dict itself and raises because required fields
+    are missing."""
+    cfg = _minimal_config()
+    schema = _schema(["title"])
+    data = {"items": [{"title": "ok"}, "stray"]}
+    with pytest.raises(PDFValidationError):
+        validate_extracted_data(data, schema, cfg)


### PR DESCRIPTION
## Summary

Fixes a latent bug in `validate_extracted_data` that surfaced after commit `9d417bb` bumped `EXTRACTION_VERSION` to `v2-gpt-4o-mini-heb-fix-ocr-gate` and invalidated the per-PDF cache: the OpenAI extraction call uses `response_format={"type":"json_object"}` which forbids a top-level JSON array, so when the prompt asks for "an array of objects" (multi-decision ethics PDFs) the LLM wraps under a single key — `{"decisions":[{...},{...}]}`. The old code treated the wrapper as one item and failed the required-field check with `'שם_החלטה' is a required property`.

Live impact: in the 2026-05-13 warm task that brought ethics K15-K23 into staging, 333 chunks across K15/K16/K17/K19/K20/K25 failed validation for exactly this reason and didn't make it into Aurora.

## How

Five-line unwrap in `validate_extracted_data` (`field_extraction.py:158-187`), placed BEFORE the existing dict-to-list normalization:

- Test `isinstance(data, dict) and len(data) == 1`
- Pull `(only_key, only_val) = next(iter(data.items()))`
- Test `isinstance(only_val, list) and all(isinstance(x, dict) for x in only_val)`
- If both: log + `data = only_val`

Pure structural change — no schema, no prompt, no `EXTRACTION_VERSION` bump. Successful v2 cache entries stay valid; previously-failed extractions are not in the cache (only successes get stored), so the next sync naturally re-calls the LLM and now passes.

## Test plan

- [x] 7 new unit tests in `tests/document_parser/pdfs/test_field_extraction.py` covering: flat-dict, bare-list, single-key wrapper unwrap, non-dict-list guardrail (raises), multi-key dict NOT unwrapped, empty-list wrapper unwraps to [], mixed-content list NOT unwrapped (raises).
- [x] Broader `tests/document_parser/pdfs/` — 18/18 pass.
- [ ] After merge + deploy: re-run the existing targeted-warm task. Expect zero schema-validation failures and a big jump in `ethics_decisions` doc count in Aurora.

## Out of scope

- No prompt change (the "array of objects" instruction is the contract we want; the LLM's wrapping is the workaround).
- No belt-and-suspenders deterministic wrapper key. Could be a follow-up — current unwrap is generic enough to handle whatever key name the LLM picks.

Generated with [Claude Code](https://claude.com/claude-code)
