### PR TITLE
fix(entrypoint): seed sync uses --update so restarts don't wipe fap-sync data

### DIFF
--- a/backend/api/api_server.sh
+++ b/backend/api/api_server.sh
@@ -47,10 +47,27 @@ sync_seed_extraction() {
   # fail on EFS with "Operation not permitted" and abort the entrypoint
   # under `set -eu`). Without ownership preservation, the new files are
   # owned by the runtime user — same as anything written to EFS by fap.
-  # Default overwrite behavior is what we want: seed files always win;
-  # non-seed files on EFS (downloaded PDFs, extracted content_files) are
-  # untouched because they don't exist under $seed_dir.
-  cp -R --preserve=mode,timestamps "$seed_dir"/. "$mount_dir"/
+  #
+  # 2026-05-27: --update added (PR rb#?). The old "seed files always win"
+  # comment was the documented design but it produced the
+  # restart-wipes-fap-sync bug: at every container restart this cp
+  # unconditionally overwrote EFS's live-fetched index.csv with the
+  # image-baked seed (mtime frozen at image build time, e.g. May 14).
+  # The next fap-sync re-derived only what was in the just-restored
+  # seed CSV, leaving everything fap-sync had previously fetched
+  # in-between as orphans that the per-file reconcile would then DELETE
+  # from `documents`. We lost the 2026 ethics decisions via this exact
+  # path on May 27.
+  #
+  # --update changes the semantic to "newer source wins": if EFS already
+  # has a newer copy (the typical state after a fap-sync run), the cp
+  # skips it. New image-baked seed updates STILL propagate because their
+  # mtime at build time is newer than whatever the old EFS file's mtime
+  # is — the operator-intended path.
+  #
+  # Non-seed files on EFS (downloaded PDFs, extracted content_files)
+  # remain untouched because they don't exist under $seed_dir.
+  cp -R --preserve=mode,timestamps --update "$seed_dir"/. "$mount_dir"/
   after=$(find "$mount_dir" -type f 2>/dev/null | wc -l | tr -d ' ')
   echo "[sync_seed_extraction] seed → mount sync complete; files in mount before=$before after=$after"
 }


### PR DESCRIPTION
## Summary

Adds `--update` to the seed→EFS copy in the entrypoint (`backend/api/api_server.sh:sync_seed_extraction`) so container restarts stop wiping fap-sync's live-fetched data.

## The bug we just paid for

On 2026-05-27 we lost the 2026 ethics decisions because every container restart this `cp -R --preserve=mode,timestamps` unconditionally overwrote EFS's live-fetched `index.csv` with the image-baked seed (mtime frozen at image build time). The next fap-sync re-derived only what was in the just-restored seed CSV, and the per-file reconcile in `vector_store_aurora.upload_files` then DELETED orphan documents chunks whose source filenames were no longer in the stale CSV.

We had **5+ task restarts** in the last 36h (deploys, health-check kills, ECS rotations), each one wiping fap-sync progress.

## The fix

```diff
- cp -R --preserve=mode,timestamps "$seed_dir"/. "$mount_dir"/
+ cp -R --preserve=mode,timestamps --update "$seed_dir"/. "$mount_dir"/
```

| Scenario | --update result |
|---|---|
| EFS file from yesterday's fap-sync, seed May 14 | EFS preserved |
| EFS empty (cold start) | seed copied |
| Seed bumped in fresh image build (newer mtime) | seed copied |
| Live file with no seed equivalent (PDFs, .md) | EFS preserved (already correct, unchanged) |

The operator-intended seed-update path (someone bakes new historical rows into the image) still works because a fresh image's seed mtime is newer than any pre-existing EFS file from before that image was built.

## Verification plan (will run after deploy)

1. Plant `SENTINEL_OPT_A.txt` on EFS with current mtime — proves non-seed files survive (the easy case).
2. Append a marker line to `ethics_decisions/index.csv` + bump its mtime to now — proves the collision case: file exists in `seed_dir` but EFS copy is newer.
3. `ecs update-service --force-new-deployment` to roll the task.
4. After new task is up, read both files. **Both must survive AND retain their post-step-2 mtimes** for the fix to be verified.

## Follow-ups (not in this PR)

- **Option C** (S3 + Aurora replacement for EFS) — discussed in incident post-mortem; this is the durable solution but it's a 1-2 week migration.
- **SYNC_DELTA observability** — already shipped in #186 yesterday, will surface any future churn in next daily fap-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
