### PR TITLE
fix(tracing): align bot Phoenix project with LibreChat to merge spans in admin trace

### DIFF
--- a/botnim/observability/tracing.py
+++ b/botnim/observability/tracing.py
@@ -61,8 +61,16 @@ def init_tracing(app: "FastAPI") -> None:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
     env = os.getenv("ENVIRONMENT", "unknown")
+    # Write to Phoenix's "default" project (no explicit project_name) so the
+    # bot's spans land in the SAME project as LibreChat's chat.turn root.
+    # The LibreChat admin trace fetch at /api/botnim/traces/<id> uses
+    # single-project lookup (it breaks out at the first project that has
+    # spans for the given trace_id); aligning projects is the simplest way
+    # to surface bot-internal spans (rrf.fuse, embed, SELECT documents)
+    # in the merged trace timeline. LibreChat uses serviceName-only export
+    # and lands in "default" too in Phoenix v15 (which doesn't auto-route
+    # by service.name without openinference.project.name).
     tracer_provider = register(
-        project_name=f"botnim-{env}",
         endpoint=endpoint,
         set_global_tracer_provider=True,
         batch=True,


### PR DESCRIPTION
LibreChat exports to Phoenix `default` project (its `serviceName=librechat-<env>` doesn't set `openinference.project.name` in v15). Bot was explicitly setting `project_name="botnim-<env>"` via `phoenix.otel.register`, so the two halves of a chat turn landed in different projects.

The admin trace fetch at `/api/botnim/traces/<id>` only queries one project per trace (breaks out at the first project with matching spans). Result: admin saw LibreChat-side spans (`chat.turn`, `llm.completion`, `tool.call` shell) but missed all bot internals (`rrf.fuse`, `embed`, `SELECT documents`).

Dropping `project_name` from `phoenix.otel.register(...)` aligns both sides to `default`. After this + redeploy, a fresh chat will produce a trace with both halves visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)