### PR TITLE
feat(plenary): fall back to sessionDet URL when stenogram missing

### DIFF
--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -354,6 +354,7 @@ async def knesset_sessions_live(
         fetch_session_stenograms,
         _hebrew_date,
         _DEFAULT_BASE,
+        session_detail_url,
     )
 
     def _parse(s: str, label: str) -> datetime:
@@ -401,9 +402,10 @@ async def knesset_sessions_live(
     # Source-URL enrichment: KNS_DocumentPlenumSession (GroupTypeID=43,
     # סטנוגרמה) gives us the canonical Knesset transcript URL per session.
     # Sessions without a published stenogram (typically upcoming sittings)
-    # simply lack `source_url`. We swallow stenogram fetch failures so a
-    # transient outage on this extra OData call doesn't break the main
-    # response.
+    # fall back to the session-detail (agenda) page, so every session in the
+    # response carries a real Knesset URL. We swallow stenogram fetch
+    # failures so a transient outage on this extra OData call doesn't break
+    # the main response — but still populate the detail URL on each session.
     if sessions:
         ids = [s["PlenumSessionID"] for s in sessions if s.get("PlenumSessionID") is not None]
         try:
@@ -415,13 +417,15 @@ async def knesset_sessions_live(
                 if sid and fp:
                     stenogram_url_by_session[sid] = fp
             for s in sessions:
-                url = stenogram_url_by_session.get(s.get("PlenumSessionID"))
-                if url:
-                    s["source_url"] = url
+                sid = s.get("PlenumSessionID")
+                s["source_url"] = (
+                    stenogram_url_by_session.get(sid)
+                    or session_detail_url(sid)
+                )
         except requests.exceptions.RequestException:
-            # Best-effort enrichment; don't fail the main response if the
-            # extra OData call has a transient issue.
-            pass
+            # Best-effort enrichment; still populate the detail URL on every session.
+            for s in sessions:
+                s["source_url"] = session_detail_url(s.get("PlenumSessionID"))
 
     for s in sessions:
         s["StartDateHe"] = _hebrew_date(s.get("StartDate", ""))

--- a/backend/api/tests/test_server.py
+++ b/backend/api/tests/test_server.py
@@ -1,0 +1,178 @@
+"""Tests for the live knesset_sessions_live endpoint URL fallback.
+
+server.py imports many heavy modules (firebase_admin, custom auth, botnim
+submodules) at module load time. We mirror the mocking pattern used in
+``tests/backend/test_metadata_filter_endpoint.py`` — install MagicMock
+placeholders in ``sys.modules`` before importing ``backend.api.server``.
+
+CRITICAL: we pre-import the real
+``botnim.document_parser.knesset_odata.process_odata`` BEFORE the heavy
+``botnim`` MagicMock replacement so that the endpoint's lazy
+``from botnim.document_parser.knesset_odata.process_odata import ...``
+still resolves through ``sys.modules`` to the real module — that's the
+module we patch in the test below.
+"""
+import sys
+import types
+from typing import Annotated, List
+from unittest.mock import MagicMock, patch
+
+# Pre-load the REAL process_odata module so sys.modules has it under
+# the dotted path. The endpoint's lazy
+# ``from botnim.document_parser.knesset_odata.process_odata import ...``
+# resolves via sys.modules['<dotted-name>'] regardless of what
+# sys.modules['botnim'] looks like, so this survives the top-level botnim
+# MagicMock clobber below.
+#
+# Co-running tests (tests/backend/test_metadata_filter_endpoint.py et al.)
+# may have already replaced sys.modules["botnim"] with a MagicMock by the
+# time this module imports — which breaks ``import botnim.document_parser…``.
+# To handle that, we evict any stale ``botnim*`` MagicMocks before the
+# real import, then re-apply the heavy mocking below.
+_stale_botnim_keys = [
+    k for k in list(sys.modules)
+    if (k == "botnim" or k.startswith("botnim."))
+    and isinstance(sys.modules[k], MagicMock)
+]
+for _k in _stale_botnim_keys:
+    sys.modules.pop(_k, None)
+# (We don't reinstall the stale MagicMocks — the heavy mock block below
+# re-creates fresh ones, which is what the existing co-running tests do
+# anyway, and they each install their own at module load time.)
+
+import botnim.document_parser.knesset_odata.process_odata as _real_process_odata  # noqa: F401,E402
+
+# Mock all heavy server-load-time dependencies.
+for mod in [
+    "firebase_admin", "firebase_admin.firestore", "firebase_admin.credentials",
+    "firebase_admin.auth",
+    "dataflows", "dataflows_airtable",
+    "botnim", "botnim.collect_sources", "botnim.vector_store",
+    "botnim.vector_store.vector_store_base", "botnim.vector_store.vector_store_openai",
+    "botnim.vector_store.vector_store_es", "botnim.vector_store.search_modes",
+    "botnim.query",
+    "botnim.bot_config", "botnim.config",
+    "botnim.fetch_and_process", "botnim.sync",
+    "botnim.db", "botnim.db.session",
+    "botnim.observability", "botnim.observability.tracing",
+    "botnim.observability.middleware",
+]:
+    sys.modules[mod] = MagicMock()
+
+# Re-pin the real process_odata under its dotted path so the endpoint's
+# lazy import resolves to the real module (which the test patches).
+sys.modules["botnim.document_parser.knesset_odata.process_odata"] = _real_process_odata
+
+sys.modules["botnim.observability.tracing"].init_tracing = MagicMock(return_value=None)
+sys.modules["botnim.observability.middleware"].install_trace_middleware = MagicMock(return_value=None)
+
+sys.modules["botnim.config"].AVAILABLE_BOTS = ["unified"]
+sys.modules["botnim.config"].VALID_ENVIRONMENTS = ["staging", "production", "local"]
+sys.modules["botnim.config"].DEFAULT_ENVIRONMENT = "local"
+
+resolve_mod = types.ModuleType("resolve_firebase_user")
+resolve_mod.FireBaseUser = Annotated[dict, lambda: None]
+sys.modules["resolve_firebase_user"] = resolve_mod
+
+refresh_auth_mod = types.ModuleType("refresh_auth")
+refresh_auth_mod.require_refresh_api_key = lambda: None
+sys.modules["refresh_auth"] = refresh_auth_mod
+sanity_auth_mod = types.ModuleType("sanity_auth")
+sanity_auth_mod.require_sanity_api_key = lambda: None
+sys.modules["sanity_auth"] = sanity_auth_mod
+
+from pydantic import BaseModel, Field
+
+
+class _StubWordDocSection(BaseModel):
+    heading: str = Field(..., min_length=1)
+    level: int = 1
+    body_md: str = Field(..., min_length=1)
+
+
+class _StubWordDocRequest(BaseModel):
+    title: str = Field(..., min_length=1)
+    sections: List[_StubWordDocSection] = Field(..., min_length=1)
+
+
+class _StubWordDocResponse(BaseModel):
+    url: str
+    filename: str
+    expires_at: str
+
+
+word_doc_pkg = types.ModuleType("botnim.word_doc")
+word_doc_models = types.ModuleType("botnim.word_doc.models")
+word_doc_models.WordDocRequest = _StubWordDocRequest
+word_doc_models.WordDocResponse = _StubWordDocResponse
+word_doc_render = types.ModuleType("botnim.word_doc.render")
+word_doc_render.render_word_doc = MagicMock(return_value=b"")
+word_doc_render.sanitize_filename = lambda s: "stub.docx"
+word_doc_storage = types.ModuleType("botnim.word_doc.storage")
+word_doc_storage.upload_word_doc = lambda **_: _StubWordDocResponse(
+    url="https://example.com/stub", filename="stub.docx", expires_at="2099-01-01T00:00:00Z",
+)
+sys.modules["botnim.word_doc"] = word_doc_pkg
+sys.modules["botnim.word_doc.models"] = word_doc_models
+sys.modules["botnim.word_doc.render"] = word_doc_render
+sys.modules["botnim.word_doc.storage"] = word_doc_storage
+
+mock_search_modes = sys.modules["botnim.vector_store.search_modes"]
+mock_search_modes.SEARCH_MODES = {}
+mock_search_modes.DEFAULT_SEARCH_MODE = MagicMock(num_results=5)
+
+sys.modules["botnim.query"].run_query = MagicMock(return_value="mock results")
+sys.modules["botnim.query"].government_distribution_sidecar = MagicMock(return_value=None)
+
+from fastapi.testclient import TestClient
+
+from backend.api.server import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def _fake_sessions():
+    return [
+        {"PlenumSessionID": 2241628, "Number": 383, "KnessetNum": 25,
+         "Name": "ישיבה רגילה", "StartDate": "2026-03-25T11:00:00",
+         "FinishDate": "2026-03-26T10:23:10", "IsSpecialMeeting": False},
+        {"PlenumSessionID": 2256195, "Number": 390, "KnessetNum": 25,
+         "Name": "ישיבה רגילה", "StartDate": "2026-05-13T11:00:00",
+         "FinishDate": "", "IsSpecialMeeting": False},
+    ]
+
+
+def _fake_stenograms():
+    # Only the past session has a stenogram.
+    return [{"PlenumSessionID": 2241628,
+             "FilePath": "https://fs.knesset.gov.il/25/plenum/25_st_383.doc",
+             "LastUpdatedDate": "2026-03-27T00:00:00"}]
+
+
+def test_knesset_sessions_live_populates_source_url_for_all_sessions():
+    """Future sessions get the session-detail URL as source_url fallback."""
+    with patch(
+        "botnim.document_parser.knesset_odata.process_odata.fetch_plenum_sessions",
+        return_value=_fake_sessions(),
+    ), patch(
+        "botnim.document_parser.knesset_odata.process_odata.fetch_session_items",
+        return_value=[],
+    ), patch(
+        "botnim.document_parser.knesset_odata.process_odata.fetch_session_stenograms",
+        return_value=_fake_stenograms(),
+    ):
+        resp = client.get(
+            "/botnim/knesset/sessions",
+            params={"from": "2026-03-01", "to": "2026-06-01", "include_items": "false"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    by_session = {s["PlenumSessionID"]: s for s in body["sessions"]}
+    assert by_session[2241628]["source_url"] == (
+        "https://fs.knesset.gov.il/25/plenum/25_st_383.doc"
+    )
+    # The new behaviour: future session also has source_url.
+    assert by_session[2256195]["source_url"] == (
+        "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=2256195"
+    )

--- a/botnim/document_parser/knesset_odata/process_odata.py
+++ b/botnim/document_parser/knesset_odata/process_odata.py
@@ -165,7 +165,7 @@ _SESSION_DETAIL_URL_TEMPLATE = (
 )
 
 
-def session_detail_url(session_id) -> str:
+def session_detail_url(session_id: int | str | None) -> str:
     """Return the Knesset session-detail (agenda) URL for ``session_id``.
 
     Works for both upcoming and past sessions — the page is the same

--- a/botnim/document_parser/knesset_odata/process_odata.py
+++ b/botnim/document_parser/knesset_odata/process_odata.py
@@ -343,35 +343,62 @@ def process_knesset_odata_source(
     for lst in items_by_session.values():
         lst.sort(key=lambda r: (r.get("Ordinal") or 0, r.get("ItemID") or 0))
 
-    fieldnames = [
-        "upstream_hash",
-        "session_id",
-        "session_number",
-        "knesset_num",
-        "session_name",
-        "session_date",       # YYYY-MM-DD
-        "session_time",       # HH:MM
-        "session_start_iso",
-        "session_finish_iso",
-        "session_human_date", # DD/MM/YYYY HH:MM (Hebrew-locale-friendly)
-        "is_special_meeting",
-        "source_url",
-        "item_ordinal",
-        "item_type",
-        "item_name",
-        "item_status_id",
-        "item_is_discussion",
-    ]
+    write_csv_rows(
+        output_csv,
+        sessions,
+        items_by_session,
+        stenogram_url_by_session,
+        upstream_hash=upstream_hash,
+    )
 
+
+_CSV_FIELDNAMES = [
+    "upstream_hash",
+    "session_id",
+    "session_number",
+    "knesset_num",
+    "session_name",
+    "session_date",       # YYYY-MM-DD
+    "session_time",       # HH:MM
+    "session_start_iso",
+    "session_finish_iso",
+    "session_human_date", # DD/MM/YYYY HH:MM (Hebrew-locale-friendly)
+    "is_special_meeting",
+    "source_url",
+    "item_ordinal",
+    "item_type",
+    "item_name",
+    "item_status_id",
+    "item_is_discussion",
+]
+
+
+def write_csv_rows(
+    output_csv: Path,
+    sessions: list[dict],
+    items_by_session: dict[int, list[dict]],
+    stenogram_url_by_session: dict[int, str],
+    *,
+    upstream_hash: str,
+) -> None:
+    """Write one CSV row per ``(session, item)`` pair (or one empty-agenda row).
+
+    Atomically replaces ``output_csv`` on success. ``source_url`` is the
+    session's stenogram URL when published, otherwise the session-detail
+    (agenda) URL — so every row has a real Knesset link, even for
+    upcoming sessions.
+    """
+    output_csv = Path(output_csv)
     out_rows: list[dict] = []
     for s in sessions:
         s_iso = _normalize_dt(s.get("StartDate"))
         f_iso = _normalize_dt(s.get("FinishDate"))
         s_date = s_iso[:10] if s_iso else ""
         s_time = s_iso[11:16] if s_iso else ""
+        sid = s.get("PlenumSessionID")
         common = {
             "upstream_hash": upstream_hash,
-            "session_id": s.get("PlenumSessionID") or "",
+            "session_id": sid or "",
             "session_number": s.get("Number") or "",
             "knesset_num": s.get("KnessetNum") or "",
             "session_name": (s.get("Name") or "").strip(),
@@ -381,9 +408,11 @@ def process_knesset_odata_source(
             "session_finish_iso": f_iso,
             "session_human_date": _hebrew_date(s_iso),
             "is_special_meeting": "כן" if s.get("IsSpecialMeeting") else "לא",
-            "source_url": stenogram_url_by_session.get(s.get("PlenumSessionID"), ""),
+            "source_url": (
+                stenogram_url_by_session.get(sid)
+                or session_detail_url(sid)
+            ),
         }
-        sid = s["PlenumSessionID"]
         rows_for_session = items_by_session.get(sid, [])
         if not rows_for_session:
             row = dict(common)
@@ -410,7 +439,7 @@ def process_knesset_odata_source(
     tmp_output = output_csv.with_suffix(output_csv.suffix + ".tmp")
     try:
         with open(tmp_output, "w", encoding="utf-8", newline="") as csv_file:
-            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer = csv.DictWriter(csv_file, fieldnames=_CSV_FIELDNAMES)
             writer.writeheader()
             for row in out_rows:
                 writer.writerow(row)

--- a/botnim/document_parser/knesset_odata/process_odata.py
+++ b/botnim/document_parser/knesset_odata/process_odata.py
@@ -160,6 +160,23 @@ def _hebrew_date(iso_dt: str) -> str:
     return dt.strftime("%d/%m/%Y %H:%M")
 
 
+_SESSION_DETAIL_URL_TEMPLATE = (
+    "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID={sid}"
+)
+
+
+def session_detail_url(session_id) -> str:
+    """Return the Knesset session-detail (agenda) URL for ``session_id``.
+
+    Works for both upcoming and past sessions — the page is the same
+    permalink the Knesset's own UI links to. Returns "" for missing or
+    falsy IDs so the caller can substitute it directly into a CSV cell.
+    """
+    if not session_id:
+        return ""
+    return _SESSION_DETAIL_URL_TEMPLATE.format(sid=session_id)
+
+
 def fetch_plenum_sessions(
     base_url: str,
     start_dt: datetime,

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -380,7 +380,7 @@
     },
     "/botnim/knesset/sessions": {
       "get": {
-        "description": "Live Knesset plenary sessions in a date window — JIT call to knesset.gov.il OData (no caching). Use this for time-sensitive questions: 'מה הישיבה הבאה במליאה', 'מה היה בישיבה לפני', 'איזה ישיבות מתוכננות בשבועיים הקרובים'. For content-driven semantic queries ('which session covered חוק מימון מפלגות'), use search_unified__plenary_schedule__dev instead. Returns sessions ordered by StartDate ascending; when include_items=true (default) each session has its agenda items inline as `items: [...]`. Hebrew dates are added as StartDateHe/FinishDateHe.",
+        "description": "Live Knesset plenary sessions in a date window — JIT call to knesset.gov.il OData (no caching). Use this for time-sensitive questions: 'מה הישיבה הבאה במליאה', 'מה היה בישיבה לפני', 'איזה ישיבות מתוכננות בשבועיים הקרובים'. For content-driven semantic queries ('which session covered חוק מימון מפלגות'), use search_unified__plenary_schedule__dev instead. Returns sessions ordered by StartDate ascending; when include_items=true (default) each session has its agenda items inline as `items: [...]`. Hebrew dates are added as StartDateHe/FinishDateHe. Every returned session carries a `source_url` field: the stenogram URL when a transcript has been published, otherwise the session-detail (agenda) URL at `https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=<X>`. Cite this URL verbatim when referring to a session in answers — never link to the bare Knesset homepage.",
         "operationId": "knesset_sessions_live",
         "parameters": [
           {

--- a/tests/document_parser/knesset_odata/test_process_odata.py
+++ b/tests/document_parser/knesset_odata/test_process_odata.py
@@ -336,6 +336,23 @@ def test_stenogram_request_filters_by_group_type_43(mock_requests, tmp_path: Pat
     assert "GroupTypeID eq 43" in params["$filter"]
 
 
+@pytest.mark.parametrize("sid,expected", [
+    (2256195, "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=2256195"),
+    ("2256195", "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=2256195"),
+    (1, "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=1"),
+])
+def test_session_detail_url_happy_path(sid, expected):
+    from botnim.document_parser.knesset_odata.process_odata import session_detail_url
+    assert session_detail_url(sid) == expected
+
+
+@pytest.mark.parametrize("sid", [None, "", 0])
+def test_session_detail_url_returns_empty_for_missing(sid):
+    """No session id → no URL (callers fall back to '' for the CSV)."""
+    from botnim.document_parser.knesset_odata.process_odata import session_detail_url
+    assert session_detail_url(sid) == ""
+
+
 @patch.object(process_odata, "requests")
 def test_paged_results_followed(mock_requests, tmp_path: Path, fixed_now):
     """``@odata.nextLink`` is followed until exhausted."""

--- a/tests/document_parser/knesset_odata/test_process_odata.py
+++ b/tests/document_parser/knesset_odata/test_process_odata.py
@@ -179,7 +179,8 @@ def test_happy_path_writes_joined_csv(mock_requests, tmp_path: Path, fixed_now):
     assert hashes.pop()  # non-empty
 
     # Sessions with a stenogram get the fs.knesset.gov.il FilePath as source_url.
-    # Session 1003 has no stenogram → source_url is empty.
+    # Session 1003 has no stenogram → falls back to the session-detail URL,
+    # so every row carries a real Knesset link.
     assert all(
         r["source_url"] == "https://fs.knesset.gov.il/25/plenum/25_st_9991.doc"
         for r in rows if r["session_id"] == "1001"
@@ -188,7 +189,9 @@ def test_happy_path_writes_joined_csv(mock_requests, tmp_path: Path, fixed_now):
         r["source_url"] == "https://fs.knesset.gov.il/25/plenum/25_st_9992.doc"
         for r in rows if r["session_id"] == "1002"
     )
-    assert s3[0]["source_url"] == ""
+    assert s3[0]["source_url"] == (
+        "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=1003"
+    )
 
 
 @patch.object(process_odata, "requests")
@@ -351,6 +354,55 @@ def test_session_detail_url_returns_empty_for_missing(sid):
     """No session id → no URL (callers fall back to '' for the CSV)."""
     from botnim.document_parser.knesset_odata.process_odata import session_detail_url
     assert session_detail_url(sid) == ""
+
+
+def test_write_csv_uses_detail_url_when_no_stenogram(tmp_path):
+    """Sessions without a stenogram get the session-detail URL as source_url."""
+    from botnim.document_parser.knesset_odata.process_odata import write_csv_rows
+
+    sessions = [
+        # Past session — has stenogram in the lookup
+        {
+            "PlenumSessionID": 2241628,
+            "Number": 383,
+            "KnessetNum": 25,
+            "Name": "ישיבה רגילה",
+            "StartDate": "2026-03-25T11:00:00",
+            "FinishDate": "2026-03-26T10:23:10",
+            "IsSpecialMeeting": False,
+        },
+        # Future session — no stenogram, should fall back to sessionDet
+        {
+            "PlenumSessionID": 2256195,
+            "Number": 390,
+            "KnessetNum": 25,
+            "Name": "ישיבה רגילה",
+            "StartDate": "2026-05-13T11:00:00",
+            "FinishDate": "",
+            "IsSpecialMeeting": False,
+        },
+    ]
+    items_by_session = {2241628: [], 2256195: []}
+    stenogram_url_by_session = {
+        2241628: "https://fs.knesset.gov.il/25/plenum/25_st_383.doc",
+        # 2256195: not present — future session
+    }
+
+    out_path = tmp_path / "plenary.csv"
+    write_csv_rows(out_path, sessions, items_by_session,
+                   stenogram_url_by_session, upstream_hash="testhash")
+
+    import csv as _csv
+    with open(out_path, encoding="utf-8") as f:
+        rows = list(_csv.DictReader(f))
+
+    by_session = {r["session_id"]: r for r in rows}
+    assert by_session["2241628"]["source_url"] == (
+        "https://fs.knesset.gov.il/25/plenum/25_st_383.doc"
+    )
+    assert by_session["2256195"]["source_url"] == (
+        "https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=2256195"
+    )
 
 
 @patch.object(process_odata, "requests")


### PR DESCRIPTION
## Summary

- New `session_detail_url(session_id)` helper returns `https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=<id>` — the same permalink the Knesset's own UI links to.
- `write_csv_rows` falls back to that URL when a session has no published stenogram, so every row in `plenary_schedule.csv` now carries a real Knesset URL.
- `/botnim/knesset/sessions` live endpoint applies the same fallback (success and `RequestException` branches), so the LLM always sees a citable `source_url` per session — including upcoming sessions for which no stenogram exists yet.
- OpenAPI description for the live endpoint documents the contract.

## Validated locally

- 16 unit tests pass: helper (int/str/None/empty), CSV writer fallback, live endpoint with both stenogram-present and stenogram-missing cases.
- End-to-end against live Knesset OData (read-only fetch, no staging writes): 5 sessions over a ±20-day window → `write_csv_rows` emitted 105 rows, **100% with non-empty `source_url`** (100 stenogram URLs, 5 sessionDet fallbacks). Sample fallback: `https://www.knesset.gov.il/plenum/heb/sessionDet.aspx?SessionID=2242709`.

## Test plan

- [ ] CI green on `Build Docker Images`
- [ ] After deploy: `curl https://botnim.staging.build-up.team/botnim/knesset/sessions?from=<today>&to=<today+30d>` — every entry has `source_url`
- [ ] Past-session entries point to stenograms; future-session entries point to `sessionDet.aspx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
