### PR TITLE
feat(refresh): dedicated OpenAI key for the daily fap-sync

### DIFF
--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -535,13 +535,24 @@ def _try_run_with_advisory_lock(key: int, label: str, fn) -> None:
 def _run_refresh_job() -> None:
     env = os.environ.get("ENVIRONMENT", DEFAULT_ENVIRONMENT)
     logger.info(f"REFRESH_START: env={env}")
-    # fetch_and_process(environment, bot, context, kind). 'all' kind so any
-    # newly-added fetcher type (bk_csv for government_decisions, future
-    # additions) gets picked up without a code change here. Static fetchers
-    # (lexicon, wikitext) re-run cheaply when nothing changed upstream.
-    fetch_and_process(env, "all", "all", "all")
-    # backend defaults to 'aurora' (sync.py:80) post-2026-04 migration.
-    sync_agents(env, "all")
+    # Daily refresh uses a dedicated OpenAI key when configured (see
+    # botnim.config.fap_sync_context). All OpenAI clients built inside
+    # this block — sync embeddings, gpt-4o-mini extraction, gpt-4.1-mini
+    # PDF field extraction — pick up OPENAI_API_KEY_<ENV>_FAP_SYNC if it
+    # is set; the chat-retrieval and sanity-judge paths on the same task
+    # are unaffected because they construct their clients OUTSIDE this
+    # context (sanity has its own daemon thread; /retrieve hits its own
+    # request context).
+    from botnim.config import fap_sync_context
+    with fap_sync_context():
+        # fetch_and_process(environment, bot, context, kind). 'all' kind so
+        # any newly-added fetcher type (bk_csv for government_decisions,
+        # future additions) gets picked up without a code change here.
+        # Static fetchers (lexicon, wikitext) re-run cheaply when nothing
+        # changed upstream.
+        fetch_and_process(env, "all", "all", "all")
+        # backend defaults to 'aurora' (sync.py:80) post-2026-04 migration.
+        sync_agents(env, "all")
     logger.info("REFRESH_OK")
 
 

--- a/botnim/config.py
+++ b/botnim/config.py
@@ -1,4 +1,6 @@
+from contextlib import contextmanager
 from pathlib import Path
+import contextvars
 import dotenv
 import logging
 import os
@@ -27,10 +29,48 @@ def get_logger(name: str) -> logging.Logger:
     #     logger.addHandler(handler)
     return logger
 
+# Set to True for the duration of a daily-refresh / fap-sync execution to
+# route OpenAI calls to the dedicated fap-sync key when one is configured.
+# Implemented as a contextvars.ContextVar so the flag rides asyncio.Task
+# boundaries automatically — and any OpenAI client constructed inside the
+# context window has its api_key baked in at construction time, so worker
+# threads that consume that client (e.g. process_pdfs.ThreadPoolExecutor)
+# inherit the right key by way of the client object, not by re-reading
+# environ inside each worker.
+_IN_FAP_SYNC: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    'botnim_in_fap_sync', default=False
+)
+
+
+@contextmanager
+def fap_sync_context():
+    """Enter a fap-sync execution context.
+
+    While the context is active, ``_resolve_openai_api_key(env)`` prefers
+    the ``OPENAI_API_KEY_<ENV>_FAP_SYNC`` env var over the regular
+    ``OPENAI_API_KEY_<ENV>``. Lets the daily refresh use a dedicated key
+    (cost isolation, rate-limit segregation) without altering the key
+    used by chat retrieval, sanity, or any other runtime path on the
+    same process.
+
+    Falls back transparently to the regular env-suffixed key if the
+    fap-sync-specific var is unset — so an env that hasn't opted in to
+    key separation keeps the old behaviour.
+    """
+    token = _IN_FAP_SYNC.set(True)
+    try:
+        yield
+    finally:
+        _IN_FAP_SYNC.reset(token)
+
+
 def _resolve_openai_api_key(environment: str | None = None) -> str:
     """Resolve OPENAI_API_KEY for the given environment.
 
     Lookup order:
+      0. ``OPENAI_API_KEY_{ENV}_FAP_SYNC`` — only consulted when the current
+         execution context is inside :func:`fap_sync_context`. Lets the
+         daily refresh use a dedicated key without affecting runtime paths.
       1. ``OPENAI_API_KEY_{ENV}`` for the requested environment (when given).
       2. The unprefixed ``OPENAI_API_KEY`` (works on any task that wires the
          secret directly under that name).
@@ -40,11 +80,18 @@ def _resolve_openai_api_key(environment: str | None = None) -> str:
          on whichever ECS task they happen to run on, instead of hardcoding
          a staging-only fallback that fails on prod.
     """
+    in_fap_sync = _IN_FAP_SYNC.get()
     candidates: list[str] = []
+    if environment and in_fap_sync:
+        candidates.append(f'OPENAI_API_KEY_{environment.upper()}_FAP_SYNC')
     if environment:
         candidates.append(f'OPENAI_API_KEY_{environment.upper()}')
     candidates.append('OPENAI_API_KEY')
     for env_name in ('PRODUCTION', 'STAGING', 'LOCAL'):
+        if in_fap_sync:
+            fap_var = f'OPENAI_API_KEY_{env_name}_FAP_SYNC'
+            if fap_var not in candidates:
+                candidates.append(fap_var)
         var = f'OPENAI_API_KEY_{env_name}'
         if var not in candidates:
             candidates.append(var)

--- a/botnim/document_parser/gov_il_decisions/aurora_writer.py
+++ b/botnim/document_parser/gov_il_decisions/aurora_writer.py
@@ -128,15 +128,18 @@ def write_decision(
 
 
 def _resolve_openai_api_key(environment: str) -> str | None:
-    """Mirror `_get_embedding_client`'s key resolution rules.
+    """Delegate to the canonical resolver in botnim.config.
 
-    Production reads OPENAI_API_KEY_PRODUCTION; everything else (local,
-    staging) reads OPENAI_API_KEY_STAGING. Documented at length in
-    CLAUDE.md ("OPENAI_API_KEY_STAGING is required even for ENV=local").
+    The central resolver also honours OPENAI_API_KEY_<ENV>_FAP_SYNC when
+    invoked inside a fap_sync_context() (e.g. from _run_refresh_job),
+    routing the daily refresh to a dedicated OpenAI key while keeping
+    chat retrieval on the regular key.
     """
-    if environment == "production":
-        return os.getenv("OPENAI_API_KEY_PRODUCTION")
-    return os.getenv("OPENAI_API_KEY_STAGING")
+    from botnim.config import _resolve_openai_api_key as _resolve
+    try:
+        return _resolve(environment)
+    except ValueError:
+        return None
 
 
 def write_decisions_batched(

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -216,12 +216,11 @@ def _get_embedding_client(environment: str):
     this function to inject a fake. Kept as a module-level function
     (not a method) so monkeypatch works without subclassing.
     """
-    api_key = (
-        os.getenv("OPENAI_API_KEY_PRODUCTION")
-        if environment == "production"
-        else os.getenv("OPENAI_API_KEY_STAGING")
-    )
-    client = OpenAI(api_key=api_key)
+    # Centralised through _resolve_openai_api_key so the contextvar in
+    # botnim.config picks up the OPENAI_API_KEY_<ENV>_FAP_SYNC override
+    # when this client is built inside a fap_sync_context().
+    from botnim.config import _resolve_openai_api_key
+    client = OpenAI(api_key=_resolve_openai_api_key(environment))
 
     class _Wrapper:
         def embed(self, text: str) -> list:
@@ -254,14 +253,13 @@ class VectorStoreAurora(VectorStoreBase):
         self.environment = env_name
 
         # OpenAI client surface — query.py expects `vector_store.openai_client.embeddings.create(...)`
-        # to mint query embeddings. Same env-var convention as VectorStoreES; the
-        # CLAUDE.md troubleshooting note covers why we read STAGING for non-prod
-        # (no separate _LOCAL key in the existing infra).
-        openai_api_key = (
-            os.getenv("OPENAI_API_KEY_PRODUCTION") if production
-            else os.getenv("OPENAI_API_KEY_STAGING")
-        )
-        self.openai_client = OpenAI(api_key=openai_api_key)
+        # to mint query embeddings. Centralised through _resolve_openai_api_key
+        # so the contextvar in botnim.config picks up the
+        # OPENAI_API_KEY_<ENV>_FAP_SYNC override when this store is built
+        # inside a fap_sync_context() (i.e. during the daily refresh, not
+        # at chat-retrieval time).
+        from botnim.config import _resolve_openai_api_key
+        self.openai_client = OpenAI(api_key=_resolve_openai_api_key(self.environment))
 
         # Trigger engine creation early so connection failures surface here, not later
         get_engine()

--- a/botnim/vector_store/vector_store_es.py
+++ b/botnim/vector_store/vector_store_es.py
@@ -78,8 +78,11 @@ class VectorStoreES(VectorStoreBase):
         logger.info(f"Connecting to Elasticsearch at {es_kwargs['hosts'][0]} for {env_name} environment")
 
         self.es_client = Elasticsearch(**es_kwargs)
-        openai_api_key = os.getenv('OPENAI_API_KEY_PRODUCTION') if production else os.getenv('OPENAI_API_KEY_STAGING')
-        self.openai_client = OpenAI(api_key=openai_api_key)
+        # Centralised through _resolve_openai_api_key so the contextvar
+        # in botnim.config picks up the OPENAI_API_KEY_<ENV>_FAP_SYNC
+        # override when this store is built inside a fap_sync_context().
+        from botnim.config import _resolve_openai_api_key
+        self.openai_client = OpenAI(api_key=_resolve_openai_api_key(env_name))
 
         # Verify connection
         try:

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -84,6 +84,11 @@ module "botnim_api" {
   secret_environment_variables = merge(
     {
       OPENAI_API_KEY_PRODUCTION = aws_secretsmanager_secret.openai_api_key.arn
+      # Dedicated key the daily refresh uses while inside
+      # botnim.config.fap_sync_context. Falls back to OPENAI_API_KEY_PRODUCTION
+      # transparently if the secret value is unset, so the refresh still runs
+      # before the secret is populated.
+      OPENAI_API_KEY_PRODUCTION_FAP_SYNC = aws_secretsmanager_secret.openai_api_key_fap_sync.arn
       # Consumed by backend/api/refresh_auth.py to authenticate the Lambda's
       # calls to /admin/refresh. Value is set out-of-band via Secrets Manager.
       BOTNIM_ADMIN_API_KEY        = aws_secretsmanager_secret.refresh_admin_api_key.arn

--- a/infra/envs/prod/secrets.tf
+++ b/infra/envs/prod/secrets.tf
@@ -12,6 +12,16 @@ resource "aws_secretsmanager_secret" "openai_api_key" {
   kms_key_id  = local.contract.ecs.kms_key_arn
 }
 
+# Dedicated key for the daily fap-sync (botnim.config.fap_sync_context).
+# Lets the refresh run on its own OpenAI org/project for cost isolation
+# without disturbing chat retrieval or sanity, which use the regular key
+# above.
+resource "aws_secretsmanager_secret" "openai_api_key_fap_sync" {
+  name        = "botnim-api/${var.environment}/openai-api-key-fap-sync"
+  description = "Dedicated OpenAI API key consumed only by the daily fap-sync (fap_sync_context)"
+  kms_key_id  = local.contract.ecs.kms_key_arn
+}
+
 # TODO(post-soak): remove after Window C closes (~T+30d) — rollback artifact.
 # Keep until Aurora migration soak period ends and we confirm no rollback to ES.
 resource "aws_secretsmanager_secret" "elasticsearch_password" {

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -144,6 +144,11 @@ module "botnim_api" {
   secret_environment_variables = merge(
     {
       "OPENAI_API_KEY_${upper(var.environment)}" = aws_secretsmanager_secret.openai_api_key.arn
+      # Dedicated key the daily refresh uses while inside
+      # botnim.config.fap_sync_context. Falls back to OPENAI_API_KEY_<ENV>
+      # transparently if the secret value is unset, so the refresh still
+      # runs before the secret is populated.
+      "OPENAI_API_KEY_${upper(var.environment)}_FAP_SYNC" = aws_secretsmanager_secret.openai_api_key_fap_sync.arn
       # Consumed by backend/api/refresh_auth.py to authenticate the Lambda's
       # calls to /admin/refresh. Value is set out-of-band via Secrets Manager.
       BOTNIM_ADMIN_API_KEY        = aws_secretsmanager_secret.refresh_admin_api_key.arn

--- a/infra/envs/staging/secrets.tf
+++ b/infra/envs/staging/secrets.tf
@@ -12,6 +12,16 @@ resource "aws_secretsmanager_secret" "openai_api_key" {
   kms_key_id  = local.contract.ecs.kms_key_arn
 }
 
+# Dedicated key for the daily fap-sync (botnim.config.fap_sync_context).
+# Lets the refresh run on its own OpenAI org/project for cost isolation
+# without disturbing chat retrieval or sanity, which use the regular key
+# above.
+resource "aws_secretsmanager_secret" "openai_api_key_fap_sync" {
+  name        = "botnim-api/${var.environment}/openai-api-key-fap-sync"
+  description = "Dedicated OpenAI API key consumed only by the daily fap-sync (fap_sync_context)"
+  kms_key_id  = local.contract.ecs.kms_key_arn
+}
+
 # TODO(post-soak): remove after Window C closes (~T+30d) — rollback artifact.
 # Keep until Aurora migration soak period ends and we confirm no rollback to ES.
 resource "aws_secretsmanager_secret" "elasticsearch_password" {

--- a/tests/test_config_fap_sync_key.py
+++ b/tests/test_config_fap_sync_key.py
@@ -1,0 +1,128 @@
+"""Tests for the OPENAI_API_KEY_<ENV>_FAP_SYNC override.
+
+The daily refresh (botnim.refresh_endpoint → server.py:_run_refresh_job)
+enters botnim.config.fap_sync_context() for the entire fetch+sync run.
+Inside that context, OpenAI client construction prefers the
+OPENAI_API_KEY_<ENV>_FAP_SYNC env var so the refresh can use a dedicated
+key without disturbing chat retrieval or sanity, which build their
+clients outside the context.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from botnim.config import _resolve_openai_api_key, fap_sync_context
+
+
+def test_resolver_uses_regular_key_outside_context(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION", "sk-regular-prod")
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", "sk-fap-prod")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert _resolve_openai_api_key("production") == "sk-regular-prod"
+
+
+def test_resolver_prefers_fap_sync_key_inside_context(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION", "sk-regular-prod")
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", "sk-fap-prod")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with fap_sync_context():
+        assert _resolve_openai_api_key("production") == "sk-fap-prod"
+    # Context exits cleanly.
+    assert _resolve_openai_api_key("production") == "sk-regular-prod"
+
+
+def test_resolver_falls_back_to_regular_key_when_fap_var_unset(monkeypatch):
+    """If OPENAI_API_KEY_<ENV>_FAP_SYNC isn't configured, the context is
+    a no-op — important for envs that haven't opted in to key separation."""
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-regular-staging")
+    monkeypatch.delenv("OPENAI_API_KEY_STAGING_FAP_SYNC", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with fap_sync_context():
+        assert _resolve_openai_api_key("staging") == "sk-regular-staging"
+
+
+def test_context_does_not_leak_to_concurrent_threads(monkeypatch):
+    """Verifies the contextvar is properly isolated: a thread spawned
+    OUTSIDE the context never sees fap-sync-mode, even if the main
+    thread is currently inside the context. This is the property that
+    keeps chat retrieval on the regular key while the daily refresh is
+    running on the same process.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION", "sk-regular")
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", "sk-fap")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    other_thread_result: list[str] = []
+    barrier = threading.Barrier(2)
+    proceed = threading.Event()
+
+    def chat_retrieval_lookalike() -> None:
+        barrier.wait(timeout=2)  # Sync up so main is inside the context.
+        other_thread_result.append(_resolve_openai_api_key("production"))
+        proceed.set()
+
+    t = threading.Thread(target=chat_retrieval_lookalike)
+    t.start()
+    with fap_sync_context():
+        barrier.wait(timeout=2)
+        assert proceed.wait(timeout=2)
+        # The OTHER thread, started before this context, must see the
+        # regular key — contextvars do not bleed across thread boundaries.
+        assert other_thread_result == ["sk-regular"]
+        # And THIS thread, inside the context, sees the fap-sync key.
+        assert _resolve_openai_api_key("production") == "sk-fap"
+    t.join(timeout=2)
+
+
+def test_context_propagates_through_asyncio_tasks(monkeypatch):
+    """asyncio.Task creation copies the current Context, so OpenAI
+    clients constructed inside coroutines spawned from the refresh
+    pipeline inherit the fap-sync key.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION", "sk-regular")
+    monkeypatch.setenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", "sk-fap")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    async def inner() -> str:
+        # Run inside an asyncio.Task — context should still be fap-sync.
+        return _resolve_openai_api_key("production")
+
+    async def runner() -> str:
+        with fap_sync_context():
+            return await asyncio.gather(inner())
+
+    result = asyncio.run(runner())
+    assert result == ["sk-fap"]
+
+
+def test_resolver_unprefixed_key_when_no_environment_passed(monkeypatch):
+    """No environment arg + unprefixed OPENAI_API_KEY still works
+    (CLI / local-dev convenience). Fap-sync context is no-op without
+    an env."""
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_STAGING", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_LOCAL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-unprefixed")
+    with fap_sync_context():
+        assert _resolve_openai_api_key() == "sk-unprefixed"
+
+
+def test_resolver_falls_through_to_other_env_suffix_in_context(monkeypatch):
+    """If OPENAI_API_KEY_PRODUCTION_FAP_SYNC is unset BUT another
+    env's _FAP_SYNC var is set, prefer that over any regular key.
+    Catches mis-configured stages where only one env got the new
+    secret wired up.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_PRODUCTION_FAP_SYNC", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING_FAP_SYNC", "sk-staging-fap")
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-staging-regular")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # Note: caller asked for production, but only staging's keys exist.
+    # Inside fap-sync, the staging fap-sync key should be preferred over
+    # the staging regular key.
+    with fap_sync_context():
+        assert _resolve_openai_api_key("production") == "sk-staging-fap"


### PR DESCRIPTION
## Summary

Lets the daily `/admin/refresh` (fap-sync) use a dedicated OpenAI key so its bursty multi-hour spend is on its own account/project, without touching the key that chat retrieval and sanity-judge use on the same task.

## Mechanism

- `botnim.config.fap_sync_context()` — `contextvars.ContextVar` that's `True` only inside `_run_refresh_job`.
- `_resolve_openai_api_key(env)` checks the contextvar; inside the context it prefers `OPENAI_API_KEY_<ENV>_FAP_SYNC` over `OPENAI_API_KEY_<ENV>`. Outside, behaviour is identical to before.
- The fap-sync code paths construct each OpenAI client *eagerly* in the parent thread (e.g. `process_pdfs.process_pdf_source` makes the client once, then hands it to ThreadPoolExecutor workers), so worker threads inherit the right key via the bound client object — no `copy_context()` plumbing.
- Sanity-judge and `/retrieve` build their clients outside the context → they stay on the regular key. **This is the load-bearing isolation property.**

## Modules touched

- `botnim/vector_store/vector_store_aurora.py` — both `_get_embed_client` (sync embedder) and `VectorStoreAurora.__init__` (query embedder) now route through `_resolve_openai_api_key`.
- `botnim/vector_store/vector_store_es.py` — same pattern.
- `botnim/document_parser/gov_il_decisions/aurora_writer.py` — local helper now delegates.
- `backend/api/server.py:_run_refresh_job` — wraps the fetch+sync block in `fap_sync_context()`.

## Infra

- `infra/envs/{prod,staging}/secrets.tf` — new secret `botnim-api/<env>/openai-api-key-fap-sync` (KMS-encrypted, value populated out-of-band).
- `infra/envs/{prod,staging}/main.tf` — new task env var `OPENAI_API_KEY_<ENV>_FAP_SYNC` pulling from the new secret. Falls back to `OPENAI_API_KEY_<ENV>` if the secret value is empty, so the deploy is safe before someone populates it.

## Tests

`tests/test_config_fap_sync_key.py` — 7 cases:

- regular key outside context
- fap-sync key inside context
- fallback to regular when fap-sync var unset
- **thread isolation** (key property — a thread that started outside the context never sees fap-sync mode)
- asyncio.Task propagation
- unprefixed `OPENAI_API_KEY` fallback
- cross-env fap-sync var fallback for half-configured states

All 7 pass locally.

## Roll-out

1. Merge this PR.
2. Apply terragrunt for both envs to create the new secrets.
3. Populate the secret value out-of-band (`aws secretsmanager put-secret-value …` from `.env.temp`).
4. `./deploy.sh prod` and `./deploy.sh staging` — tasks now have `OPENAI_API_KEY_<ENV>_FAP_SYNC` wired.
5. Verify next daily refresh uses the new key (logs / OpenAI dashboard split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
