### PR TITLE
fix(phoenix): set prod account id (was placeholder, blocked first-deploy)

### DIFF
--- a/infra/live/prod/phoenix/.terraform.lock.hcl
+++ b/infra/live/prod/phoenix/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/live/prod/phoenix/terragrunt.hcl
+++ b/infra/live/prod/phoenix/terragrunt.hcl
@@ -38,7 +38,7 @@ locals {
 
   # AWS account ID for prod. Used to construct the Secrets Manager ARN.
   # Verify with: aws --profile anubanu-prod sts get-caller-identity
-  aws_account_id = "REPLACE_WITH_PROD_ACCOUNT_ID"
+  aws_account_id = "086879295714"
 
   # ECS cluster + Service Connect namespace are read from the prod platform
   # contract (see local.contract below). Discovery on staging on 2026-05-10


### PR DESCRIPTION
## Summary

The prod phoenix terragrunt stack had a literal placeholder:

```hcl
aws_account_id = "REPLACE_WITH_PROD_ACCOUNT_ID"
```

That meant `phoenix_db_secret_arn` interpolated to
`arn:aws:secretsmanager:il-central-1:REPLACE_WITH_PROD_ACCOUNT_ID:secret:botnim/prod/phoenix-db-url`,
which IAM rejects with `MalformedPolicyDocument: The policy failed legacy parsing`
when `aws_iam_role_policy.task_exec_secrets` (`phoenix-db-secret-read`) attaches
to the task exec role. First-deploy of the prod phoenix stack failed on this
during the 2026-05-16 prod deploy. After patching + creating the operator-gated
`botnim/prod/phoenix-db-url` secret (with CMK encryption to satisfy the
`task_exec_kms_decrypt` policy), the re-deploy applied cleanly and
`phoenix-prod` is now running on prod (desired/running 1/1, rolloutState COMPLETED).

Also commits the terraform provider lock file that was generated on first init.

## Test plan

- [x] `./deploy.sh prod --auto-approve` completed all phases on 2026-05-16
- [x] phoenix-prod service shows 1/1 running, COMPLETED
- [x] `/botnim/health` 200; `/botnim/retrieve` 200 with valid Hebrew legal text body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
