### PR TITLE
feat(sync): SYNC_DELTA log line distinguishes new content from churn

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -329,6 +329,16 @@ class VectorStoreAurora(VectorStoreBase):
         successful = 0  # row count, not file count
         skipped = 0
         files_seen = 0
+        # Per-chunk delta breakdown — SYNC_DELTA observability (2026-05-27).
+        # Before, `successful` counted both "skipped because exists" and
+        # "INSERTed because new" together, so log readers couldn't tell
+        # whether a run actually surfaced new content or just paid LLM cost
+        # to re-embed chunks whose content_hash drifted. These split the
+        # counter so the per-context SYNC_DELTA line can expose
+        # chunks_inserted (real work) vs chunks_unchanged (cache hits)
+        # vs orphans_deleted (reconcile replacements).
+        chunks_unchanged = 0  # (cid, content_hash) row already existed → no embed, no INSERT
+        chunks_inserted  = 0  # row didn't exist → embed + INSERT happened
         # Every chunk content_hash this run produces (whether skipped as
         # unchanged or freshly inserted). Used after the upload pass to
         # delete rows whose content the run no longer produces.
@@ -398,6 +408,7 @@ class VectorStoreAurora(VectorStoreBase):
                                 fname, chunk_index + 1, total_chunks,
                             )
                             successful += 1
+                            chunks_unchanged += 1
                             continue
 
                         # New or changed content — embed and insert
@@ -424,6 +435,7 @@ class VectorStoreAurora(VectorStoreBase):
                             "sid": (metadata or {}).get("source_id"),
                         })
                         successful += 1
+                        chunks_inserted += 1
                     except Exception as exc:
                         logger.error(
                             "Failed to process %s (chunk %d/%d): %s",
@@ -474,11 +486,40 @@ class VectorStoreAurora(VectorStoreBase):
                     orphaned, len(files_processed), cid, len(seen_hashes),
                 )
             else:
+                orphaned = 0
                 logger.warning(
                     "upload_files produced 0 chunks for context_id=%s — skipping "
                     "orphan reconcile so a transient empty run cannot wipe the "
                     "context.", cid,
                 )
+
+            # Structured per-context SYNC_DELTA marker (2026-05-27). One line,
+            # grep-friendly. Distinguishes the three meaningful outcomes of a
+            # delta sync that the unsplit `successful` counter could not:
+            #   - chunks_unchanged: existed at the same content_hash → cache hit
+            #   - chunks_inserted:  embedded + INSERTed (content_hash didn't exist)
+            #   - orphans_deleted:  removed by per-file reconcile (stale chunks
+            #                       in files the run touched but no longer
+            #                       produces this content_hash for)
+            #
+            # churn_ratio = orphans_deleted / chunks_inserted:
+            #   ~0.0 → inserts are net-new content (good, expected for genuine
+            #          upstream additions)
+            #   ~1.0 → every insert displaced an old chunk in the same file
+            #          (= re-extraction churn — extraction non-determinism,
+            #          chunking drift, etc. costs LLM money for ~0 new info)
+            if chunks_inserted > 0:
+                churn_pct_str = f"{int(round(100.0 * orphaned / chunks_inserted))}%"
+            else:
+                churn_pct_str = "N/A"
+            logger.info(
+                "SYNC_DELTA: bot=%s context=%s files_processed=%d "
+                "chunks_unchanged=%d chunks_inserted=%d orphans_deleted=%d "
+                "chunks_skipped_error=%d churn_ratio=%s",
+                self.config.get('slug', '?'), context_name, len(files_processed),
+                chunks_unchanged, chunks_inserted, orphaned,
+                skipped, churn_pct_str,
+            )
 
         if callable(callback):
             callback(successful)

--- a/tests/vector_store/test_aurora_delta.py
+++ b/tests/vector_store/test_aurora_delta.py
@@ -210,3 +210,175 @@ def test_replace_context_none_with_force_rebuild_false_is_noop(aurora_db, monkey
         f"replace_context='none' must not delete; got {mock_delete.call_count} call(s)"
     )
     assert _doc_count(cid) == pre_count, "row count unchanged"
+
+
+# ---------------------------------------------------------------------------
+# SYNC_DELTA observability (2026-05-27)
+#
+# Pins down the per-context structured log line that distinguishes
+# "chunks_unchanged" (cache hit, no LLM cost) from "chunks_inserted"
+# (genuinely new content_hash, paid LLM cost) and "orphans_deleted"
+# (reconcile displacement of stale content_hashes in the same files).
+# The motivation: before this line, the existing `successful` counter
+# folded the first two together, and there was no way to tell from logs
+# whether a run did new work or just churned existing chunks because of
+# extraction non-determinism. churn_ratio = orphans / inserts answers
+# that question at-a-glance.
+# ---------------------------------------------------------------------------
+
+
+def _parse_sync_delta(caplog) -> dict[str, str]:
+    """Extract the latest SYNC_DELTA line and return its k=v pairs as a dict."""
+    lines = [r.getMessage() for r in caplog.records if r.getMessage().startswith("SYNC_DELTA: ")]
+    assert lines, "no SYNC_DELTA log line emitted"
+    payload = lines[-1][len("SYNC_DELTA: "):]
+    out = {}
+    for pair in payload.split():
+        if "=" not in pair:
+            continue
+        k, v = pair.split("=", 1)
+        out[k] = v
+    return out
+
+
+def test_sync_delta_logs_cache_hit_on_unchanged_chunks(aurora_db, monkeypatch, caplog):
+    """Re-uploading the SAME chunks should produce SYNC_DELTA with
+    chunks_unchanged=N, chunks_inserted=0, orphans_deleted=0, churn_ratio=N/A."""
+    import logging
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_delta_log_a"}, "ctx_delta_log_a",
+        replace_context=False, force_rebuild=False,
+    )
+    # Seed.
+    store.upload_files(
+        {"slug": "ctx_delta_log_a"}, "ctx_delta_log_a", cid,
+        _file_streams([("a.md", "alpha", {"title": "A"})]),
+        callback=lambda _: None,
+    )
+
+    # Re-upload identical input → all unchanged, no inserts, no orphans.
+    with caplog.at_level(logging.INFO, logger="botnim.vector_store.vector_store_aurora"):
+        store.upload_files(
+            {"slug": "ctx_delta_log_a"}, "ctx_delta_log_a", cid,
+            _file_streams([("a.md", "alpha", {"title": "A"})]),
+            callback=lambda _: None,
+        )
+    delta = _parse_sync_delta(caplog)
+    assert delta["bot"] == "unified"
+    assert delta["context"] == "ctx_delta_log_a"
+    assert delta["files_processed"] == "1"
+    assert delta["chunks_unchanged"] == "1"
+    assert delta["chunks_inserted"] == "0"
+    assert delta["orphans_deleted"] == "0"
+    assert delta["churn_ratio"] == "N/A", (
+        "churn_ratio must be N/A when chunks_inserted=0 (avoid 0/0); "
+        f"got {delta['churn_ratio']!r}"
+    )
+
+
+def test_sync_delta_logs_new_content_with_zero_churn(aurora_db, monkeypatch, caplog):
+    """Adding a NEW file with a NEW chunk_hash (no prior row in the file)
+    should produce chunks_inserted>0, orphans_deleted=0, churn_ratio=0%."""
+    import logging
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_delta_log_b"}, "ctx_delta_log_b",
+        replace_context=False, force_rebuild=False,
+    )
+    # Seed with one file.
+    store.upload_files(
+        {"slug": "ctx_delta_log_b"}, "ctx_delta_log_b", cid,
+        _file_streams([("a.md", "alpha", {"title": "A"})]),
+        callback=lambda _: None,
+    )
+    # Now upload: same a.md (unchanged) + a brand-new b.md.
+    with caplog.at_level(logging.INFO, logger="botnim.vector_store.vector_store_aurora"):
+        store.upload_files(
+            {"slug": "ctx_delta_log_b"}, "ctx_delta_log_b", cid,
+            _file_streams([
+                ("a.md", "alpha", {"title": "A"}),
+                ("b.md", "beta",  {"title": "B"}),
+            ]),
+            callback=lambda _: None,
+        )
+    delta = _parse_sync_delta(caplog)
+    assert delta["chunks_unchanged"] == "1"
+    assert delta["chunks_inserted"] == "1"
+    assert delta["orphans_deleted"] == "0"
+    assert delta["churn_ratio"] == "0%", (
+        "1 insert + 0 deletes = 0% churn (the new content displaced nothing); "
+        f"got {delta['churn_ratio']!r}"
+    )
+
+
+def test_sync_delta_logs_pure_churn_at_100pct(aurora_db, monkeypatch, caplog):
+    """Re-uploading the SAME filename with DIFFERENT content body simulates
+    the extraction-drift pattern from the 2026-05-27 incident: every chunk
+    has a new content_hash, the per-file reconcile deletes the previous
+    chunks, net documents stays the same. churn_ratio must report 100%
+    so an operator can spot 'we paid LLM cost for ~0 new info' at a glance.
+    """
+    import logging
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+
+    fake = _FakeEmbeddingClient()
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: fake,
+    )
+    store = VectorStoreAurora(
+        config={"slug": "unified", "name": "Unified"},
+        config_dir=".", environment="staging",
+    )
+    cid = store.get_or_create_vector_store(
+        {"slug": "ctx_delta_log_c"}, "ctx_delta_log_c",
+        replace_context=False, force_rebuild=False,
+    )
+    # Seed.
+    store.upload_files(
+        {"slug": "ctx_delta_log_c"}, "ctx_delta_log_c", cid,
+        _file_streams([("a.md", "version-one body", {"title": "A"})]),
+        callback=lambda _: None,
+    )
+    assert _doc_count(cid) == 1
+    # Re-upload the SAME filename with different body → fresh content_hash;
+    # reconcile drops the old hash; net stays at 1.
+    with caplog.at_level(logging.INFO, logger="botnim.vector_store.vector_store_aurora"):
+        store.upload_files(
+            {"slug": "ctx_delta_log_c"}, "ctx_delta_log_c", cid,
+            _file_streams([("a.md", "version-two body — extraction drifted",
+                            {"title": "A"})]),
+            callback=lambda _: None,
+        )
+    assert _doc_count(cid) == 1, (
+        "net doc_count must stay at 1 after the per-file reconcile drops the stale chunk"
+    )
+    delta = _parse_sync_delta(caplog)
+    assert delta["chunks_unchanged"] == "0"
+    assert delta["chunks_inserted"] == "1"
+    assert delta["orphans_deleted"] == "1"
+    assert delta["churn_ratio"] == "100%", (
+        "1 insert + 1 delete in the same file = 100% churn; "
+        f"got {delta['churn_ratio']!r}"
+    )


### PR DESCRIPTION
## Summary

Today's daily fap-sync (2026-05-27) inserted **3,153 documents** — but a DB cross-check showed **~85% of those inserts were re-extractions of EXISTING source documents** whose chunk `content_hash` drifted. The per-file reconcile then deleted the displaced old rows. Net change: zero new information; cost: real LLM spend.

This was invisible from the logs because the existing per-context line —

```
Uploaded N rows from M files to context_id=...
```

— folds "skipped because already exists" and "INSERTed because new" together under one `successful` counter. Operators (and Claude) could not tell from the logs whether a run produced new info or just churned chunks.

This PR adds a single structured log line per context, emitted at INFO right after the reconcile pass:

```
SYNC_DELTA: bot=<slug> context=<name> files_processed=N
            chunks_unchanged=N chunks_inserted=N orphans_deleted=N
            chunks_skipped_error=N churn_ratio=<pct>
```

`churn_ratio = orphans_deleted / chunks_inserted`, rendered as percentage:
- `0%` → every insert is genuinely new content (no displacement). Good.
- `100%` → every insert displaced an old chunk in the same file. Pure churn — paying LLM cost for ~zero new info. The pattern from the 2026-05-27 incident.
- `N/A` → `chunks_inserted == 0` (steady-state quiet day; no math to do).

## Tests

`tests/vector_store/test_aurora_delta.py` adds three cases (uses the existing per-test postgres `aurora_db` fixture):

1. **Cache hit only** — re-upload identical input. Asserts `chunks_unchanged=1 chunks_inserted=0 orphans_deleted=0 churn_ratio=N/A`.
2. **New content, zero churn** — add a brand-new file with new chunk. Asserts `chunks_inserted=1 orphans_deleted=0 churn_ratio=0%`.
3. **Pure churn at 100%** — re-upload same filename with different body (simulates extraction drift). Asserts `chunks_inserted=1 orphans_deleted=1 churn_ratio=100%` AND net doc_count unchanged.

6/6 tests pass (3 pre-existing + 3 new).

## Roll-out

Ships with the next prod deploy. Tomorrow's 04:00 UTC daily refresh will produce one `SYNC_DELTA` line per context in CloudWatch — at-a-glance grep tells whether the run did meaningful work or just rotated existing chunks.

## Follow-ups (NOT in this PR)

- **PR-B**: root-cause and fix the content_hash drift driving today's 85% churn. Likely candidates: extraction prompt nondeterminism in gpt-4o-mini, chunking algorithm boundary drift, metadata leakage into chunk content.
- **PR-C**: churn-shaped safety cap — e.g. circuit-break if `churn_ratio > 80%` after N chunks. Replaces the flat 5k cap that was just disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
