### PR TITLE
feat(sync): per-run circuit breaker on total extraction LLM calls

### DIFF
--- a/botnim/_concurrency.py
+++ b/botnim/_concurrency.py
@@ -33,6 +33,16 @@ logger = get_logger(__name__)
 
 DEFAULT_SYNC_CONCURRENCY = 10
 DEFAULT_REWARM_BUDGET = 2000
+# Per-context hard ceiling on TOTAL extraction LLM calls (rewarms + misses).
+# Defense-in-depth circuit breaker: the rewarm budget only caps the
+# stale→current re-warm path; genuinely-new chunks (llm_misses) are
+# otherwise uncapped. A content_hash-instability bug (see the 2026-05-20
+# `upstream_hash` poison fix) can route an entire corpus through the miss
+# path. 15000 sits above a legitimate cold-start of the largest context
+# (knesset_protocols, ~13K rows — which RPD-outs at ~10K/day anyway) and
+# well below a runaway (~104K). Tripping it is an alert, not a steady
+# state — it means "investigate", not "this is fine".
+DEFAULT_LLM_CALL_CEILING = 15000
 
 
 def get_sync_concurrency() -> int:
@@ -89,6 +99,31 @@ def get_rewarm_budget() -> int:
     return value
 
 
+def get_llm_call_ceiling() -> int:
+    """Read the per-context total-LLM-call circuit-breaker ceiling.
+
+    Caps rewarms + llm_misses combined. ``0`` disables the breaker
+    (uncapped — the pre-2026-05-20 behavior). See DEFAULT_LLM_CALL_CEILING.
+    """
+    raw = os.environ.get("EXTRACTION_MAX_LLM_CALLS_PER_RUN", "").strip()
+    if not raw:
+        return DEFAULT_LLM_CALL_CEILING
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "EXTRACTION_MAX_LLM_CALLS_PER_RUN=%r is not an int; falling back to %d",
+            raw, DEFAULT_LLM_CALL_CEILING,
+        )
+        return DEFAULT_LLM_CALL_CEILING
+    if value < 0:
+        logger.warning(
+            "EXTRACTION_MAX_LLM_CALLS_PER_RUN=%d is < 0; clamping to 0", value,
+        )
+        return 0
+    return value
+
+
 class SyncConcurrency:
     """Shared per-run gating primitives.
 
@@ -101,6 +136,7 @@ class SyncConcurrency:
         self,
         concurrency: int | None = None,
         rewarm_budget: int | None = None,
+        llm_call_ceiling: int | None = None,
     ) -> None:
         self.concurrency = concurrency if concurrency is not None else get_sync_concurrency()
         # Bounds in-flight OpenAI calls (extraction + embeddings share this).
@@ -129,6 +165,17 @@ class SyncConcurrency:
         # asyncio.run() event loop closes mid-LLM-call and the tasks get
         # cancelled — leaving rewarmed_count=0 even though budget was taken.
         self.rewarm_tasks: list[asyncio.Task] = []
+        # Circuit breaker: hard ceiling on TOTAL extraction LLM calls
+        # (rewarms + misses) for this run. Defense-in-depth against a
+        # content_hash-instability bug routing a whole corpus through the
+        # uncapped llm_miss path. See get_llm_call_ceiling() / llm_call_permit().
+        self._llm_call_ceiling = (
+            llm_call_ceiling if llm_call_ceiling is not None else get_llm_call_ceiling()
+        )
+        self._llm_calls_made = 0
+        self._llm_lock = asyncio.Lock()
+        self.circuit_broken = False
+
         # Observability counters — written by _get_metadata_for_content_async
         # and _rewarm_extraction; read at end-of-run for the
         # EXTRACTION_CACHE_SUMMARY log line.
@@ -136,6 +183,40 @@ class SyncConcurrency:
         self.stale_served_count = 0
         self.rewarmed_count = 0
         self.llm_miss_count = 0
+        self.circuit_skipped_count = 0
+
+    async def llm_call_permit(self) -> bool:
+        """Atomically claim a slot from the per-run total-LLM-call ceiling.
+
+        Returns ``True`` if an extraction LLM call may proceed, ``False``
+        if the circuit breaker has tripped (caller must NOT make the call;
+        it serves stale if it can, else returns an error metadata record).
+
+        A ceiling of 0 disables the breaker entirely (uncapped). The first
+        trip logs a loud EXTRACTION_CIRCUIT_BREAKER line — it means a bug,
+        not a steady state.
+        """
+        if self._llm_call_ceiling <= 0:
+            return True
+        async with self._llm_lock:
+            if self._llm_calls_made >= self._llm_call_ceiling:
+                if not self.circuit_broken:
+                    self.circuit_broken = True
+                    logger.error(
+                        "EXTRACTION_CIRCUIT_BREAKER: hit %d LLM-call ceiling for "
+                        "this run — remaining chunks served stale or skipped. "
+                        "This indicates content_hash churn or a cold corpus far "
+                        "larger than expected; investigate before the next refresh.",
+                        self._llm_call_ceiling,
+                    )
+                return False
+            self._llm_calls_made += 1
+            return True
+
+    @property
+    def llm_calls_made(self) -> int:
+        """Read-only view of LLM calls consumed — for summary logs."""
+        return self._llm_calls_made
 
     async def rewarm_budget_take(self) -> bool:
         """Atomically decrement the per-run re-warm budget.

--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -258,8 +258,18 @@ async def _get_metadata_for_content_async(
 
             return payload
 
-    # Full miss. Bounded LLM call.
+    # Full miss — no cache row at any version. Circuit breaker: if this
+    # run has already burned its total-LLM-call ceiling, do NOT make the
+    # call. There's no older version to fall back to, so the chunk gets a
+    # minimal error metadata record and is picked up by a future run.
+    # This bounds the cost of a content_hash-instability bug.
     concurrency.llm_miss_count += 1
+    if not await concurrency.llm_call_permit():
+        concurrency.circuit_skipped_count += 1
+        return _build_metadata_record(
+            content, file_path, document_type, None,
+            RuntimeError("extraction skipped: per-run LLM-call ceiling reached"),
+        )
     try:
         extracted_data = await concurrency.run_bounded(
             extract_structured_content_async,
@@ -323,6 +333,12 @@ async def _rewarm_extraction(
     from .dynamic_extraction import (
         EXTRACTION_VERSION, RpdExhausted, extract_structured_content_async,
     )
+    # Circuit breaker: a re-warm is an LLM call too. If the run's total
+    # ceiling is reached, skip — the stale payload was already served to
+    # the sync caller, so skipping the re-warm is harmless (the row stays
+    # at the older version and is retried on a future run).
+    if not await concurrency.llm_call_permit():
+        return
     try:
         extracted = await concurrency.run_bounded(
             extract_structured_content_async,
@@ -616,13 +632,17 @@ def collect_context_sources(context_, config_dir: Path, *, bot=None, extraction_
     logger.info(
         "EXTRACTION_CACHE_SUMMARY: bot=%s context=%s "
         "exact_hits=%d stale_served=%d rewarmed=%d llm_misses=%d "
-        "rewarm_budget_remaining=%d",
+        "rewarm_budget_remaining=%d llm_calls_made=%d circuit_skipped=%d "
+        "circuit_broken=%s",
         bot or '?', context_slug,
         concurrency.exact_hits_count,
         concurrency.stale_served_count,
         concurrency.rewarmed_count,
         concurrency.llm_miss_count,
         concurrency.rewarm_budget_remaining,
+        concurrency.llm_calls_made,
+        concurrency.circuit_skipped_count,
+        concurrency.circuit_broken,
     )
     return result
 

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -439,6 +439,73 @@ async def test_collect_serves_stale_payload_and_schedules_rewarm(cache, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_llm_call_permit_caps_total_calls():
+    """The circuit breaker caps total LLM calls (rewarms + misses)."""
+    sc = SyncConcurrency(llm_call_ceiling=3)
+    assert await sc.llm_call_permit() is True   # 1
+    assert await sc.llm_call_permit() is True   # 2
+    assert await sc.llm_call_permit() is True   # 3
+    assert await sc.llm_call_permit() is False  # ceiling hit
+    assert await sc.llm_call_permit() is False
+    assert sc.circuit_broken is True
+    assert sc.llm_calls_made == 3
+
+
+@pytest.mark.asyncio
+async def test_llm_call_permit_zero_ceiling_disables_breaker():
+    """ceiling=0 → uncapped (pre-2026-05-20 behavior)."""
+    sc = SyncConcurrency(llm_call_ceiling=0)
+    for _ in range(50):
+        assert await sc.llm_call_permit() is True
+    assert sc.circuit_broken is False
+
+
+@pytest.mark.asyncio
+async def test_collect_circuit_breaker_skips_misses_past_ceiling(cache, tmp_path):
+    """With a tiny ceiling, llm_misses past the ceiling are skipped (no LLM
+    call) and return an error metadata record instead of blowing the budget."""
+    # 4 distinct CSV rows → 4 never-cached chunks → 4 llm_misses.
+    csv_path = tmp_path / "src.csv"
+    csv_path.write_text(
+        "body\nalpha-uncached\nbeta-uncached\ngamma-uncached\ndelta-uncached\n",
+        encoding="utf-8",
+    )
+    context_ = {"name": "ctx_cb", "slug": "ctx_cb", "type": "csv",
+                "source": "src.csv", "fetcher": None}
+
+    import shutil
+    repo_root = Path(__file__).resolve().parent.parent
+    (repo_root / "cache" / "metadata.sqlite").unlink(missing_ok=True)
+    shutil.rmtree(repo_root / "cache" / "metadata", ignore_errors=True)
+
+    llm_calls = {"n": 0}
+    async def _fake_completion(client, system_message):
+        llm_calls["n"] += 1
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=MagicMock(
+            content='{"DocumentMetadata": {"DocumentTitle": "x"}}'
+        ))]
+        return resp
+
+    # ceiling=2 → only the first 2 misses get an LLM call; the other 2 skipped.
+    concurrency = SyncConcurrency(llm_call_ceiling=2)
+    with patch("botnim.dynamic_extraction._async_chat_completion_inner", side_effect=_fake_completion):
+        streams = await collect_context_sources_async(
+            context_, tmp_path, concurrency,
+            bot="unified", extraction_cache=cache,
+        )
+
+    assert len(streams) == 4
+    assert llm_calls["n"] == 2, f"ceiling=2 must cap LLM calls at 2, got {llm_calls['n']}"
+    assert concurrency.circuit_broken is True
+    assert concurrency.llm_miss_count == 4
+    assert concurrency.circuit_skipped_count == 2
+    # The 2 skipped chunks still produced a (degraded) metadata record.
+    statuses = [m.get("status") for _, _, _, m in streams]
+    assert statuses.count("extraction_error") == 2
+
+
+@pytest.mark.asyncio
 async def test_collect_zero_budget_serves_stale_without_rewarm(cache, tmp_path):
     """budget=0: stale payload served, no LLM call scheduled."""
     csv_value = "zero-budget-content"


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #173 (the `upstream_hash` content_hash poison fix).

#173 fixed the *cause* of the ~$40/day `gpt-4o-mini` bill. This adds a *backstop* so the next poison-class bug costs ~$3-6 and a loud log line instead of $40/day of silence.

The rewarm budget (#170) only caps the stale→current re-warm path. Genuinely-new chunks (`llm_misses`) were uncapped — and a content_hash-instability bug routes an entire corpus through exactly that path. There was no hard ceiling on **total** extraction LLM calls per run.

This adds `SyncConcurrency.llm_call_permit()` — a per-context ceiling counting rewarms + misses combined:
- `DEFAULT_LLM_CALL_CEILING = 15000`, env-overridable via `EXTRACTION_MAX_LLM_CALLS_PER_RUN` (0 = disabled). Sits above a legitimate cold-start of the largest context (`knesset_protocols` ~13K, RPD-bound at ~10K/day) and well below a runaway (~104K).
- Past the ceiling: `llm_misses` get a minimal error metadata record (retried next run); `_rewarm_extraction` skips (stale payload already served).
- First trip logs a loud `EXTRACTION_CIRCUIT_BREAKER` error — a CloudWatch metric filter on it is the alert. Tripping means a bug, not a steady state.
- `EXTRACTION_CACHE_SUMMARY` now also logs `llm_calls_made`, `circuit_skipped`, `circuit_broken`.

## Test plan

- [x] `tests/test_extraction_cache.py` — `llm_call_permit` caps total calls; `ceiling=0` disables; `collect_context_sources_async` with `ceiling=2` over 4 uncached chunks → exactly 2 LLM calls, 2 `circuit_skipped`, `circuit_broken=True`.
- [x] `test_collect_sources.py` (13) + `test_extraction_cache.py` (21) pass in isolation. Combined-with-`test_query_error_handling.py` failure is the pre-existing `sys.modules` isolation bug, unrelated.
- [ ] Prod: deploy + trigger a fap-sync; `EXTRACTION_CACHE_SUMMARY` should show `circuit_broken=False` and (post-#173) `knesset_protocols` `exact_hits` ≈ total rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
