### PR TITLE
chore(infra): disable extraction-call cap + pause sanity auto-runs

### DIFF
--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -74,6 +74,13 @@ module "botnim_api" {
     # S3 bucket for /tools/generate_word_doc uploads. Bucket lifecycle
     # auto-purges objects after 7 days; presigned URLs are shorter-lived.
     WORD_DOCS_BUCKET = aws_s3_bucket.word_docs.id
+    # 2026-05-26: disable the per-run extraction LLM-call ceiling. The
+    # default 5000 (botnim/_concurrency.py:DEFAULT_LLM_CALL_CEILING) cut
+    # the daily refresh short on backlog days when cache misses spike;
+    # since fap-sync now uses its own OpenAI key
+    # (OPENAI_API_KEY_PRODUCTION_FAP_SYNC) the cost-isolation arg for the
+    # cap is gone. 0 disables the circuit breaker.
+    EXTRACTION_MAX_LLM_CALLS_PER_RUN = "0"
   }
 
   secret_arns = concat(

--- a/infra/envs/prod/sanity.tf
+++ b/infra/envs/prod/sanity.tf
@@ -202,7 +202,12 @@ resource "aws_scheduler_schedule" "sanity" {
   name                = "botnim-sanity-${var.environment}"
   group_name          = "default"
   schedule_expression = "cron(0 3,12 * * ? *)"
-  state               = "ENABLED"
+  # 2026-05-26: auto-runs paused. Each twice-daily fire costs ~$3-4 in
+  # gpt-4o (LibreChat capture + sanity-judge) on the regular OpenAI key.
+  # Admins can still trigger sanity manually from the /d/sanity UI; the
+  # scheduler resource is kept so re-enabling is a one-line flip back to
+  # "ENABLED" rather than a resource recreate.
+  state = "DISABLED"
   flexible_time_window {
     mode = "OFF"
   }

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -101,6 +101,13 @@ module "botnim_api" {
       # S3 bucket for /tools/generate_word_doc uploads. Bucket lifecycle
       # auto-purges objects after 7 days; presigned URLs are shorter-lived.
       WORD_DOCS_BUCKET = aws_s3_bucket.word_docs.id
+      # 2026-05-26: disable the per-run extraction LLM-call ceiling
+      # (mirrors prod). Default 5000 in
+      # botnim/_concurrency.py:DEFAULT_LLM_CALL_CEILING cut the daily
+      # refresh short on backlog days; fap-sync now has its own OpenAI
+      # key so the cost-isolation arg for the cap is gone. 0 disables
+      # the circuit breaker.
+      EXTRACTION_MAX_LLM_CALLS_PER_RUN = "0"
       # Phoenix LLM-tracing collector (in-cluster Service Connect DNS).
       # When unset, botnim/observability/tracing.py is a no-op. The phoenix
       # ECS service is provisioned by infra/live/staging/phoenix/. Botnim-api

--- a/infra/envs/staging/sanity.tf
+++ b/infra/envs/staging/sanity.tf
@@ -202,7 +202,10 @@ resource "aws_scheduler_schedule" "sanity" {
   name                = "botnim-sanity-${var.environment}"
   group_name          = "default"
   schedule_expression = "cron(0 3,12 * * ? *)"
-  state               = "ENABLED"
+  # 2026-05-26: auto-runs paused (mirrors prod). Admins can still trigger
+  # sanity manually from the /d/sanity UI; flip back to "ENABLED" to
+  # restore the twice-daily auto-runs.
+  state = "DISABLED"
   flexible_time_window {
     mode = "OFF"
   }


### PR DESCRIPTION
## Summary

Two infra-only changes, prod + staging mirrored:

### 1. `EXTRACTION_MAX_LLM_CALLS_PER_RUN=0` on the ECS task env

Disables the per-run extraction-LLM-call circuit breaker (default 5000 in `_concurrency.py:DEFAULT_LLM_CALL_CEILING`). The cap was a cost-isolation guard back when fap-sync shared the chat-retrieval OpenAI key — now that the daily refresh has its own dedicated key (#184), the cap is no longer needed and has been cutting today's refresh short on cache-delta backlog days.

### 2. `aws_scheduler_schedule.sanity` → `state = "DISABLED"`

Pauses the twice-daily auto-sanity (cron `0 3,12 * * ? *` UTC). Each fire costs ~$3-4 on the regular OpenAI key (14 questions × 2 turns × gpt-4o through LibreChat + sanity-judge calls). Admins can still trigger sanity manually from `/d/sanity` → "Run sanity now"; the scheduler resource itself is kept in Terraform so re-enabling is a one-line `ENABLED` flip.

## Roll-out

`./deploy.sh prod` and `./deploy.sh staging` — terragrunt apply propagates both changes; ECS rolls new tasks with the env var; the scheduler state flips at apply time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
