### PR TITLE
fix(sanity/judge): read env-suffixed OPENAI_API_KEY in botnim tasks

### DIFF
--- a/botnim/sanity/judge.py
+++ b/botnim/sanity/judge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Optional
 
 from openai import OpenAI
@@ -69,7 +70,19 @@ _RUBRIC_SCHEMA = {
 
 
 def _client() -> OpenAI:
-    return OpenAI()  # reads OPENAI_API_KEY from env
+    # botnim tasks store the OpenAI key under env-suffixed names
+    # (OPENAI_API_KEY_PRODUCTION / OPENAI_API_KEY_STAGING) rather than
+    # the SDK-default OPENAI_API_KEY. Same convention used by the
+    # embedder — see botnim.vector_store.vector_store_aurora._client.
+    env = os.environ.get("ENVIRONMENT", "staging")
+    api_key = (
+        os.environ.get("OPENAI_API_KEY_PRODUCTION")
+        if env == "production"
+        else os.environ.get("OPENAI_API_KEY_STAGING")
+    )
+    # Final fallback to the SDK-default for local dev convenience.
+    api_key = api_key or os.environ.get("OPENAI_API_KEY")
+    return OpenAI(api_key=api_key)
 
 
 def _side_text(side: SideCapture) -> str:

--- a/tests/sanity/test_judge.py
+++ b/tests/sanity/test_judge.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from botnim.sanity import judge
-from botnim.sanity.types import Answer, CaptureRow
+from botnim.sanity.types import Answer, CaptureRow, SideCapture
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -25,9 +25,17 @@ def _make_row(row: int = 0, **kwargs) -> CaptureRow:
         expected_behavior="Cites §78 and explains the budget vote sequence.",
         must_not_contain=["איזה סוג מידע אתם מחפשים"],
         observed_notes="",
-        answer_old=Answer(text="ועדת הכנסת מצביעה על התקציב.", ok=True),
-        answer_new=Answer(text="לפי §78(ג) של תקנון הכנסת…", ok=True),
+        followup_prompt=None,
+        expected_after_followup=None,
+        answer_old=SideCapture(turn1=Answer(text="ועדת הכנסת מצביעה על התקציב.", ok=True)),
+        answer_new=SideCapture(turn1=Answer(text="לפי §78(ג) של תקנון הכנסת…", ok=True)),
     )
+    # Allow callers to override answer_old / answer_new with a bare Answer for
+    # convenience — wrap it in a SideCapture so the CaptureRow constructor
+    # gets the new schema.
+    for k in ("answer_old", "answer_new"):
+        if k in kwargs and isinstance(kwargs[k], Answer):
+            kwargs[k] = SideCapture(turn1=kwargs[k])
     base.update(kwargs)
     return CaptureRow(**base)
 
@@ -149,3 +157,45 @@ def test_judge_handles_unparseable_response_as_infra(monkeypatch):
     out = judge.judge_rubric(row)
     assert out.verdict == "INFRA"
     assert "parse" in out.reason.lower() or "json" in out.reason.lower()
+
+
+def test_client_reads_env_suffixed_api_key_production(monkeypatch):
+    """Regression guard for the 2026-05-24 prod incident: every prod
+    sanity run produced 14 INFRA verdicts because `_client()` called
+    `OpenAI()` with no args, and the SDK couldn't find an OPENAI_API_KEY
+    — the botnim task only sets OPENAI_API_KEY_PRODUCTION (same
+    convention as the embedder). Make sure we read the env-suffixed
+    name and pass it explicitly to OpenAI().
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION", "sk-prod-from-suffix")
+    monkeypatch.delenv("OPENAI_API_KEY_STAGING", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    seen = {}
+    monkeypatch.setattr(judge, "OpenAI", lambda api_key=None: seen.setdefault("k", api_key))
+    judge._client()
+    assert seen["k"] == "sk-prod-from-suffix"
+
+
+def test_client_reads_env_suffixed_api_key_staging(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-staging-from-suffix")
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    seen = {}
+    monkeypatch.setattr(judge, "OpenAI", lambda api_key=None: seen.setdefault("k", api_key))
+    judge._client()
+    assert seen["k"] == "sk-staging-from-suffix"
+
+
+def test_client_falls_back_to_standard_openai_api_key(monkeypatch):
+    """For local-dev convenience: if neither suffixed var is set but
+    OPENAI_API_KEY is, use that."""
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_STAGING", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-local-fallback")
+    seen = {}
+    monkeypatch.setattr(judge, "OpenAI", lambda api_key=None: seen.setdefault("k", api_key))
+    judge._client()
+    assert seen["k"] == "sk-local-fallback"


### PR DESCRIPTION
## Summary

* `judge._client()` called `OpenAI()` with no args → SDK looked for `OPENAI_API_KEY`, which botnim ECS tasks never set (they use `OPENAI_API_KEY_PRODUCTION` / `_STAGING`, same convention as the embedder).
* In prod every sanity run captured 14 rows correctly but every judge call failed with `Missing credentials`, so all 14 rows became `ab=TIE` + `rubric=INFRA`. The dashboard showed `0 / 0 / 14` everywhere — looked like a total failure.
* Mirror the embedder pattern: pick `OPENAI_API_KEY_PRODUCTION` or `_STAGING` based on `ENVIRONMENT`, with a final fallback to `OPENAI_API_KEY` for local dev.
* Three new tests guard each branch of the env-resolution. Also bring `_make_row` up to the post-2026-05-10 `SideCapture` schema so the existing 7 judge tests stop failing on schema-rot.

## Test plan

- [x] `pytest tests/sanity/test_judge.py` — 10/10 pass locally (3 new + 7 previously-rotten now fixed)
- [ ] After merge + deploy: kick off a sanity run from `/d/sanity` and verify it produces real `ab_verdict` + `rubric_verdict` values instead of all-INFRA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
