### PR TITLE
ops(phoenix): pull image via prod ECR mirror, not public DockerHub

### DIFF
--- a/infra/live/prod/phoenix/terragrunt.hcl
+++ b/infra/live/prod/phoenix/terragrunt.hcl
@@ -157,6 +157,15 @@ inputs = {
   # silently rendered `arizephoenix/phoenix:<git-sha>` → CannotPullContainerError.
   phoenix_image_tag = "version-7.0.0"
 
+  # Pull from in-account ECR mirror (`mirror/phoenix`) instead of public
+  # DockerHub. On 2026-05-24 prod Phoenix entered a crashloop because Fargate's
+  # outbound NAT IP pool was hitting DockerHub's 100-pulls/6h anonymous limit;
+  # the registry started returning 429 toomanyrequests on every task placement.
+  # The mirror eliminates the DockerHub dependency. Same convention as the
+  # existing `mirror/mongo` and `mirror/meilisearch` repos in this account.
+  # Recipe to refresh the mirror image is in parlibot/CLAUDE.md.
+  phoenix_image_repository = "086879295714.dkr.ecr.il-central-1.amazonaws.com/mirror/phoenix"
+
   # Defense-in-depth: Phoenix must never be on the public internet.
   # The module already defaults this to false and enforces it via a validation
   # block; we repeat it here so this stack's intent is visible without reading

--- a/infra/modules/phoenix/main.tf
+++ b/infra/modules/phoenix/main.tf
@@ -280,7 +280,7 @@ resource "aws_ecs_task_definition" "phoenix" {
   container_definitions = jsonencode([
     {
       name  = "phoenix"
-      image = "arizephoenix/phoenix:${var.phoenix_image_tag}"
+      image = "${var.phoenix_image_repository}:${var.phoenix_image_tag}"
 
       portMappings = [
         {

--- a/infra/modules/phoenix/variables.tf
+++ b/infra/modules/phoenix/variables.tf
@@ -52,7 +52,21 @@ variable "phoenix_image_tag" {
   # used for botnim-api / librechat ECR images). When the names collided,
   # terragrunt silently rendered `arizephoenix/phoenix:<git-sha>` and the
   # Phoenix task failed with CannotPullContainerError every deploy.
-  description = "arizephoenix/phoenix Docker tag — pin to a known-good version"
+  description = "Phoenix Docker tag — pin to a known-good version"
+}
+
+variable "phoenix_image_repository" {
+  type        = string
+  default     = "arizephoenix/phoenix"
+  # On 2026-05-24 prod started failing CannotPullContainerError with 429
+  # toomanyrequests against registry-1.docker.io because Fargate's outbound
+  # NAT shares an IP pool with everyone else in the region, and DockerHub's
+  # unauthenticated rate limit (100 pulls / 6h / source IP) was being eaten
+  # by neighbours. Overriding this to an in-account ECR mirror
+  # (e.g. 086879295714.dkr.ecr.il-central-1.amazonaws.com/mirror/phoenix)
+  # eliminates the DockerHub dependency entirely. See parlibot/CLAUDE.md
+  # for the mirror-image recipe.
+  description = "Container image repository (without tag). Defaults to the public DockerHub repo; override to an ECR mirror when DockerHub rate limits are biting."
 }
 
 variable "aurora_security_group_id" {


### PR DESCRIPTION
## Summary

During the 2026-05-24 incident the prod phoenix ECS service entered a crashloop with `CannotPullContainerError` because Fargate's outbound NAT shares an IP pool with everyone else in `il-central-1`, and DockerHub's anonymous rate limit (100 pulls / 6h / source IP) was being eaten by neighbours. Every retry returned HTTP 429 `toomanyrequests` from `registry-1.docker.io/v2/arizephoenix/phoenix/manifests/...`.

Restoring Phoenix required eliminating the DockerHub dependency.

## What changed

- **`infra/modules/phoenix/variables.tf`** — new `phoenix_image_repository` input. Defaults to `arizephoenix/phoenix` (the existing public DockerHub path) so other consumers of this module are unaffected.
- **`infra/modules/phoenix/main.tf`** — container `image` is now `${phoenix_image_repository}:${phoenix_image_tag}`.
- **`infra/live/prod/phoenix/terragrunt.hcl`** — override the new var to `086879295714.dkr.ecr.il-central-1.amazonaws.com/mirror/phoenix`. Same `mirror/*` convention as the existing `mirror/mongo` and `mirror/meilisearch` repos in this account.

## Already applied to prod

This commit captures IaC state to match what was deployed during incident response — `phoenix-prod:3` task def is currently pulling from the ECR mirror and healthy. Without this commit there's drift between IaC and runtime, and a future `terragrunt apply` would revert prod back to the DockerHub path and re-trigger the rate limit.

## Mirror image was populated out-of-band

I pulled `arizephoenix/phoenix:version-7.0.0` (linux/amd64) and pushed to the new ECR repo `mirror/phoenix`. Future image upgrades follow the same flow:

```bash
docker pull --platform linux/amd64 arizephoenix/phoenix:version-X.Y.Z
docker tag arizephoenix/phoenix:version-X.Y.Z \
  086879295714.dkr.ecr.il-central-1.amazonaws.com/mirror/phoenix:version-X.Y.Z
docker push 086879295714.dkr.ecr.il-central-1.amazonaws.com/mirror/phoenix:version-X.Y.Z
```

Then bump `phoenix_image_tag` in the terragrunt config and apply.

## Staging unchanged

Staging hasn't observed the DockerHub rate-limit issue (different account, different NAT IPs). If it becomes a problem there we can apply the same override.

## Test plan

- [x] `terragrunt plan` from `infra/live/prod/phoenix` — clean (no drift after this PR merges)
- [x] Service is currently RUNNING with desired=1, healthy, on the ECR image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
