### PR TITLE
feat(infra): match botnim.co.il on the botnim-api ALB rule

### DIFF
--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -41,7 +41,13 @@ module "botnim_api" {
     # librechat co-habits at the same host with /* catch-all and does NOT
     # create its own DNS record. Using `subdomain` (vs `host_headers`) is what
     # triggers org-infra's auto-wiring of the service-connect ingress SG.
-    subdomain         = "botnim"
+    subdomain = "botnim"
+    # subdomain is kept (drives the build-up.team DNS record + the auto-wiring
+    # noted above); host_headers is added so the listener rule also matches the
+    # legacy botnim.co.il host (served via the shared ALB + an ACM SNI cert).
+    # host_headers replaces the default [<fqdn>], so botnim.build-up.team MUST
+    # stay in the list.
+    host_headers      = ["botnim.build-up.team", "botnim.co.il", "www.botnim.co.il"]
     listener_priority = var.listener_priority
     path_patterns     = ["/botnim/*"]
   }


### PR DESCRIPTION
Adds `host_headers = [botnim.build-up.team, botnim.co.il, www.botnim.co.il]` to the botnim-api `public` block so the `/botnim/*` listener rule (priority 400) on the shared ALB also serves the legacy **botnim.co.il** host.

- `subdomain` is kept (drives the build-up.team DNS record + existing auto-wiring); `host_headers` is added on top. It replaces the default `[<fqdn>]`, so botnim.build-up.team stays in the list.
- Routing-only + scoped to botnim's rule; no other host/app on the shared ALB is affected.
- Pairs with: org-infra ACM cert (#78/#79, applied) + listener-cert attach, and the matching LibreChat host_headers PR.

Apply after merge (plan first; expect an in-place rule update from 1→3 host values).