### PR TITLE
fix(config): committee_decisions name is singular (ועדת, not ועדות)

### DIFF
--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -297,7 +297,7 @@ context:
 
         '
 - slug: committee_decisions
-  name: החלטות ועדות הכנסת
+  name: החלטות ועדת הכנסת
   description: 'Search the knesset committee decisions. Use for: the knesset committee
     resolutions, procedural decisions, administrative committee matters.'
   examples: החלטת ועדת הכנסת על נוהל, החלטה פרוצדורלית, הסדר עבודה


### PR DESCRIPTION
The corpus is scoped to committee_id=2211 (ועדת הכנסת, singular). The user-facing name said "ועדות הכנסת" (plural — all committees), which would mis-route Finance / Constitution / Foreign-Affairs queries here. One-character fix. Agent prompt already uses the correct singular form throughout. No corpus re-embed needed.