### PR TITLE
chore(infra): pause daily fap-sync scheduler in both envs

### DIFF
--- a/infra/envs/prod/refresh.tf
+++ b/infra/envs/prod/refresh.tf
@@ -222,7 +222,11 @@ resource "aws_scheduler_schedule" "refresh" {
   name                = "botnim-refresh-${var.environment}"
   group_name          = "default"
   schedule_expression = "cron(0 4 * * ? *)"
-  state               = "ENABLED"
+  # 2026-05-27: paused following the EFS-clobber incident. We're moving
+  # to local-prod-DB rehearsal of fap-sync before re-enabling. Flip
+  # back to "ENABLED" when the team is confident the architectural
+  # fixes (S3 replacement or filename stabilisation) are in place.
+  state = "DISABLED"
 
   flexible_time_window {
     mode = "OFF"

--- a/infra/envs/staging/refresh.tf
+++ b/infra/envs/staging/refresh.tf
@@ -227,7 +227,9 @@ resource "aws_scheduler_schedule" "refresh" {
   name                = "botnim-refresh-${var.environment}"
   group_name          = "default"
   schedule_expression = "cron(0 4 * * ? *)"
-  state               = "ENABLED"
+  # 2026-05-27: paused alongside prod following the EFS-clobber
+  # incident. Flip back to "ENABLED" when ready.
+  state = "DISABLED"
 
   flexible_time_window {
     mode = "OFF"


### PR DESCRIPTION
Following the 2026-05-27 EFS-clobber incident, both prod + staging fap-sync schedules are flipped to DISABLED in Terraform so future deploys don't re-enable them. CLI disable already applied. Lambda invokers left in place; re-enable is a one-line revert.