### PR TITLE
feat(staging): enable trace propagation so admin trace UI shows bot internals

### DIFF
--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -108,6 +108,25 @@ module "botnim_api" {
       # to this endpoint; protocol=http/protobuf required (Phoenix rejects
       # JSON OTLP with HTTP 415).
       PHOENIX_COLLECTOR_ENDPOINT = "http://phoenix:6006/v1/traces"
+      # Trust the upstream LibreChat `traceparent` header so bot-side spans
+      # (rrf.fuse, embed, db.select, tool execution) join the same trace as
+      # the originating chat.turn. Without this, the admin trace view at
+      # /admin/sources only shows LibreChat-side spans; bot internals land
+      # in a separate Phoenix trace that LibreChat never queries.
+      #
+      # Security trade-off: botnim/observability/middleware.py:9 warns
+      # against this in staging/prod because a public caller could forge
+      # a traceparent to inject spans into a chosen trace_id. In our
+      # topology this is acceptable for STAGING because:
+      #   - Phoenix UI/data is internal-only (no external port)
+      #   - /api/botnim/traces/<id> is admin-only behind LibreChat JWT
+      #   - The only "exposure" is that an admin viewing a trace might
+      #     see injected content from a forged-traceparent request — and
+      #     only if the attacker guessed/observed a real LibreChat
+      #     trace_id (128-bit random; effectively unguessable).
+      # Re-evaluate before turning on in prod; the durable fix is to
+      # stitch traces server-side in LibreChat (see follow-up issue).
+      PHOENIX_PROPAGATE_TRACE = "true"
     },
   )
 


### PR DESCRIPTION
## Summary

Sets `PHOENIX_PROPAGATE_TRACE=true` on the staging `botnim-api` ECS task so bot-side OTel spans (`rrf.fuse`, `embed`, `db.select`, tool execution) join the same Phoenix trace as the originating LibreChat `chat.turn`.

## Why

Without propagation, `botnim/observability/middleware.py:26` strips the incoming `traceparent` header (security defense against forged trace IDs from public callers) and starts a fresh root span on the bot side. The two halves of a chat turn end up in **separate Phoenix traces**:

- LibreChat trace: `chat.turn` → `llm.completion` → `tool.call` shell (timing only)
- Bot trace: the actual `rrf.fuse`, `embed`, `db.select`, retrieval ranking

The admin trace expander at `/api/botnim/traces/<id>` only queries one trace, so admins see timing-only steps with no tool inputs/results/retrieval details — what surfaced this issue today.

## Trade-off

Documented in the code comment. In staging the bot's `/botnim/retrieve/*` is publicly reachable (no auth), so an attacker can forge a `traceparent` header. With propagation enabled, the bot trusts it and writes its spans into the attacker-chosen `trace_id`. Impact is bounded by:

- Phoenix UI / data is internal-only (no external port; reached only via Service Connect from LibreChat container)
- `/api/botnim/traces/<id>` is gated by `requireJwtAuth + checkAdmin`
- The only "exposure" is that an admin viewing a polluted trace might see injected content — but only if the attacker guessed a real LibreChat trace_id (128-bit random, effectively unguessable)

**Acceptable for staging. Do not turn on in prod without server-side trace stitching** (the durable fix — a follow-up issue should be filed).

## Validation

After deploy:
- A fresh chat on staging produces ONE merged Phoenix trace
- Admin expand of `ⓘ trace` shows the full tool-execution chain (botnim-api retrieval stages with embedding/RRF/SQL timings) inline with LibreChat's `chat.turn`
- `tool.parameters` and `tool.response.preview` populated on the merged tool span

## Test plan

- [ ] CI green
- [ ] After deploy: ask any question on staging, expand the trace, confirm `rrf.fuse`, `embed`, `SELECT documents …` spans appear under the LibreChat `tool.call`
- [ ] Confirm bot response carries `x-phoenix-trace-id` (sanity check the middleware still runs in propagate mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
