### PR TITLE
fix(phoenix): allow ingress from bot task SG (real root cause of missing bot spans)

### DIFF
--- a/infra/live/staging/phoenix/terragrunt.hcl
+++ b/infra/live/staging/phoenix/terragrunt.hcl
@@ -146,6 +146,19 @@ inputs = {
   # ../buildup-org-infra), exposed via /buildup/shared/staging/contract.
   internal_service_clients_sg_id = local.contract.internal_services.client_security_group_id
 
+  # Workaround: the botnim-api task ENI doesn't carry the cluster-wide
+  # internal-service-clients SG (its app module ref
+  # `feat/ecs-efs-and-sidecars-v2` predates the auto-attach that
+  # LibreChat's `648976c` ref includes), so the canonical ingress rule
+  # above silently denies bot→phoenix traffic. Every OTLP export from
+  # botnim-api was failing without a visible error — Phoenix logs only
+  # ever showed LibreChat's spans. Allowlist the bot's task SG directly
+  # until the bot module ref is bumped. The SG id is hardcoded because
+  # it's the long-lived task SG created once by org-infra modules/app;
+  # if the bot ever rebuilds its SG (terraform replace), this needs an
+  # update.
+  extra_client_security_group_ids = ["sg-06e042ecc3b57aa9b"]
+
   # Shared Aurora cluster's SG. Phoenix module appends a rule on this SG
   # allowing phoenix's task SG on 5432 — Aurora's ingress allowlist is
   # explicit per task SG (NOT internal-service-clients-sg-based), so phoenix

--- a/infra/modules/phoenix/main.tf
+++ b/infra/modules/phoenix/main.tf
@@ -76,6 +76,23 @@ resource "aws_security_group_rule" "phoenix_ingress_from_clients" {
   description              = "Allow Service Connect callers (LibreChat / botnim-api) to reach Phoenix:6006"
 }
 
+# Workaround ingress rules — needed while some app tasks use an older
+# org-infra modules/app ref that doesn't auto-attach the cluster-wide
+# internal-service-clients SG to their ENIs. Without this, those tasks
+# can't reach phoenix:6006 over Service Connect (Phoenix logs see only
+# the other client tasks' traffic). See var.extra_client_security_group_ids.
+resource "aws_security_group_rule" "phoenix_ingress_from_extra_clients" {
+  for_each = toset(var.extra_client_security_group_ids)
+
+  type                     = "ingress"
+  from_port                = 6006
+  to_port                  = 6006
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.phoenix.id
+  source_security_group_id = each.value
+  description              = "Allow ${each.value} (legacy client SG) to reach Phoenix:6006"
+}
+
 # Open Aurora's SG to phoenix on 5432. Org-infra's modules/app does this
 # automatically for `enable_aurora_access = true` callers (e.g. botnim-api,
 # whose task SG is on Aurora's ingress allowlist). Our hand-rolled phoenix

--- a/infra/modules/phoenix/variables.tf
+++ b/infra/modules/phoenix/variables.tf
@@ -65,6 +65,12 @@ variable "internal_service_clients_sg_id" {
   description = "SG ID of the cluster-wide internal-service-clients SG that botnim-api / librechat tasks attach to. Consumed by an aws_security_group_rule that allows TCP 6006 ingress on phoenix from that SG so Service Connect calls succeed (the SC sidecar forwards directly to the upstream ENI, which AWS still enforces SG ingress on). Sourced from /buildup/shared/<env>/contract → internal_services.client_security_group_id; defined in ../buildup-org-infra."
 }
 
+variable "extra_client_security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "Additional task SGs allowed to reach phoenix:6006. Workaround for app modules that don't attach the cluster-wide internal-service-clients SG to their ENIs (e.g., the botnim-api task currently uses an org-infra modules/app ref that predates that auto-attach). For each SG in this list the phoenix module appends a parallel aws_security_group_rule alongside the canonical internal_service_clients_sg_id ingress. Remove the entry once the upstream module bumps its modules/app ref to one that includes the cluster-wide client SG."
+}
+
 variable "secrets_kms_key_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
After today's diagnostic chain (env var propagation, Phoenix v15 bump, SC perRequestTimeout, project alignment), the **real root cause** of "bot internals missing from admin trace UI" turned out to be a **silent network drop**.

## Definitive evidence

Direct query of Phoenix Postgres (`spans` table on Aurora):
- 42,128 spans total
- 45 spans inserted in last 10 min
- **Zero** match the bot's logged span_id `1806fc9211a7f5b0`
- All recent spans are LibreChat's HTTP instrumentation (`GET`/`HEAD`)

Diagnostic logging in bot middleware proved the bot creates spans correctly when LibreChat passes traceparent — they just never reach Phoenix.

SG comparison:
- LibreChat ENI: `librechat-staging-api-tasks-sg` + `buildup-staging-internal-service-clients-sg`
- Bot ENI: `botnim-api-staging-api-tasks-sg` only ← **missing the cluster-wide clients SG**

Phoenix's ingress only allows `internal-service-clients-sg`, so bot OTLP exports were silently denied at the SG layer. Python OTel SDK swallows connection failures by default.

## Fix

New input `extra_client_security_group_ids` on the phoenix module → list of additional task SGs allowed to reach `phoenix:6006`. Staging passes the bot's task SG `sg-06e042ecc3b57aa9b` directly. Right long-term fix is to bump the bot's `org-infra//modules/app` ref from `feat/ecs-efs-and-sidecars-v2` to `648976c` (matches LibreChat) so the SG attaches automatically — but that's an org-infra change requiring testing; this workaround unblocks tracing immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)