### PR TITLE
fix(sync): content-hash reconcile in upload_files — stop full re-embed every sync

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -331,6 +331,10 @@ class VectorStoreAurora(VectorStoreBase):
         successful = 0  # row count, not file count
         skipped = 0
         files_seen = 0
+        # Every chunk content_hash this run produces (whether skipped as
+        # unchanged or freshly inserted). Used after the upload pass to
+        # delete rows whose content the run no longer produces.
+        seen_hashes: set[str] = set()
 
         # Per-context chunking — see _CHUNK_*_DEFAULT for rationale.
         # `context` here is the parsed YAML entry for this slug, so it carries
@@ -373,6 +377,7 @@ class VectorStoreAurora(VectorStoreBase):
                 for chunk_index, chunk_content in enumerate(chunks):
                     try:
                         chunk_hash = hashlib.sha256(chunk_content.encode("utf-8")).hexdigest()
+                        seen_hashes.add(chunk_hash)
 
                         # Content-hash skip: if this exact (context_id, content_hash)
                         # is already present, do nothing.
@@ -420,6 +425,42 @@ class VectorStoreAurora(VectorStoreBase):
                         skipped += 1
                         continue
 
+            # Reconcile: delete rows whose content this run did NOT produce
+            # — i.e. stale chunks of edited files and chunks of orphaned
+            # files. Runs AFTER the upload pass so the content-hash skip
+            # above can reuse unchanged rows (this replaces the old
+            # filename-based delete_existing_files, which ran BEFORE upload
+            # and wiped the rows the skip relied on).
+            #
+            # Safety guard: if the run produced zero chunks (empty or failed
+            # collection), skip the delete entirely — a transient upstream
+            # failure must never wipe an entire context.
+            if seen_hashes:
+                sess.execute(text(
+                    "CREATE TEMP TABLE _seen_hashes (h text PRIMARY KEY) "
+                    "ON COMMIT DROP"
+                ))
+                sess.execute(text(
+                    "INSERT INTO _seen_hashes (h) "
+                    "SELECT DISTINCT unnest(CAST(:hs AS text[]))"
+                ), {"hs": list(seen_hashes)})
+                reconcile = sess.execute(text(
+                    "DELETE FROM documents WHERE context_id = :cid "
+                    "AND content_hash NOT IN (SELECT h FROM _seen_hashes)"
+                ), {"cid": cid})
+                orphaned = reconcile.rowcount or 0
+                logger.info(
+                    "Reconcile: removed %d stale/orphan rows for context_id=%s "
+                    "(%d distinct content hashes kept this run)",
+                    orphaned, cid, len(seen_hashes),
+                )
+            else:
+                logger.warning(
+                    "upload_files produced 0 chunks for context_id=%s — skipping "
+                    "orphan reconcile so a transient empty run cannot wipe the "
+                    "context.", cid,
+                )
+
         if callable(callback):
             callback(successful)
         if skipped:
@@ -434,16 +475,23 @@ class VectorStoreAurora(VectorStoreBase):
             )
 
     def delete_existing_files(self, context_, vector_store, file_names):
-        """Delete documents whose metadata.filename matches any in file_names.
-        Returns the count of deleted rows.
+        """No-op — superseded by content-hash reconciliation in upload_files.
+
+        The previous implementation ran a filename-based DELETE *before*
+        upload_files. Because csv-type contexts name files positionally
+        (``<context>_0.md`` … ``_N.md``), every run's file list matched
+        every existing row, so this deleted the entire context — which in
+        turn defeated upload_files' content-hash skip (the rows it would
+        have reused were already gone), forcing a full re-embed of the
+        whole corpus on every sync (~$0.55/day for knesset_protocols
+        alone, even with no upstream changes).
+
+        upload_files now keeps unchanged chunks via the content-hash skip
+        and deletes only genuinely stale/orphan rows in a reconcile pass
+        AFTER the upload. This method is kept because the base
+        orchestrator calls it, but it intentionally does nothing.
         """
-        cid = vector_store
-        with get_session() as sess:
-            result = sess.execute(text(
-                "DELETE FROM documents "
-                "WHERE context_id = :cid AND metadata->>'filename' = ANY(:names)"
-            ), {"cid": cid, "names": list(file_names)})
-            return result.rowcount
+        return 0
 
     def _recency_search(
         self,

--- a/tests/test_vector_store_aurora.py
+++ b/tests/test_vector_store_aurora.py
@@ -213,7 +213,14 @@ def test_upload_files_skips_non_markdown(aurora_db, monkeypatch):
     assert fake.call_count == 0
 
 
-def test_delete_existing_files_removes_by_filename(aurora_db, monkeypatch):
+def test_delete_existing_files_is_noop(aurora_db, monkeypatch):
+    """delete_existing_files is now a no-op.
+
+    Its old filename-based DELETE ran before upload_files and wiped every
+    row for the current run's files — defeating upload_files' content-hash
+    skip and forcing a full re-embed every sync. Reconciliation now lives
+    in upload_files (see test_upload_files_reconciles_stale_and_orphan_rows).
+    """
     from botnim.vector_store.vector_store_aurora import VectorStoreAurora
     from botnim.db.session import get_engine
 
@@ -234,7 +241,7 @@ def test_delete_existing_files_removes_by_filename(aurora_db, monkeypatch):
     store.upload_files({"slug": "x"}, "x", cid, streams, lambda n: None)
 
     deleted = store.delete_existing_files({"slug": "x"}, cid, ["drop.md"])
-    assert deleted == 1
+    assert deleted == 0  # no-op — deletes nothing
 
     eng = get_engine()
     with eng.connect() as conn:
@@ -242,7 +249,84 @@ def test_delete_existing_files_removes_by_filename(aurora_db, monkeypatch):
             "SELECT (metadata->>'filename') FROM documents WHERE context_id=:cid"
         ), {"cid": cid}).fetchall()
     names = {r[0] for r in rows}
-    assert names == {"keep.md"}
+    assert names == {"keep.md", "drop.md"}  # nothing deleted
+
+
+def test_upload_files_reconciles_stale_and_orphan_rows(aurora_db, monkeypatch):
+    """upload_files deletes rows whose content the run no longer produces:
+    stale chunks of an edited file + chunks of an orphaned (removed) file.
+    Unchanged content is kept (skip), new content is inserted."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.db.session import get_engine
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "x"}, "x", False)
+    eng = get_engine()
+
+    def contents():
+        with eng.connect() as conn:
+            return {r[0] for r in conn.execute(text(
+                "SELECT content FROM documents WHERE context_id=:c"), {"c": cid}).fetchall()}
+
+    # run 1 — two files
+    store.upload_files({"slug": "x"}, "x", cid,
+                       _make_file_streams([("a.md", "alpha", {}), ("b.md", "beta", {})]),
+                       lambda n: None)
+    assert contents() == {"alpha", "beta"}
+    assert fake.call_count == 2
+
+    # run 2 — a.md edited, b.md removed (orphan), c.md new
+    store.upload_files({"slug": "x"}, "x", cid,
+                       _make_file_streams([("a.md", "alpha-v2", {}), ("c.md", "gamma", {})]),
+                       lambda n: None)
+    # 'alpha' (edited away) + 'beta' (orphan) reconciled out; new content embedded
+    assert contents() == {"alpha-v2", "gamma"}
+    assert fake.call_count == 4  # +2 new embeds, nothing else
+
+    # run 3 — identical to run 2: pure steady state, zero embeds, zero changes
+    store.upload_files({"slug": "x"}, "x", cid,
+                       _make_file_streams([("a.md", "alpha-v2", {}), ("c.md", "gamma", {})]),
+                       lambda n: None)
+    assert contents() == {"alpha-v2", "gamma"}
+    assert fake.call_count == 4  # unchanged — the steady-state $0 case
+
+
+def test_upload_files_empty_run_does_not_wipe_context(aurora_db, monkeypatch):
+    """Safety guard: an empty file_streams (transient collection failure)
+    must NOT trigger the reconcile delete — the context stays intact."""
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.db.session import get_engine
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    config = {"slug": "unified", "name": "Unified"}
+    store = VectorStoreAurora(config=config, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "x"}, "x", False)
+
+    store.upload_files({"slug": "x"}, "x", cid,
+                       _make_file_streams([("a.md", "alpha", {}), ("b.md", "beta", {})]),
+                       lambda n: None)
+    eng = get_engine()
+    with eng.connect() as conn:
+        before = conn.execute(text(
+            "SELECT count(*) FROM documents WHERE context_id=:c"), {"c": cid}).scalar()
+    assert before == 2
+
+    # empty run — the guard must skip the reconcile delete entirely
+    store.upload_files({"slug": "x"}, "x", cid, [], lambda n: None)
+    with eng.connect() as conn:
+        after = conn.execute(text(
+            "SELECT count(*) FROM documents WHERE context_id=:c"), {"c": cid}).scalar()
+    assert after == 2  # context intact — NOT wiped
 
 
 def _seed_documents(database_url, context_id, docs):


### PR DESCRIPTION
## Problem

`delete_existing_files` ran a **filename-based** `DELETE` *before* `upload_files`. For `type: csv` contexts the filenames are positional (`<context>_0.md` … `_N.md`), so every runs file list matched **every** existing row → the whole context was deleted each sync. That defeated `upload_files` content-hash skip (the rows it would have reused were already gone) → **the entire corpus re-embedded on every refresh**.

Measured on prod `knesset_protocols`: ~137K chunks (~30M tokens) re-embedded daily ≈ **$0.55/day (~$17/mo)**, even with zero upstream changes. A simulated next-run `delete_existing_files` would remove **136,885 / 137,104** rows.

## Fix

- `delete_existing_files` → **no-op** (kept; the base orchestrator still calls it).
- `upload_files` → keeps unchanged chunks via the content-hash skip, and deletes only genuinely **stale/orphan** rows in a reconcile pass **after** the upload (`content_hash NOT IN` the set produced this run).
- **Safety guard**: a run producing zero chunks skips the reconcile entirely — a transient empty/failed collection can never wipe a context.

Applies to all Aurora contexts, not just `knesset_protocols`.

## Verification

1. **Chunk-hash stability** — re-chunking todays prod CSV, all 4,000 sampled turn-rows chunks already present in `documents` (100%).
2. **Dry-run vs prod** — simulating the fixed `upload_files` against live prod data: skip 137,104 / embed **0** / reconcile-delete **0** → first-run cost **$0.00**, zero data change.
3. **Integration tests** (new, against a real per-test Postgres): reconcile removes stale + orphan rows; steady-state re-run embeds 0; empty run does **not** wipe the context; `delete_existing_files` no-op confirmed. Existing `upload_files` tests still green.

Note: `test_upload_files_chunks_oversize_content_into_multiple_rows` fails — verified **pre-existing** (fails identically on untouched `main`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)