### PR TITLE
fix(sanity): runner accepts canonical env names ('production', not 'prod')

### DIFF
--- a/botnim/sanity/runner.py
+++ b/botnim/sanity/runner.py
@@ -35,11 +35,19 @@ _SANITY_PASSWORD = "rebuilding279602"
 
 
 def _urls_for_env(env: str) -> tuple[str, str]:
-    if env == "prod":
+    # Canonical env names match botnim.config.VALID_ENVIRONMENTS:
+    #   ['production', 'staging', 'local']
+    # The server.py route handler reads `os.environ['ENVIRONMENT']` and
+    # passes it through to run_sanity verbatim, so the names that arrive
+    # here MUST be the canonical ones. Historic acceptance of `"prod"`
+    # was a one-off that caused `ValueError: unknown env: production`
+    # in prod once LibreChat started setting ENVIRONMENT=production
+    # for its own AdminSanity dashboard filter.
+    if env == "production":
         return ("https://botnim.co.il", "https://botnim.build-up.team")
     if env == "staging":
         return ("https://botnim.co.il", "https://botnim.staging.build-up.team")
-    raise ValueError(f"unknown env: {env}")
+    raise ValueError(f"unknown env: {env!r} (expected one of: production, staging)")
 
 
 def run_sanity(*, env: str, db_url: str) -> str:

--- a/tests/sanity/test_runner.py
+++ b/tests/sanity/test_runner.py
@@ -17,6 +17,7 @@ from botnim.sanity.types import (
     CaptureResult,
     CaptureRow,
     GoldEntry,
+    SideCapture,
 )
 
 
@@ -34,8 +35,9 @@ def fake_pipeline(monkeypatch):
         return CaptureResult(rows=[CaptureRow(
             row=0, question="q", expected_behavior="e",
             must_not_contain=[], observed_notes="",
-            answer_old=Answer(text="old", ok=True),
-            answer_new=Answer(text="new", ok=True),
+            followup_prompt=None, expected_after_followup=None,
+            answer_old=SideCapture(turn1=Answer(text="old", ok=True)),
+            answer_new=SideCapture(turn1=Answer(text="new", ok=True)),
         )])
 
     def fake_judge_all(rows):
@@ -87,7 +89,7 @@ def test_run_sanity_happy_path_finalizes_succeeded(fake_pipeline):
 
 
 def test_run_sanity_uses_env_specific_urls(fake_pipeline):
-    runner.run_sanity(env="prod", db_url="postgres://fake")
+    runner.run_sanity(env="production", db_url="postgres://fake")
     capture_kwargs = fake_pipeline["captured"]["capture_kwargs"]
     assert capture_kwargs["url_old"] == "https://botnim.co.il"
     assert capture_kwargs["url_new"] == "https://botnim.build-up.team"
@@ -97,6 +99,37 @@ def test_run_sanity_staging_uses_staging_url(fake_pipeline):
     runner.run_sanity(env="staging", db_url="postgres://fake")
     capture_kwargs = fake_pipeline["captured"]["capture_kwargs"]
     assert capture_kwargs["url_new"] == "https://botnim.staging.build-up.team"
+
+
+def test_urls_for_env_rejects_short_form_prod():
+    """Regression guard for the 2026-05-24 prod incident: botnim-api's
+    server.py reads `os.environ['ENVIRONMENT']`, which is set to
+    'production' / 'staging' / 'local' per botnim.config.VALID_ENVIRONMENTS.
+    `_urls_for_env` used to accept the SHORT form 'prod' instead of the
+    canonical 'production', so every prod sanity invocation crashed with
+    `ValueError: unknown env: production`. Pin the canonical naming so
+    nobody silently re-introduces the alias.
+    """
+    with pytest.raises(ValueError, match="unknown env"):
+        runner._urls_for_env("prod")
+
+
+def test_urls_for_env_accepts_canonical_production_and_staging():
+    assert runner._urls_for_env("production") == (
+        "https://botnim.co.il", "https://botnim.build-up.team",
+    )
+    assert runner._urls_for_env("staging") == (
+        "https://botnim.co.il", "https://botnim.staging.build-up.team",
+    )
+
+
+def test_urls_for_env_error_message_lists_accepted_values():
+    """The error message must guide the operator to the right input."""
+    with pytest.raises(ValueError) as exc:
+        runner._urls_for_env("dev")
+    msg = str(exc.value)
+    assert "production" in msg
+    assert "staging" in msg
 
 
 def test_run_sanity_capture_failure_marks_failed(monkeypatch, caplog):


### PR DESCRIPTION
## Summary

Prod sanity invocations were silently failing async with `ValueError: unknown env: production`. `server.py` reads canonical `ENVIRONMENT` env var and passes verbatim to `run_sanity` — but `_urls_for_env` only accepted the short form `'prod'`. Twice-daily Lambda has been getting 202 ACCEPTED but no row ever landed in `sanity_runs` for env=production.

## Fix

- `runner.py:_urls_for_env` — accept `'production'` and `'staging'` (matching `botnim.config.VALID_ENVIRONMENTS`), reject `'prod'`.
- Error message now lists accepted values for operator-readability.
- Tests: 3 new regression-guard cases pinning the canonical naming + fixed 2 schema-rot issues in the existing `fake_capture_pair` fixture (`CaptureRow` got new required fields, `Answer` got wrapped in `SideCapture` — previously hidden because `env=prod` aborted before constructor was reached).

## Companion PR

LibreChat-side: `AdminSanity/aurora.js` ENV filter computation aligned to canonical names (separate repo).

## Test plan

- [x] `pytest tests/sanity/test_runner.py` — 9/9 passing
- [ ] After deploy: hit `/d/sanity` 'Run sanity now' on prod, expect `SANITY_START` then `SANITY_OK` (instead of `SANITY_FAILED: ValueError`) in CloudWatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)