### PR TITLE
fix(sync): drop per-run bookkeeping columns from CSV content_hash (the real $40/day cause)

### DIFF
--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -105,6 +105,25 @@ _SOURCE_URL_LINE_RE = re.compile(
 _SOURCE_URL_ALIASES = frozenset({"source_url", "file_url", "url"})
 _METADATA_ONLY_CSV_COLUMNS = frozenset({"source_url", "file_url", "url", "lexicon_url"})
 
+# Per-run / per-source provenance bookkeeping columns written by the
+# fetchers — NOT real document content. They MUST be dropped before the
+# CSV row is flattened into markdown, for two reasons:
+#
+#  1. They'd pollute the embedding with meaningless hash/revision strings.
+#  2. Far worse — they change the chunk's content_hash on every refresh
+#     where the upstream moved at all. `knesset_protocols.csv` carries an
+#     `upstream_hash` column = a hash of the *entire* OData index, so it
+#     rotates whenever ANY protocol is added or edited (i.e. essentially
+#     daily). With ~100K rows that means ~100K permanent extraction-cache
+#     misses every single day — the cache can never warm. The PDF CSVs
+#     carry `upstream_revision` / `revision` with the same failure mode.
+#
+# These columns stay in the CSV file itself (the fetchers' own delta
+# logic reads them) — they're only excluded from the flattened content
+# the sync pipeline hashes + embeds. Dropped entirely, not kept as
+# metadata: the bot has no use for them.
+_BOOKKEEPING_CSV_COLUMNS = frozenset({"upstream_hash", "upstream_revision", "revision"})
+
 
 def _extract_source_url(content: str) -> str | None:
     """Return the first https?:// URL found under a URL-typed column, or None."""
@@ -438,6 +457,10 @@ def _collect_raw_streams_csv(config_dir, context_name, source, offset=0):
             content = ''
             extra_meta: dict = {}
             for k, v in row.items():
+                if k in _BOOKKEEPING_CSV_COLUMNS:
+                    # Per-run provenance — never enters content or metadata.
+                    # See _BOOKKEEPING_CSV_COLUMNS for why this is critical.
+                    continue
                 if k in _METADATA_ONLY_CSV_COLUMNS:
                     if v:
                         # ``source_url`` / ``file_url`` / ``url`` are

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -151,3 +151,76 @@ def test_lexicon_url_column_is_metadata_only(tmp_path):
     assert extra_meta["source_url"] == (
         "https://he.wikisource.org/wiki/תקנון_הכנסת#סעיף_137"
     )
+
+
+# -----------------------------------------------------------------------------
+# Bookkeeping columns must not poison content_hash — 2026-05-20 fix
+# -----------------------------------------------------------------------------
+
+import hashlib as _hashlib  # noqa: E402
+
+
+def test_csv_collector_drops_upstream_hash_from_content(tmp_path):
+    """knesset_protocols' upstream_hash column is per-run provenance; it must
+    NOT appear in the flattened content (would poison content_hash daily)."""
+    csv_path = tmp_path / "kp.csv"
+    _write_csv(csv_path, [
+        {
+            "upstream_hash": "a" * 64,
+            "document_id": "537",
+            "speaker_name": "ישראל ישראלי",
+            "turn_text": "טקסט הדיון",
+        },
+    ])
+    out = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "kp.csv")
+    fname, content, ctype, extra_meta = out[0]
+    assert "upstream_hash" not in content
+    assert "a" * 64 not in content
+    # Real content survives.
+    assert "speaker_name:\nישראל ישראלי" in content
+    assert "turn_text:\nטקסט הדיון" in content
+    # Bookkeeping is dropped entirely — not parked in metadata either.
+    assert "upstream_hash" not in extra_meta
+
+
+def test_csv_content_hash_stable_across_upstream_hash_change(tmp_path):
+    """The core regression: two CSVs identical except for upstream_hash must
+    produce byte-identical flattened content → identical content_hash. This
+    is what lets the extraction cache actually hit for knesset_protocols."""
+    row_a = {
+        "upstream_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+        "document_id": "537",
+        "turn_text": "אותו הטקסט בדיוק",
+    }
+    row_b = dict(row_a, upstream_hash="2222222222222222222222222222222222222222222222222222222222222222")
+
+    csv_a = tmp_path / "a.csv"
+    csv_b = tmp_path / "b.csv"
+    _write_csv(csv_a, [row_a])
+    _write_csv(csv_b, [row_b])
+
+    content_a = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "a.csv")[0][1]
+    content_b = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "b.csv")[0][1]
+
+    assert content_a == content_b, "content must not vary with upstream_hash"
+    h = lambda s: _hashlib.sha256(s.strip().encode("utf-8")).hexdigest()
+    assert h(content_a) == h(content_b)
+
+
+def test_csv_collector_drops_pdf_revision_columns(tmp_path):
+    """PDF CSVs carry `revision` + `upstream_revision` — same poison, dropped."""
+    csv_path = tmp_path / "pdf.csv"
+    _write_csv(csv_path, [
+        {
+            "revision": "v7",
+            "upstream_revision": "2026-05-20T03:00:00",
+            "מספר_מסמך": "2024/123",
+            "טקסט_מלא": "תוכן המסמך",
+        },
+    ])
+    out = _collect_raw_streams_csv(tmp_path, "legal_advisor_opinions", "pdf.csv")
+    fname, content, ctype, extra_meta = out[0]
+    assert "revision" not in content
+    assert "upstream_revision" not in content
+    assert "v7" not in content
+    assert "טקסט_מלא:\nתוכן המסמך" in content


### PR DESCRIPTION
## Summary

**This is the real cause of the ~$40/day `gpt-4o-mini` bill** the operator flagged on 2026-05-20.

The extraction-cache delta (#170) and per-doc deltas (#171, #172) all work — but were structurally defeated for every CSV-sourced context by a `content_hash` poisoning bug.

`_collect_raw_streams_csv` flattens every CSV column into the markdown `content` that gets both embedded AND sha256'd into the extraction-cache key — except 4 URL columns. `knesset_protocols.csv` carries an `upstream_hash` column: a sha256 of the **entire OData index**, written identically into all ~104K rows, rotating whenever *any* protocol changes upstream (≈ daily).

→ Every knesset_protocols chunk's `content_hash` rotated daily → guaranteed extraction-cache miss for all ~104K rows every refresh → ~104K uncapped `gpt-4o-mini` calls/env/day. (The rewarm budget can't help — these are `llm_misses`, not stale-version hits.)

**Verified empirically:** a 5000-row sample of prod `knesset_protocols.csv` shows `upstream_hash` with exactly **1 distinct value** across all rows. PDF CSVs have the same bug via `revision` + `upstream_revision`.

**Fix:** `_BOOKKEEPING_CSV_COLUMNS = {upstream_hash, upstream_revision, revision}` are dropped before flattening — not embedded, not hashed, not kept as metadata. The CSV files keep every column (the fetchers' delta logic still reads them).

## Cost impact

| | Without fix | With fix |
|---|---|---|
| First refresh after deploy | $40 | $40 (one-time — content_hash changes once) |
| Every subsequent day | **$40** | **~$0** (cache finally warms + stays warm) |

## Test plan

- [x] `tests/test_collect_sources.py` — 13 pass incl. 3 new: `upstream_hash` dropped from content; `content_hash` byte-identical across CSVs differing only in `upstream_hash` (the core regression); `revision`/`upstream_revision` dropped for PDF CSVs.
- [ ] Staging + prod: after deploy, the first daily refresh re-extracts CSV contexts one final time; the *following* day's `EXTRACTION_CACHE_SUMMARY` for `knesset_protocols` should show `exact_hits` ≈ total rows, `llm_misses` ≈ only genuinely-new protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
