### PR TITLE
feat(wikitext): per-source cache to skip re-extracting unchanged Wikisource pages

### DIFF
--- a/botnim/document_parser/wikitext/pipeline_config.py
+++ b/botnim/document_parser/wikitext/pipeline_config.py
@@ -4,6 +4,7 @@ Pipeline configuration and validation.
 """
 
 from dataclasses import dataclass, field
+import hashlib
 from pathlib import Path
 import re
 from typing import Optional, Dict, Any, List
@@ -71,8 +72,13 @@ class WikitextProcessorConfig:
     
     def __post_init__(self):
         """Initialize derived paths."""
+        # Download the HTML once. Cache the bytes' sha256 so the run() cache
+        # check can short-circuit the LLM-driven Stage 1 when the upstream
+        # Wikisource page hasn't changed since the last fap.
+        html_bytes = requests.get(self.input_url, headers=HEADERS).content
+        self.input_html_sha256 = hashlib.sha256(html_bytes).hexdigest()
         with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as tf:
-            tf.write(requests.get(self.input_url, headers=HEADERS).content)
+            tf.write(html_bytes)
             tf.flush()
             self.input_html_file = Path(tf.name)
         self.output_base_dir = Path(self.output_base_dir)

--- a/botnim/document_parser/wikitext/process_document.py
+++ b/botnim/document_parser/wikitext/process_document.py
@@ -17,6 +17,35 @@ import json
 # Logger setup
 logger = get_logger(__name__)
 
+
+# Wikitext structure-extractor version. Bump when:
+#   - the system prompt in extract_structure.extract_structure_from_html changes
+#   - the response schema (StructureResponse / StructureItem) changes
+#   - the model in pipeline_config.WikitextProcessorConfig.model changes
+#   - any post-processing in build_nested_structure changes
+# Bumping invalidates every cached content_file at one stroke; the next fap
+# re-extracts. Unlike the per-chunk extraction_cache, wikitext sources are a
+# handful per bot (~10 for unified), so the bump cost is bounded.
+WIKITEXT_EXTRACTOR_VERSION = "v1-gpt-4.1-mini"
+
+
+def _read_cached_metadata(content_file: Path) -> dict | None:
+    """Return the metadata dict from an existing content_file, or None.
+
+    Failures (missing file, malformed JSON, missing metadata key) return None
+    so the caller falls through to a fresh extraction — never raise from
+    the cache-check fast path.
+    """
+    if not content_file.exists():
+        return None
+    try:
+        with open(content_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    md = data.get('metadata') if isinstance(data, dict) else None
+    return md if isinstance(md, dict) else None
+
 def validate_markdown_output(output_dir: Path) -> list:
     errors = []
     if not output_dir.exists() or not output_dir.is_dir():
@@ -59,7 +88,11 @@ class WikitextProcessor:
             nested_structure = build_nested_structure(structure_items)
             # Convert to JSON-serializable format
             structure_data = nested_structure # No longer using flatten_for_json_serialization
-            # Prepare output data with metadata
+            # Prepare output data with metadata. ``html_sha256`` and
+            # ``wikitext_extractor_version`` are the cache key for the
+            # next-run skip in ``run()``. They flow through Stage 2 verbatim
+            # (extract_content_for_sections mutates structure data in place,
+            # leaves metadata alone) and end up in the final content_file.
             output_data = {
                 "metadata": {
                     "input_file": str(self.config.input_url),
@@ -69,7 +102,9 @@ class WikitextProcessor:
                     "max_tokens": self.config.max_tokens,
                     "total_items": len(structure_items),
                     "structure_type": "nested_hierarchy",
-                    "mark_type": self.config.content_type
+                    "mark_type": self.config.content_type,
+                    "html_sha256": self.config.input_html_sha256,
+                    "wikitext_extractor_version": WIKITEXT_EXTRACTOR_VERSION,
                 },
                 "structure": structure_data
             }
@@ -189,6 +224,34 @@ class WikitextProcessor:
         # Initialize metadata
         self.start_time = datetime.now()
         self.metadata.start_time = self.start_time.isoformat()
+
+        # Cache fast-path: if the previous run's content_file is still on
+        # disk and was extracted from this exact same HTML at the current
+        # WIKITEXT_EXTRACTOR_VERSION, skip both Stage 1 (the LLM call) and
+        # Stage 2. Saves ~30K input tokens / source / day in steady state.
+        # Bumping WIKITEXT_EXTRACTOR_VERSION (or any content change at the
+        # upstream Wikisource URL) invalidates the cache and forces a
+        # fresh extraction on the next fap.
+        cached_md = _read_cached_metadata(self.config.content_file)
+        if (cached_md is not None
+                and cached_md.get('html_sha256') == self.config.input_html_sha256
+                and cached_md.get('wikitext_extractor_version') == WIKITEXT_EXTRACTOR_VERSION):
+            logger.info(
+                "WIKITEXT_CACHE_HIT: url=%s html_sha256=%s version=%s "
+                "(skipping LLM structure extraction)",
+                self.config.input_url,
+                self.config.input_html_sha256[:12],
+                WIKITEXT_EXTRACTOR_VERSION,
+            )
+            self.metadata.end_time = datetime.now().isoformat()
+            return True
+
+        logger.info(
+            "WIKITEXT_CACHE_MISS: url=%s html_sha256=%s version=%s",
+            self.config.input_url,
+            self.config.input_html_sha256[:12],
+            WIKITEXT_EXTRACTOR_VERSION,
+        )
 
         try:
             # Stage 1: Extract structure

--- a/tests/test_wikitext_cache.py
+++ b/tests/test_wikitext_cache.py
@@ -1,0 +1,191 @@
+"""Wikitext per-source structure-extraction cache.
+
+The WikitextProcessor downloads Wikisource HTML and runs a single
+`gpt-4.1-mini` call to derive a hierarchical structure. With ~10 wikitext
+sources on the unified bot, the daily fap burns ~10 LLM calls/day on
+content that rarely changes. The cache fast-path skips the LLM call when
+the previous run's content_file is still on disk and was extracted from
+this exact same HTML at the current WIKITEXT_EXTRACTOR_VERSION.
+
+These tests exercise the cache decision logic without making real HTTP
+requests or LLM calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _build_processor(tmp_path: Path, html_bytes: bytes, *, model: str = "gpt-4.1-mini"):
+    """Construct a WikitextProcessor with mocked HTTP fetch + writable output."""
+    from botnim.document_parser.wikitext.pipeline_config import (
+        Environment,
+        WikitextProcessorConfig,
+    )
+    from botnim.document_parser.wikitext.process_document import WikitextProcessor
+
+    fake_resp = MagicMock()
+    fake_resp.content = html_bytes
+    with patch(
+        "botnim.document_parser.wikitext.pipeline_config.requests.get",
+        return_value=fake_resp,
+    ):
+        config = WikitextProcessorConfig(
+            input_url="https://he.wikisource.org/wiki/Test_Page",
+            output_base_dir=tmp_path,
+            content_type="סעיף",
+            environment=Environment.STAGING,
+            model=model,
+            max_tokens=None,
+        )
+    return WikitextProcessor(config)
+
+
+def _write_existing_content_file(
+    path: Path, *, html_sha256: str, version: str, model: str = "gpt-4.1-mini"
+) -> None:
+    """Drop a minimal valid content_file at `path` with the given cache key."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "metadata": {
+            "input_file": "https://he.wikisource.org/wiki/Test_Page",
+            "document_name": "Test_Page",
+            "environment": "staging",
+            "model": model,
+            "max_tokens": None,
+            "total_items": 0,
+            "structure_type": "nested_hierarchy",
+            "mark_type": "סעיף",
+            "html_sha256": html_sha256,
+            "wikitext_extractor_version": version,
+        },
+        "structure": [],
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+
+def test_run_cache_hit_skips_llm_call(tmp_path: Path):
+    """A content_file with matching html_sha256 + version → skip LLM."""
+    from botnim.document_parser.wikitext.process_document import (
+        WIKITEXT_EXTRACTOR_VERSION,
+    )
+
+    html = b"<html><body>same content</body></html>"
+    proc = _build_processor(tmp_path, html)
+    _write_existing_content_file(
+        proc.config.content_file,
+        html_sha256=proc.config.input_html_sha256,
+        version=WIKITEXT_EXTRACTOR_VERSION,
+    )
+
+    llm = MagicMock()
+    with patch(
+        "botnim.document_parser.wikitext.process_document.extract_structure_from_html",
+        llm,
+    ):
+        ok = proc.run(generate_markdown=False)
+
+    assert ok is True
+    llm.assert_not_called()
+
+
+def test_run_cache_miss_when_no_content_file(tmp_path: Path):
+    """No content_file on disk → fresh extraction."""
+    html = b"<html><body>brand new</body></html>"
+    proc = _build_processor(tmp_path, html)
+    assert not proc.config.content_file.exists()
+
+    fake_struct = []
+    fake_content = MagicMock()
+    with patch(
+        "botnim.document_parser.wikitext.process_document.extract_structure_from_html",
+        return_value=fake_struct,
+    ) as llm, patch(
+        "botnim.document_parser.wikitext.process_document.extract_content_from_html",
+        fake_content,
+    ):
+        ok = proc.run(generate_markdown=False)
+
+    assert ok is True
+    llm.assert_called_once()
+
+
+def test_run_cache_miss_when_html_changed(tmp_path: Path):
+    """Existing content_file at a different html_sha256 → fresh extraction."""
+    from botnim.document_parser.wikitext.process_document import (
+        WIKITEXT_EXTRACTOR_VERSION,
+    )
+
+    html = b"<html><body>new content</body></html>"
+    proc = _build_processor(tmp_path, html)
+    _write_existing_content_file(
+        proc.config.content_file,
+        html_sha256="0" * 64,  # deliberately mismatched
+        version=WIKITEXT_EXTRACTOR_VERSION,
+    )
+
+    with patch(
+        "botnim.document_parser.wikitext.process_document.extract_structure_from_html",
+        return_value=[],
+    ) as llm, patch(
+        "botnim.document_parser.wikitext.process_document.extract_content_from_html",
+    ):
+        proc.run(generate_markdown=False)
+
+    llm.assert_called_once()
+
+
+def test_run_cache_miss_when_extractor_version_bumped(tmp_path: Path):
+    """Existing content_file at an older version → fresh extraction."""
+    html = b"<html><body>same content</body></html>"
+    proc = _build_processor(tmp_path, html)
+    _write_existing_content_file(
+        proc.config.content_file,
+        html_sha256=proc.config.input_html_sha256,
+        version="v0-some-older-version",  # deliberately mismatched
+    )
+
+    with patch(
+        "botnim.document_parser.wikitext.process_document.extract_structure_from_html",
+        return_value=[],
+    ) as llm, patch(
+        "botnim.document_parser.wikitext.process_document.extract_content_from_html",
+    ):
+        proc.run(generate_markdown=False)
+
+    llm.assert_called_once()
+
+
+def test_stage_one_output_stamps_html_sha256_and_version(tmp_path: Path):
+    """Stage 1 writes html_sha256 + wikitext_extractor_version into metadata
+    so subsequent runs can compare against it."""
+    from botnim.document_parser.wikitext.process_document import (
+        WIKITEXT_EXTRACTOR_VERSION,
+    )
+
+    html = b"<html><body>fresh</body></html>"
+    proc = _build_processor(tmp_path, html)
+    expected_hash = proc.config.input_html_sha256
+
+    with patch(
+        "botnim.document_parser.wikitext.process_document.extract_structure_from_html",
+        return_value=[],
+    ), patch(
+        "botnim.document_parser.wikitext.process_document.build_nested_structure",
+        return_value=[],
+    ), patch(
+        "botnim.document_parser.wikitext.process_document.extract_content_from_html",
+    ):
+        proc.run(generate_markdown=False)
+
+    # Stage 1 writes the structure_file with the cache key in metadata.
+    assert proc.config.structure_file.exists()
+    with open(proc.config.structure_file, "r", encoding="utf-8") as f:
+        written = json.load(f)
+    md = written["metadata"]
+    assert md["html_sha256"] == expected_hash
+    assert md["wikitext_extractor_version"] == WIKITEXT_EXTRACTOR_VERSION


### PR DESCRIPTION
## Summary

Closes the last unconditional-LLM-call hole in the daily fap. The 10 wikitext sources on the unified bot (2 in `common_takanon_knowledge`, 8 in `legal_text`) each triggered one `gpt-4.1-mini` structure-extraction call per fap, regardless of whether the upstream Wikisource HTML had actually changed. ~$0.12/day, 100% waste in steady state since takanon + related laws rarely change day-to-day.

Cache key: `(html_sha256, wikitext_extractor_version)`. Mechanism details and rationale are in the commit message.

## E2E verification

Real end-to-end against `https://he.wikisource.org/wiki/חוק_הפרשנות` inside the botnim_api container:

| Run | First-line marker | LLM call | Elapsed |
|---|---|---|---|
| 1 | `WIKITEXT_CACHE_MISS` | yes — `POST /v1/chat/completions 200` | 24.5s |
| 2 | `WIKITEXT_CACHE_HIT` | **no** | 0.3s |

## Test plan

- [x] `tests/test_wikitext_cache.py` — 5 cases (hit, miss-no-file, miss-html-changed, miss-version-bumped, Stage 1 stamps metadata).
- [x] In-container E2E with real OpenAI key.
- [ ] Staging: after deploy, manual `POST /admin/refresh` → expect `WIKITEXT_CACHE_MISS` for all 10 sources (first run after upgrade, existing content_files lack the new metadata) → next refresh's 10 calls disappear.
- [ ] Prod: same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
