### PR TITLE
feat(knesset_protocols): per-document delta to skip re-downloading unchanged .doc files

### DIFF
--- a/botnim/document_parser/knesset_protocols/process_protocols.py
+++ b/botnim/document_parser/knesset_protocols/process_protocols.py
@@ -233,6 +233,31 @@ def process_knesset_protocols_source(
                     upstream_hash, output_csv)
         return
 
+    # Per-document delta: even when the overall upstream_hash changed (one new
+    # protocol uploaded, or a single existing one re-edited), the vast
+    # majority of documents are unchanged. Re-downloading + re-parsing 13K
+    # .doc files because one was added is wasteful. Build a reuse index
+    # keyed by (document_id, file_last_updated) — if a document's
+    # LastUpdatedDate from OData matches what we already have on disk, we
+    # reuse the per-turn rows verbatim (only refreshing the upstream_hash
+    # column so the file remains internally consistent). When LastUpdatedDate
+    # differs (or the doc is new) we fall through to a fresh download+parse.
+    existing_rows_by_doc: dict[str, list[dict]] = {}
+    existing_last_updated_by_doc: dict[str, str] = {}
+    if output_csv.exists():
+        with open(output_csv, "r", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                doc_id = row.get("document_id") or ""
+                if not doc_id:
+                    continue
+                existing_rows_by_doc.setdefault(doc_id, []).append(row)
+                # All rows for the same document share the same file_last_updated;
+                # last writer wins but they should be identical.
+                existing_last_updated_by_doc[doc_id] = row.get("file_last_updated") or ""
+
+    reused_doc_count = 0
+    downloaded_doc_count = 0
+
     fieldnames = [
         "upstream_hash",
         "doc_kind",                # "committee" | "plenum"
@@ -257,10 +282,28 @@ def process_knesset_protocols_source(
     failures = 0
 
     def _process_doc(row: dict, kind: str, doc_id_field: str, sess_id_field: str):
-        nonlocal failures
+        nonlocal failures, reused_doc_count, downloaded_doc_count
         url = row.get("FilePath") or ""
         if not url.lower().endswith((".doc", ".docx")):
             return
+        doc_id = row.get(doc_id_field) or ""
+        upstream_last_updated = row.get("LastUpdatedDate") or ""
+        # Per-document cache hit: reuse the existing per-turn rows verbatim,
+        # only updating upstream_hash so the file's internal consistency
+        # marker reflects the current run. No download, no parse.
+        if (
+            doc_id
+            and doc_id in existing_rows_by_doc
+            and upstream_last_updated
+            and existing_last_updated_by_doc.get(doc_id) == upstream_last_updated
+        ):
+            for cached in existing_rows_by_doc[doc_id]:
+                refreshed = dict(cached)
+                refreshed["upstream_hash"] = upstream_hash
+                out_rows.append(refreshed)
+            reused_doc_count += 1
+            return
+        downloaded_doc_count += 1
         body = _download(url, timeout=_http_timeout)
         if rate_limit_seconds > 0:
             time.sleep(rate_limit_seconds)
@@ -333,4 +376,9 @@ def process_knesset_protocols_source(
     logger.info(
         "Wrote %d turn rows from %d documents (%d failures) to %s [hash=%s]",
         len(out_rows), total - failures, failures, output_csv, upstream_hash,
+    )
+    logger.info(
+        "KNESSET_PROTOCOLS_CACHE_SUMMARY: reused=%d downloaded=%d failures=%d "
+        "total_upstream=%d",
+        reused_doc_count, downloaded_doc_count, failures, total,
     )

--- a/tests/document_parser/knesset_protocols/test_process_protocols.py
+++ b/tests/document_parser/knesset_protocols/test_process_protocols.py
@@ -260,3 +260,112 @@ def test_skips_non_doc_paths(mock_requests, tmp_path, fixed_now,
     )
     rows = list(csv.DictReader(out.open(encoding="utf-8")))
     assert all(r["document_id"] == "2" for r in rows)
+
+
+# -----------------------------------------------------------------------------
+# Per-document delta — 2026-05-19 follow-up to the wikitext per-source cache
+# -----------------------------------------------------------------------------
+
+@patch.object(process_protocols, "requests")
+def test_per_doc_delta_reuses_rows_when_last_updated_unchanged(
+    mock_requests, tmp_path, fixed_now, sample_committee_doc,
+):
+    """One run downloads + parses. Second run with the SAME LastUpdatedDate
+    but a different upstream_hash (e.g. a new doc was added elsewhere) must
+    reuse the per-turn rows for doc 1 without re-downloading."""
+    out = tmp_path / "knesset_protocols.csv"
+
+    # Run 1: two committees uploaded, both fresh → 2 OData calls (committees +
+    # plenum) + 2 .doc downloads = 4 GETs.
+    mock_requests.get.side_effect = [
+        _odata_response([_committee_index(1, last="2026-04-01T00:00:00"),
+                         _committee_index(2, last="2026-04-01T00:00:00")]),
+        _odata_response([]),
+        _doc_response(sample_committee_doc),
+        _doc_response(sample_committee_doc),
+    ]
+    process_protocols.process_knesset_protocols_source(
+        output_csv_path=out, base_url="https://example.test/Odata/x.svc",
+        days_history=30, max_protocols=10, rate_limit_seconds=0,
+        now=fixed_now,
+    )
+    rows_after_run1 = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert {r["document_id"] for r in rows_after_run1} == {"1", "2"}
+    run1_calls = mock_requests.get.call_count
+    assert run1_calls == 4
+
+    # Run 2: doc 1 unchanged, doc 2 unchanged, but a THIRD doc appears with
+    # a different LastUpdatedDate → upstream_hash differs (so the coarse
+    # short-circuit doesn't kick in), but docs 1+2 should be reused.
+    # Expected new downloads: only doc 3.
+    mock_requests.get.side_effect = [
+        _odata_response([_committee_index(1, last="2026-04-01T00:00:00"),
+                         _committee_index(2, last="2026-04-01T00:00:00"),
+                         _committee_index(3, last="2026-05-19T00:00:00")]),
+        _odata_response([]),
+        _doc_response(sample_committee_doc),  # only doc 3 expected
+    ]
+    process_protocols.process_knesset_protocols_source(
+        output_csv_path=out, base_url="https://example.test/Odata/x.svc",
+        days_history=30, max_protocols=10, rate_limit_seconds=0,
+        now=fixed_now,
+    )
+    # The mock list was the per-call return values. If our code tried to
+    # download more than once (e.g. all three), it would exhaust the list
+    # and raise StopIteration. Reaching here means we made exactly one
+    # download in run 2.
+    rows_after_run2 = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert {r["document_id"] for r in rows_after_run2} == {"1", "2", "3"}
+    # The CSV's upstream_hash must reflect the NEW run's hash uniformly —
+    # reused rows had their upstream_hash refreshed.
+    hashes = {r["upstream_hash"] for r in rows_after_run2}
+    assert len(hashes) == 1, f"upstream_hash should be uniform, got {hashes}"
+
+
+@patch.object(process_protocols, "requests")
+def test_per_doc_delta_redownloads_when_last_updated_changed(
+    mock_requests, tmp_path, fixed_now, sample_committee_doc,
+):
+    """A document whose LastUpdatedDate changed → re-downloaded + re-parsed."""
+    out = tmp_path / "knesset_protocols.csv"
+
+    # Run 1: one committee at older timestamp.
+    mock_requests.get.side_effect = [
+        _odata_response([_committee_index(1, last="2026-04-01T00:00:00")]),
+        _odata_response([]),
+        _doc_response(sample_committee_doc),
+    ]
+    process_protocols.process_knesset_protocols_source(
+        output_csv_path=out, base_url="https://example.test/Odata/x.svc",
+        days_history=30, max_protocols=10, rate_limit_seconds=0,
+        now=fixed_now,
+    )
+
+    # Run 2: same doc_id, BUT LastUpdatedDate bumped + a sibling new doc to
+    # force the upstream_hash to differ. Expect doc 1 to be re-downloaded.
+    fresh_doc = _make_doc([
+        (None, "מישיבת ועדת הכספים"),
+        ("נושא", "<< נושא >> נושא מעודכן"),
+        ("יור", '<< יור >> היו"ר חבר חדש: << יור >>'),
+        (None, "טקסט חדש."),
+    ])
+    mock_requests.get.side_effect = [
+        _odata_response([_committee_index(1, last="2026-05-19T10:00:00")]),
+        _odata_response([]),
+        _doc_response(fresh_doc),
+    ]
+    process_protocols.process_knesset_protocols_source(
+        output_csv_path=out, base_url="https://example.test/Odata/x.svc",
+        days_history=30, max_protocols=10, rate_limit_seconds=0,
+        now=fixed_now,
+    )
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    # The new chair name appears in the rewritten rows.
+    chair_rows = [r for r in rows if r["speaker_role"] == "chair"]
+    assert chair_rows, "expected at least one chair row"
+    assert any("חבר חדש" in r["speaker_name"] for r in chair_rows), (
+        f"expected fresh chair name in re-parsed rows, got "
+        f"{[r['speaker_name'] for r in chair_rows]}"
+    )
+    # And LastUpdatedDate is the new one.
+    assert {r["file_last_updated"] for r in rows} == {"2026-05-19T10:00:00"}


### PR DESCRIPTION
## Summary

Closes the last "downloads everything" hole in the daily fap. Until this PR, when even ONE Knesset protocol changed upstream (one new session uploaded, or one existing protocol re-edited), the existing coarse `upstream_hash` short-circuit fell through and the fetcher re-downloaded + re-parsed ALL ~13K committee + plenum `.doc` files.

Per-document delta key: `(document_id, file_last_updated)`. Both fields come straight from the OData index. Documents whose `LastUpdatedDate` matches what's already on disk reuse the existing per-turn rows verbatim (only refreshing `upstream_hash`). New documents and changed ones go through the existing download → parse path.

**Cost shape change:**
- Today: one new protocol per day → 13K downloads (~10-20 min, hundreds of MB of network traffic)
- After this PR: one new protocol per day → 1 download (under a minute)
- `KNESSET_PROTOCOLS_CACHE_SUMMARY: reused=X downloaded=Y failures=Z total_upstream=N` log line for observability.

Companion to `#170` (extraction-cache delta) and `#171` (wikitext per-source cache). Together: the daily refresh in steady state does ~0 LLM calls and ~0 redundant downloads.

## Test plan

- [x] `test_per_doc_delta_reuses_rows_when_last_updated_unchanged` — adds a new doc to an existing CSV; only the new doc is downloaded (mock side_effect list deliberately too short to allow extra downloads → StopIteration if delta is wrong).
- [x] `test_per_doc_delta_redownloads_when_last_updated_changed` — bumps `LastUpdatedDate`; that doc IS re-downloaded and the fresh content replaces the cached rows.
- [x] 7 existing tests still pass (hash short-circuit, empty-upstream, filter shape, failure isolation, max-protocols cap, non-doc skip).
- [ ] Staging: after deploy, manual `POST /admin/refresh` → expect `KNESSET_PROTOCOLS_CACHE_SUMMARY` line with `reused=~13000, downloaded=≤N_new` (the first refresh after upgrade will see all existing docs as cache hits since their `file_last_updated` columns are already populated in the CSV).
- [ ] Prod: same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
