### PR TITLE
chore(unified): rename committee_decisions slug to house_committee_decisions

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -517,7 +517,11 @@ class VectorStoreAurora(VectorStoreBase):
                     ) AS rn
                   FROM dated
                   WHERE doc_date IS NOT NULL
-                    AND doc_date ~ '^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}'
+                    -- Strict: realistic year (1900-2039), valid month (01-12), valid day (01-31).
+                    -- The loose `^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}` admitted garbage like
+                    -- '3390-06-91' (committee_decisions _427.md), which sorted to position [0]
+                    -- under ORDER BY doc_date DESC and poisoned every recency query.
+                    AND doc_date ~ '^(19[0-9]{{2}}|20[0-3][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])'
                 )
                 SELECT id, content, metadata
                 FROM ranked

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -249,7 +249,7 @@
     },
     "/botnim/retrieve/unified/house_committee_decisions__dev": {
       "get": {
-        "description": "Search Knesset committee decisions. THREE modes — choose by intent: (a) 'אילו החלטות התקבלו לאחרונה', 'מה ההחלטות האחרונות', 'הכי חדשות' → search_mode=RECENCY_BROWSE: calendar-newest decisions in pure date-desc order (no similarity ranking). (b) 'אילו החלטות יש על X', 'רשימת החלטות בנושא…', topical browse → search_mode=METADATA_BROWSE (25 similarity-ranked summaries). (c) substantive content question → leave REGULAR (default). Present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results.",
+        "description": "Search Knesset committee decisions. THREE modes — choose by intent: (a) 'אילו החלטות התקבלו לאחרונה', 'מה ההחלטות האחרונות', 'הכי חדשות', 'מה ההחלטה האחרונה' → search_mode=RECENCY_BROWSE: results are returned strictly date-desc (SQL `ORDER BY doc_date DESC, id DESC`), so results[0] IS the newest decision. When the user asks for THE latest (singular), report results[0] verbatim — do NOT re-rank by inspecting dates yourself, do NOT pick a different item even if its date string looks 'rounder' or appears earlier in the list visually. When the user asks for the latest few, present them in the order received. (b) 'אילו החלטות יש על X', 'רשימת החלטות בנושא…', topical browse → search_mode=METADATA_BROWSE (25 similarity-ranked summaries). (c) substantive content question → leave REGULAR (default). Present 3–5 items with title, date, one-line subject, and קישור_למקור.",
         "operationId": "search_unified__house_committee_decisions__dev",
         "parameters": [
           {

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -247,10 +247,10 @@
         "deprecated": false
       }
     },
-    "/botnim/retrieve/unified/committee_decisions__dev": {
+    "/botnim/retrieve/unified/house_committee_decisions__dev": {
       "get": {
         "description": "Search Knesset committee decisions. THREE modes — choose by intent: (a) 'אילו החלטות התקבלו לאחרונה', 'מה ההחלטות האחרונות', 'הכי חדשות' → search_mode=RECENCY_BROWSE: calendar-newest decisions in pure date-desc order (no similarity ranking). (b) 'אילו החלטות יש על X', 'רשימת החלטות בנושא…', topical browse → search_mode=METADATA_BROWSE (25 similarity-ranked summaries). (c) substantive content question → leave REGULAR (default). Present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results.",
-        "operationId": "search_unified__committee_decisions__dev",
+        "operationId": "search_unified__house_committee_decisions__dev",
         "parameters": [
           {
             "name": "query",

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -296,7 +296,7 @@ context:
         החזר מערך של אובייקטים JSON, כל אובייקט מייצג מסמך אחד.
 
         '
-- slug: committee_decisions
+- slug: house_committee_decisions
   name: החלטות ועדת הכנסת
   description: 'Search the knesset committee decisions. Use for: the knesset committee
     resolutions, procedural decisions, administrative committee matters.'

--- a/tests/test_vector_store_aurora.py
+++ b/tests/test_vector_store_aurora.py
@@ -697,3 +697,76 @@ def test_upload_files_writes_source_id_from_metadata(aurora_db, monkeypatch):
         ), {"cid": cid}).fetchall()
     assert rows, "expected at least one row inserted"
     assert all(r[0] == "חוק_הכנסת" for r in rows), f"all rows should have source_id; got {rows!r}"
+
+
+def test_recency_search_filters_invalid_dates(aurora_db, database_url, monkeypatch):
+    """RECENCY_BROWSE must filter out garbage dates that pass a loose regex but
+    sort to the top under ORDER BY doc_date DESC.
+
+    Real-world bug (committee_decisions _427.md, 2026-05-15): metadata.תאריך
+    held the literal string '3390-06-91' (year out of range, day=91). The
+    previous regex `^[0-9]{4}-[0-9]{2}-[0-9]{2}` accepted it; the bogus row
+    sorted to position [0] and poisoned every recency answer for that
+    context. Lock in the stricter validation so a future "simplification"
+    can't silently regress.
+    """
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import RECENCY_BROWSE_CONFIG
+
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "x"}, "x", False)
+
+    dummy_emb = [0.0] * 1536
+    seed = [
+        # (filename, date_string, expected_in_results)
+        ("decision_25apr.md",   "2026-04-25",                 True),
+        ("decision_25mar.md",   "2026-03-25",                 True),
+        ("decision_31may1999.md","1999-05-31",                True),
+        ("decision_with_time.md","2025-04-03T10:00:00",       True),
+        ("decision_bogus.md",   "3390-06-91",                 False),  # the real bug
+        ("decision_old.md",     "1850-01-01",                 False),  # pre-1900
+        ("decision_future.md",  "2040-12-31",                 False),  # post-2039
+        ("decision_bad_month.md","2025-13-01",                False),
+        ("decision_bad_day.md", "2025-04-32",                 False),
+        ("decision_hebrew.md",  "תשע\"ח",                     False),
+        ("decision_dmy.md",     "25-04-2025",                 False),  # DD-MM-YYYY
+    ]
+    docs = []
+    for fname, date_str, _expected in seed:
+        docs.append((
+            f"content of {fname}",
+            dummy_emb,
+            {"filename": fname, "source_id": fname, "תאריך": date_str},
+        ))
+    _seed_documents(database_url, cid, docs)
+
+    results = store.search(
+        context_name="x",
+        query_text="anything",
+        search_mode=RECENCY_BROWSE_CONFIG,
+        embedding=dummy_emb,
+        num_results=20,
+    )
+    returned_dates = [
+        h["_source"]["metadata"]["תאריך"] for h in results["hits"]["hits"]
+    ]
+
+    expected_kept = {date_str for _, date_str, expected in seed if expected}
+    expected_dropped = {date_str for _, date_str, expected in seed if not expected}
+
+    assert set(returned_dates) == expected_kept, (
+        f"unexpected set of dates returned.\n"
+        f"  got:      {returned_dates!r}\n"
+        f"  expected: {expected_kept!r}"
+    )
+    assert not (set(returned_dates) & expected_dropped), (
+        f"bogus dates leaked into results: "
+        f"{set(returned_dates) & expected_dropped!r}"
+    )
+
+    # The ordering is the load-bearing part: results[0] is what the LLM treats
+    # as "the latest". After filtering, 2026-04-25 must be on top.
+    assert returned_dates[0] == "2026-04-25", (
+        f"results[0] must be the newest valid date; got {returned_dates[0]!r}"
+    )


### PR DESCRIPTION
## Summary

This PR contains **two related changes** to the unified bot:

1. **Rename** the `committee_decisions` context slug to `house_committee_decisions` (commit `565b51c`).
2. **Make `RECENCY_BROWSE` deterministic** — tighten date regex + lock-in test + sharpen tool description (commit `766697a`).

## 1. Rename

- `specs/unified/config.yaml` — slug change only (Hebrew display name unchanged).
- `specs/openapi/botnim.yaml` — REST path + operationId for the staging `__dev` tool.

The data plane was renamed in staging Aurora out-of-band (in-place SQL UPDATE on `contexts.name` + `documents.metadata.context_name` + `context_snapshots.context`). This PR brings the spec into agreement so future deploys from a clean tree don't regress.

**Safety:** Manual cluster snapshot taken before the data rename: `buildup-staging-pre-committee-rename-20260515-203803` (kept). Snapshot was restored to a temporary verify cluster, per-context doc + snapshot counts compared against live staging — all 1538 docs and 125 snapshot rows for the renamed context preserved; counts for the other 9 unified contexts are bit-identical. Verify cluster torn down post-check.

Next `botnim sync` is a no-op for this context: delta-sync finds matching `content_hash` for all chunks under the new slug.

## 2. Recency determinism

Live staging surfaced a real bug: the same prompt (*"מה החלטה אחרונה של ועדה בכנסת?"*) returned **two different "latest decisions"** depending on the call (25/03/2026 vs 25/04/2026). Investigation found the culprit:

- `metadata->>'תאריך'` on file `_החלטות ועדות הכנסת_427.md` holds the literal string `'3390-06-91'` (5 chunks, all identical).
- The previous regex `^[0-9]{4}-[0-9]{2}-[0-9]{2}` accepted it because it only validated **shape**, not value.
- Under `ORDER BY doc_date DESC` the bogus row sorted to position [0] and poisoned every recency answer for that context.

Three coupled fixes:

- **`botnim/vector_store/vector_store_aurora.py`** — tighten the `_recency_search` regex to validate year (1900–2039), month (01–12), day (01–31). Bogus row drops out.
- **`tests/test_vector_store_aurora.py`** — new `test_recency_search_filters_invalid_dates` with 11 cases (valid recent, valid 1999, valid with-time-suffix, the 3390 bogus, pre-1900, post-2039, bad month/day, Hebrew calendar, DD-MM-YYYY format). Locks in the regex and asserts results[0] is the newest valid date.
- **`specs/openapi/botnim.yaml`** — strengthen RECENCY_BROWSE tool description: explicit "results are returned strictly date-desc, results[0] IS the newest, do not pick a different item by inspecting dates yourself."

Verified live in staging immediately after deploy: same prompt now consistently returns 25/04/2026 as the latest, with the bot deferring to the tool's ordering (*"לפי תוצאות החיפוש זו ההחלטה האחרונה שהוחזרה"*).

Bad data row in `_427.md` is still in Aurora — not addressed in this PR (blocked by regex now), but should be patched separately so the document itself isn't lost.

## Test plan

- [x] Pytest passes (`./deploy.sh staging` phase 2: 12 tests in `test_query_error_handling.py`)
- [x] New `test_recency_search_filters_invalid_dates` passes locally (won't be auto-run by deploy.sh — the existing test infra has an `sys.modules` isolation bug that prevents `pytest tests/`)
- [x] Staging deploy lands cleanly (image `a354c77`, both deploys)
- [x] Phase 9 re-seeds the LibreChat agent with `search_unified__house_committee_decisions__dev` (13 functions, 16 DRAFT tools)
- [x] Health + `/botnim/retrieve` smoke checks pass
- [x] Live UI sanity at https://botnim.staging.build-up.team — recency query consistently returns the correct latest decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
