### PR TITLE
fix(tracing): wrapt<2 pin + isolate OpenAIInstrumentor failure

### DIFF
--- a/botnim/observability/tracing.py
+++ b/botnim/observability/tracing.py
@@ -92,7 +92,16 @@ def init_tracing(app: "FastAPI") -> None:
     )
     tracer_provider.add_span_processor(SecretScrubbingSpanProcessor())
 
-    OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+    try:
+        OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+    except Exception as e:
+        # openinference-instrumentation-openai 0.1.18 broke with wrapt 2.x
+        # ("wrap_function_wrapper() got an unexpected keyword argument
+        # 'module'"). Don't let that take down the rest of the pipeline —
+        # FastAPI / SQLAlchemy spans are the load-bearing ones for the
+        # admin trace UI. Bump openinference once a compatible release
+        # lands.
+        logger.warning("OpenAI instrumentation skipped: %s", e)
     FastAPIInstrumentor.instrument_app(
         app, tracer_provider=tracer_provider,
         excluded_urls="health,healthz",

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,12 @@ arize-phoenix-otel==0.7.1
 openinference-instrumentation-openai==0.1.18
 opentelemetry-instrumentation-sqlalchemy
 opentelemetry-instrumentation-fastapi
+# Pin wrapt <2 — openinference-instrumentation-openai 0.1.18 calls
+# wrap_function_wrapper(module=..., ...). wrapt 2.x removed the `module`
+# kwarg so the call raises TypeError at init time, taking down the whole
+# tracing pipeline. Remove this pin once we bump openinference to a
+# release compatible with wrapt 2.x.
+wrapt<2
 
 # AWS SDK — used by alembic 0014_phoenix_app_password_from_secret to read
 # botnim/<env>/phoenix-db-url and ALTER ROLE phoenix_app to match the


### PR DESCRIPTION
Today the docker rebuild (after `docker system prune -af`) pulled `wrapt 2.x`. `openinference-instrumentation-openai==0.1.18` calls `wrap_function_wrapper(module=..., ...)`. `wrapt 2.x` removed the `module` kwarg → `TypeError` at startup → `init_tracing` aborts before `FastAPIInstrumentor` and `SQLAlchemyInstrumentor` get wired up. That is the actual reason bot spans never appeared in Phoenix even after PR #166 corrected the BatchSpanProcessor overwrite.

Two fixes:
1. Wrap `OpenAIInstrumentor().instrument(...)` in `try/except` so its failure does not poison the rest of the pipeline.
2. Pin `wrapt<2` in `requirements.txt` so newly-built images stop hitting this. Remove the pin once openinference ships a release compatible with `wrapt 2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)