### PR TITLE
chore(prod): re-enable refresh scheduler on Tue+Thu 02:00 UTC

### DIFF
--- a/infra/envs/prod/refresh.tf
+++ b/infra/envs/prod/refresh.tf
@@ -182,10 +182,11 @@ resource "aws_cloudwatch_metric_alarm" "refresh_lambda_errors" {
 }
 
 # ---------------------------------------------------------------------------
-# EventBridge Scheduler: daily at 04:00 UTC (07:00 Asia/Jerusalem).
-# Backups run at 03:00 UTC (see efs_backup.tf); refresh runs an hour later so
-# the two jobs don't contend for the filesystem. Same UTC hour as staging
-# per operator policy.
+# EventBridge Scheduler: Tue & Thu at 02:00 UTC (05:00 Asia/Jerusalem).
+# (Was daily 04:00 UTC.) NOTE: EFS backups still run DAILY at 03:00 UTC (see
+# efs_backup.tf). A long-running refresh started at 02:00 could overlap the
+# 03:00 backup on Tue/Thu — revisit the offset (or the backup time) if
+# filesystem contention reappears now that refresh precedes the backup.
 # ---------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "refresh_scheduler_assume" {
@@ -221,12 +222,13 @@ resource "aws_iam_role_policy" "refresh_scheduler_invoke" {
 resource "aws_scheduler_schedule" "refresh" {
   name                = "botnim-refresh-${var.environment}"
   group_name          = "default"
-  schedule_expression = "cron(0 4 * * ? *)"
-  # 2026-05-27: paused following the EFS-clobber incident. We're moving
-  # to local-prod-DB rehearsal of fap-sync before re-enabling. Flip
-  # back to "ENABLED" when the team is confident the architectural
-  # fixes (S3 replacement or filename stabilisation) are in place.
-  state = "DISABLED"
+  schedule_expression = "cron(0 2 ? * TUE,THU *)"
+  # 2026-05-27: paused following the EFS-clobber incident (rehearse
+  # fap-sync against a local prod-DB copy before re-enabling).
+  # 2026-06-04: re-enabled per operator request, twice-weekly (Tue+Thu
+  # 02:00 UTC) rather than daily to limit blast radius while the EFS
+  # behaviour is monitored.
+  state = "ENABLED"
 
   flexible_time_window {
     mode = "OFF"


### PR DESCRIPTION
## What
Re-enable the **prod** botnim refresh EventBridge schedule and move it from daily to **twice-weekly Tue & Thu 02:00 UTC**.

- `schedule_expression`: `cron(0 4 * * ? *)` → `cron(0 2 ? * TUE,THU *)`
- `state`: `DISABLED` → `ENABLED`
- `infra/envs/prod/refresh.tf` only.

## Why
The prod schedule has been `DISABLED` since the **2026-05-27 EFS-clobber incident** (the note gated re-enable on the architectural fix / rehearsal). Re-enabling per operator request, on a reduced twice-weekly cadence to limit blast radius while EFS behaviour is monitored.

The refresh chain is unchanged: EventBridge → `botnim-refresh-invoker` Lambda → `POST /botnim/admin/refresh` → `_run_refresh_job()` (fetch-and-process + sync, using the dedicated `OPENAI_API_KEY_PRODUCTION_FAP_SYNC` key).

## ⚠️ Reviewer note — backup timing
EFS backup still runs **daily 03:00 UTC** (`efs_backup.tf`). The old offset put refresh *after* the backup (04:00). Now refresh starts at **02:00**, so a long-running refresh could still be running when the 03:00 backup begins on Tue/Thu. Flagged in the file comment — decide whether to also shift the backup or the refresh offset before applying.

## Rollout
Not applied. Run `terragrunt apply` in `infra/live/prod/...` (profile `anubanu-prod`) after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)