### PR TITLE
fix(cache): drop file_last_updated from hashed content (knesset_protocols churn)

### DIFF
--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -122,7 +122,16 @@ _METADATA_ONLY_CSV_COLUMNS = frozenset({"source_url", "file_url", "url", "lexico
 # logic reads them) — they're only excluded from the flattened content
 # the sync pipeline hashes + embeds. Dropped entirely, not kept as
 # metadata: the bot has no use for them.
-_BOOKKEEPING_CSV_COLUMNS = frozenset({"upstream_hash", "upstream_revision", "revision"})
+# 2026-06-04: added `file_last_updated` — knesset_protocols' per-document OData
+# LastUpdatedDate (process_protocols.py:326). It rotates whenever the upstream
+# doc is touched, so leaving it in the flattened content re-hashed every turn
+# and the extraction cache never warmed (prod probe: 334K cache rows for a
+# ~134K-chunk corpus ≈ 2.5x bloat, ~7-9K fresh rows + 0 hits every run). Same
+# provenance class as upstream_hash; stays in the CSV for the fetcher's delta
+# logic, only excluded from the hashed/embedded content.
+_BOOKKEEPING_CSV_COLUMNS = frozenset(
+    {"upstream_hash", "upstream_revision", "revision", "file_last_updated"}
+)
 
 
 def _extract_source_url(content: str) -> str | None:

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -224,3 +224,55 @@ def test_csv_collector_drops_pdf_revision_columns(tmp_path):
     assert "upstream_revision" not in content
     assert "v7" not in content
     assert "טקסט_מלא:\nתוכן המסמך" in content
+
+
+# -----------------------------------------------------------------------------
+# knesset_protocols' file_last_updated (= OData LastUpdatedDate) is per-document
+# provenance that rotates whenever the upstream doc is touched. It MUST be
+# dropped from content like upstream_hash — otherwise every turn re-hashes and
+# the extraction cache never warms (observed in prod 2026-06-04: 334K cache rows
+# for a ~134K-chunk corpus ≈ 2.5x bloat, 7-9K fresh rows every run, 0 hits).
+# -----------------------------------------------------------------------------
+
+
+def test_csv_collector_drops_file_last_updated_from_content(tmp_path):
+    csv_path = tmp_path / "kp.csv"
+    _write_csv(csv_path, [
+        {
+            "file_last_updated": "2026-06-04T11:10:54.293",
+            "document_id": "537",
+            "speaker_name": "ישראל ישראלי",
+            "turn_text": "טקסט הדיון",
+        },
+    ])
+    out = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "kp.csv")
+    fname, content, ctype, extra_meta = out[0]
+    assert "file_last_updated" not in content
+    assert "2026-06-04T11:10:54.293" not in content
+    # Real content survives.
+    assert "speaker_name:\nישראל ישראלי" in content
+    assert "turn_text:\nטקסט הדיון" in content
+    # Dropped entirely — not parked in metadata either.
+    assert "file_last_updated" not in extra_meta
+
+
+def test_csv_content_hash_stable_across_file_last_updated_change(tmp_path):
+    """Core regression: two CSVs identical except for file_last_updated must
+    produce byte-identical flattened content → identical content_hash, so the
+    extraction cache can finally warm for knesset_protocols."""
+    row_a = {
+        "file_last_updated": "2026-06-04T11:10:54.293",
+        "document_id": "537",
+        "turn_text": "אותו הטקסט בדיוק",
+    }
+    row_b = dict(row_a, file_last_updated="2026-05-01T08:00:00.000")
+
+    _write_csv(tmp_path / "a.csv", [row_a])
+    _write_csv(tmp_path / "b.csv", [row_b])
+
+    content_a = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "a.csv")[0][1]
+    content_b = _collect_raw_streams_csv(tmp_path, "knesset_protocols", "b.csv")[0][1]
+
+    assert content_a == content_b, "content must not vary with file_last_updated"
+    h = lambda s: _hashlib.sha256(s.strip().encode("utf-8")).hexdigest()
+    assert h(content_a) == h(content_b)


### PR DESCRIPTION
## Problem
`knesset_protocols` extraction cache never warms — every fap-sync re-extracts the entire ~134K-chunk protocol corpus via `gpt-4o-mini` (the multi-hour refresh runtime) and re-embeds + reconcile-churns the `documents` rows.

## Root cause
`knesset_protocols.csv` carries **`file_last_updated`** (= OData `LastUpdatedDate`, `process_protocols.py:326`), which rotates whenever the upstream doc is touched. `collect_sources._collect_raw_streams_csv:490` flattens every column not in `_BOOKKEEPING_CSV_COLUMNS` into the content that feeds `content_hash` — so this volatile timestamp re-hashed every speaker turn on every run. Exactly the failure mode the `_BOOKKEEPING_CSV_COLUMNS` docstring already warns about for `upstream_hash`.

## Evidence (prod probe, 2026-06-04)
- `extraction_cache`: **334,746** rows for `פרוטוקולי דיונים בכנסת` vs **~134K** chunks ≈ **2.5x bloat**.
- **7–9K fresh cache rows created every run** (a warm cache should create ~0); **0 hits** observed live.
- The churned value leaks into extractions as `PublicationDate: "2026-06-04T11:10:54.293"`.
- `EXTRACTION_VERSION` unchanged → not a version-bump invalidation.

## Fix
Add `file_last_updated` to `_BOOKKEEPING_CSV_COLUMNS` (same treatment as `upstream_hash`): stays in the CSV for the fetcher's delta logic, only excluded from the hashed/embedded content. `content_hash` is now invariant to it.

- **No `EXTRACTION_VERSION` bump** — only the affected contexts re-hash once; other contexts are untouched.
- After deploy, the next fap-sync re-extracts protocols **once** with stable hashes, then the cache warms permanently (subsequent runs hit → dramatically faster/cheaper).

## Tests (TDD)
Two regression tests mirroring the `upstream_hash` ones — fail before, pass after; full `tests/test_collect_sources.py` green (15 passed).

## Follow-ups (not in this PR)
- `plenary_schedule` shows ~4.5x cache bloat too (session date/time columns from `process_odata.py`); fix is nuanced (date/time is semantic) — separate PR after confirming the exact churn field.
- Optional: purge the ~334K stale `extraction_cache` protocol rows (dead weight; rebuilds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
