### PR TITLE
fix(phoenix): set Service Connect perRequestTimeout=60s

### DIFF
--- a/infra/modules/phoenix/main.tf
+++ b/infra/modules/phoenix/main.tf
@@ -361,6 +361,21 @@ resource "aws_ecs_service" "phoenix" {
         # bare alias org-infra's modules/app sets for botnim-api.
         dns_name = "phoenix"
       }
+
+      # AWS ECS Service Connect's default perRequestTimeout is 15 seconds
+      # (configurable since Jan 2024). Phoenix's GraphQL endpoint —
+      # used by LibreChat's admin trace UI at /api/botnim/traces/<id> —
+      # routinely takes longer than that on first hit (cold cache, schema
+      # loading, multi-project scan). With the default 15s in effect,
+      # OTLP POST /v1/traces (fast, sub-second) ingested fine while every
+      # request to /graphql, /healthz, / returned 504 at exactly 15.0s
+      # before reaching Phoenix at all (Phoenix logs showed zero
+      # non-OTLP traffic). Raising to 60s mirrors the inbound timeout
+      # already in place on botnim-api's SC mapping.
+      timeout {
+        per_request_timeout_seconds = 60
+        idle_timeout_seconds        = 120
+      }
     }
   }
 


### PR DESCRIPTION
AWS ECS Service Connect ships a [default 15s `perRequestTimeout`](https://aws.amazon.com/about-aws/whats-new/2024/01/amazon-ecs-configurable-timeout-service-connect/) on every service mapping. Phoenix had no override, so every request hitting the envoy proxy timed out before Phoenix could reply.

**Symptom**: OTLP `POST /v1/traces` (sub-second) ingested fine; every other path (`/graphql`, `/healthz`, `/`) returned 504 "upstream request timeout" at exactly 15.0s. Phoenix logs showed only OTLP traffic — non-OTLP requests never reached the container at all.

**Fix**: add a `timeout` block to the Phoenix Service Connect service config:
```
timeout {
  per_request_timeout_seconds = 60
  idle_timeout_seconds        = 120
}
```

Mirrors the inbound timeout already in place on `botnim-api`s SC mapping. After apply, LibreChat admin trace UI at `/api/botnim/traces/<id>` should successfully fetch trace data for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)