### PR TITLE
fix(gov_il): follow gov.il API migration to openapi-gc gateway + loud-fail guards

### DIFF
--- a/botnim/document_parser/gov_il_decisions/api.py
+++ b/botnim/document_parser/gov_il_decisions/api.py
@@ -1,33 +1,73 @@
-"""Thin client wrapping the three gov.il endpoints we use.
+"""Thin client wrapping the gov.il "openapi" decisions gateway.
 
-Endpoints documented in Tal's GOV_DEC_DEV_GUIDE.md:
-* GET /CollectorsWebApi/api/DataCollector/GetResults — paginated listing
-* GET /ContentPageWebApi/api/content-pages/{pageId} — full content
-* GET <attachment_url>                              — PDF / DOCX bytes
+Endpoint migration (2026-05)
+----------------------------
+gov.il moved its decisions API off ``www.gov.il`` to the
+``openapi-gc.digital.gov.il`` gateway. The old hosts now return the SPA
+HTML shell (HTTP 200, ``text/html``) for these paths, which used to
+surface as an opaque ``JSONDecodeError`` and silently stalled the
+``government_decisions`` context for ~a month. Current endpoints:
 
-All three sit behind Cloudflare's TLS-fingerprinting WAF; from Python
-only ``curl_cffi`` with ``impersonate="chrome"`` reliably gets a 200.
-Standard ``requests`` / ``httpx`` get a 403.
+* GET {API_BASE}/collectors/v1/api/DataCollector/GetResults  — paginated listing
+* GET {API_BASE}/contentpage/v1/api/content-pages/{pageId}   — full content
+* GET <attachment_url>                                       — PDF / DOCX bytes
 
-The client exposes ``_session`` so tests can inject a MagicMock without
-real network calls; production callers never touch ``_session`` directly.
+The gateway requires, in addition to the Cloudflare TLS clearance that
+``curl_cffi`` with ``impersonate="chrome"`` provides:
+
+* header ``x-client-id`` — the SPA's public API key, shipped in its JS
+  bundle. Overridable via the ``GOV_IL_CLIENT_ID`` env var in case gov.il
+  rotates it.
+* ``Referer`` / ``Origin`` of ``https://www.gov.il``.
+* a session cookie seeded by one warmup GET to the gateway host. A bare
+  (never-warmed) session gets HTTP 500 from the gateway; a warmed session
+  gets 200. The warmup is lazy (fires on the first real call) so unit
+  tests that inject a mock ``_session`` and pass ``warmup=False`` never
+  touch the network.
+
+The client exposes ``_session`` so tests can inject a ``MagicMock``;
+production callers never touch ``_session`` directly.
 """
 from __future__ import annotations
 
+import os
 import time
 from typing import Any, Optional
 
 from curl_cffi import requests as _cc_requests
 
 from ...config import get_logger
+from .exceptions import GovIlApiError
 
 logger = get_logger(__name__)
 
 
+# Host gov.il decisions still live under for human-facing source_urls and
+# (historically) attachment downloads.
 GOV_BASE = "https://www.gov.il"
-LISTING_PATH = "/CollectorsWebApi/api/DataCollector/GetResults"
-CONTENT_PATH = "/ContentPageWebApi/api/content-pages"
+
+# The "openapi" gateway the SPA migrated to (2026-05).
+API_BASE = "https://openapi-gc.digital.gov.il/pub/cio/govil/rest"
+LISTING_PATH = "/collectors/v1/api/DataCollector/GetResults"
+CONTENT_PATH = "/contentpage/v1/api/content-pages"
 GOV_RESOLUTIONS_TYPE = "30280ed5-306f-4f0b-a11d-cacf05d36648"
+
+# The SPA ships this public client id in its JS bundle; the gateway 500s
+# without it. Overridable via env in case gov.il rotates the key.
+DEFAULT_CLIENT_ID = "9KFgciHHGDyNiqz5MdQS0eK2ApeJYMc6YnElUICpN1atirZc"
+
+# One GET here (returns 404, but Set-Cookie seeds the cookie the gateway's
+# DataCollector / contentpage endpoints require) before the first real call.
+_WARMUP_URL = "https://openapi-gc.digital.gov.il/"
+
+
+def _build_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "x-client-id": os.environ.get("GOV_IL_CLIENT_ID", DEFAULT_CLIENT_ID),
+        "Referer": "https://www.gov.il/",
+        "Origin": "https://www.gov.il",
+    }
 
 
 class GovIlClient:
@@ -36,15 +76,28 @@ class GovIlClient:
     ``delay_seconds`` is the polite interval between any two requests,
     enforced by the client itself so callers don't have to remember.
     Tal's guide recommends 0.3–0.5s.
+
+    ``warmup`` controls the lazy cookie-warmup GET; pass ``warmup=False``
+    in unit tests (which inject a mock ``_session``) to keep the network
+    out of the assertions.
     """
 
-    def __init__(self, *, delay_seconds: float = 0.3, timeout: int = 30) -> None:
+    def __init__(
+        self,
+        *,
+        delay_seconds: float = 0.3,
+        timeout: int = 30,
+        warmup: bool = True,
+    ) -> None:
         self._impersonate = "chrome"
         self._session = _cc_requests.Session()
         self._session.impersonate = self._impersonate
         self._delay = delay_seconds
         self._timeout = timeout
         self._last_call = 0.0
+        self._headers = _build_headers()
+        self._warmup_enabled = warmup
+        self._warmed = False
 
     def _sleep_if_needed(self) -> None:
         elapsed = time.monotonic() - self._last_call
@@ -52,11 +105,56 @@ class GovIlClient:
             time.sleep(self._delay - elapsed)
         self._last_call = time.monotonic()
 
+    def _ensure_warmed(self) -> None:
+        """Seed the gateway session cookie before the first real request.
+
+        A bare session gets HTTP 500 from the gateway; one warmup GET (even
+        a 404 on the gateway root) sets the cookie that the API endpoints
+        require. Best-effort: a failed warmup is logged and the call
+        proceeds — the API call itself surfaces any real problem (a
+        non-JSON body raises ``GovIlApiError`` via ``_json_or_raise``).
+        """
+        if self._warmed or not self._warmup_enabled:
+            return
+        # Set first so a raising warmup never loops on the next call.
+        self._warmed = True
+        try:
+            self._session.get(_WARMUP_URL, headers=self._headers, timeout=self._timeout)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("gov_il warmup request failed (continuing): %s", exc)
+
+    def _json_or_raise(self, resp, *, url: str) -> Any:
+        """Return ``resp.json()``, or raise ``GovIlApiError`` for non-JSON.
+
+        Guards on ``Content-Type``: the gateway (and the old, now-dead
+        ``www.gov.il`` endpoints) return an HTML SPA shell with HTTP 200
+        when a path moves or the request is blocked. ``.json()`` on that
+        raises an opaque ``JSONDecodeError`` — the exact failure that hid
+        the 2026-05 migration. Fail loudly with the URL + content-type.
+        """
+        try:
+            ctype = (resp.headers.get("content-type") or "").lower()
+        except Exception:  # noqa: BLE001 — headers shape varies across clients
+            ctype = ""
+        if "json" not in ctype:
+            snippet = ""
+            try:
+                snippet = (resp.text or "")[:160].replace("\n", " ")
+            except Exception:  # noqa: BLE001
+                pass
+            raise GovIlApiError(
+                f"gov.il returned non-JSON (content-type={ctype!r}) from {url} — "
+                f"the endpoint likely moved or is WAF-blocked. Body head: {snippet!r}"
+            )
+        return resp.json()
+
     def list_decisions(self, *, skip: int, limit: int) -> dict[str, Any]:
-        """One page of the listing API."""
+        """One page of the listing API (newest-first)."""
+        self._ensure_warmed()
         self._sleep_if_needed()
+        url = f"{API_BASE}{LISTING_PATH}"
         resp = self._session.get(
-            f"{GOV_BASE}{LISTING_PATH}",
+            url,
             params={
                 "CollectorType": ["policy", "pmopolicy"],
                 "Type": GOV_RESOLUTIONS_TYPE,
@@ -64,28 +162,33 @@ class GovIlClient:
                 "limit": limit,
                 "culture": "he",
             },
+            headers=self._headers,
             timeout=self._timeout,
         )
         resp.raise_for_status()
-        return resp.json()
+        return self._json_or_raise(resp, url=url)
 
     def fetch_content(self, page_id: str) -> Optional[dict[str, Any]]:
         """Full content page. Returns ``None`` for 404 (deleted/moved)."""
+        self._ensure_warmed()
         self._sleep_if_needed()
+        url = f"{API_BASE}{CONTENT_PATH}/{page_id}"
         resp = self._session.get(
-            f"{GOV_BASE}{CONTENT_PATH}/{page_id}",
+            url,
             params={"culture": "he"},
+            headers=self._headers,
             timeout=self._timeout,
         )
         if resp.status_code == 404:
             logger.info("content 404 for %s — skipping", page_id)
             return None
         resp.raise_for_status()
-        return resp.json()
+        return self._json_or_raise(resp, url=url)
 
     def download_attachment(self, url: str) -> bytes:
         """Raw bytes for a PDF / DOCX attachment URL."""
+        self._ensure_warmed()
         self._sleep_if_needed()
-        resp = self._session.get(url, timeout=self._timeout * 2)
+        resp = self._session.get(url, headers=self._headers, timeout=self._timeout * 2)
         resp.raise_for_status()
         return resp.content

--- a/botnim/document_parser/gov_il_decisions/aurora_writer.py
+++ b/botnim/document_parser/gov_il_decisions/aurora_writer.py
@@ -60,6 +60,27 @@ def existing_page_ids(context_id: str) -> set[str]:
     return {r[0] for r in rows if r[0]}
 
 
+def newest_publish_date(context_id: str):
+    """Return the max ``publish_date`` (a ``datetime.date``) across this
+    context's documents, or ``None`` if the context is empty / has no
+    parseable publish_date.
+
+    ``publish_date`` is stored in metadata as ``DD.MM.YYYY`` (e.g.
+    ``01.06.2026``); we parse it in SQL and guard with a regex so a
+    malformed value can't error the query. Used by the gov_il fetcher's
+    freshness alarm to turn silent staleness into a loud, alarmable log
+    line (see ``process.process_gov_il_decisions_source``).
+    """
+    with get_session() as sess:
+        row = sess.execute(sql_text(
+            "SELECT max(to_date(metadata->>'publish_date', 'DD.MM.YYYY')) "
+            "FROM documents "
+            "WHERE context_id = :cid "
+            "AND metadata->>'publish_date' ~ '^[0-9]{2}\\.[0-9]{2}\\.[0-9]{4}$'"
+        ), {"cid": context_id}).fetchone()
+    return row[0] if row else None
+
+
 def write_decision(
     context_id: str,
     *,

--- a/botnim/document_parser/gov_il_decisions/exceptions.py
+++ b/botnim/document_parser/gov_il_decisions/exceptions.py
@@ -14,3 +14,17 @@ from ..pdfs.exceptions import EmptyUpstreamIndex  # noqa: F401  (re-export)
 class CategorizationError(Exception):
     """LLM categorization failed even after one retry."""
     pass
+
+
+class GovIlApiError(Exception):
+    """gov.il returned an unexpected (non-JSON) response.
+
+    The gov.il SPA serves an HTML shell with HTTP 200 when an API path
+    moves (as happened in the 2026-05 migration off
+    ``www.gov.il/CollectorsWebApi`` to the ``openapi-gc.digital.gov.il``
+    gateway) or when the request is WAF-blocked. Calling ``.json()`` on
+    that body raises an opaque ``JSONDecodeError`` — which is exactly what
+    silently hid the migration for a month. The client raises this instead,
+    naming the URL + content-type so the failure is greppable and loud.
+    """
+    pass

--- a/botnim/document_parser/gov_il_decisions/process.py
+++ b/botnim/document_parser/gov_il_decisions/process.py
@@ -17,11 +17,17 @@ silently wiping the indexed corpus on a fresh install.
 """
 from __future__ import annotations
 
+from datetime import date
 from typing import Optional
 
 from ...config import get_logger
 from .api import GovIlClient
-from .aurora_writer import existing_page_ids, get_or_create_context, write_decision
+from .aurora_writer import (
+    existing_page_ids,
+    get_or_create_context,
+    newest_publish_date,
+    write_decision,
+)
 from .categorize import categorize
 from .exceptions import EmptyUpstreamIndex
 from .extract import docx_to_text, html_to_text, pdf_to_text
@@ -136,6 +142,7 @@ def process_gov_il_decisions_source(
     max_pages: int = 1000,
     bot_slug: str = "unified",
     context_name: str = "government_decisions",
+    stale_after_days: int = 30,
 ) -> None:
     """Refresh gov.il government decisions into Aurora.
 
@@ -209,3 +216,29 @@ def process_gov_il_decisions_source(
         "gov_il_decisions: upstream_total=%s new_this_run=%d total_in_context=%d",
         seen_total, new_count, len(seen),
     )
+
+    # Freshness alarm. The 2026-05 endpoint migration stalled this context
+    # for a month while every refresh "succeeded" (the broken fetch was
+    # swallowed by fetch_and_process's per-context isolation). Emit a loud,
+    # greppable line when the newest decision we hold is older than the
+    # threshold so a CloudWatch metric-filter alarm on GOV_IL_DECISIONS_STALE
+    # can page instead of the rot going unnoticed.
+    try:
+        newest = newest_publish_date(context_id)
+        if newest is not None:
+            age_days = (date.today() - newest).days
+            if age_days > stale_after_days:
+                logger.error(
+                    "GOV_IL_DECISIONS_STALE: newest decision in (%s, %s) is %s "
+                    "(%d days old > %d-day threshold) — fetcher may be broken "
+                    "(new_this_run=%d, upstream_total=%s)",
+                    bot_slug, context_name, newest.isoformat(), age_days,
+                    stale_after_days, new_count, seen_total,
+                )
+            else:
+                logger.info(
+                    "gov_il_decisions: freshness OK — newest decision %s (%d days old)",
+                    newest.isoformat(), age_days,
+                )
+    except Exception as exc:  # noqa: BLE001 — freshness is advisory, never fatal
+        logger.warning("gov_il_decisions freshness check failed: %s", exc)

--- a/tests/document_parser/gov_il_decisions/test_api.py
+++ b/tests/document_parser/gov_il_decisions/test_api.py
@@ -1,11 +1,16 @@
 """API client unit tests — every external call mocked.
 
-The real curl_cffi session is constructed once via ``GovIlClient()``
-and patched in tests with a MagicMock that records call args. We assert
-the URL shape, the params (CollectorType list, Type GUID, skip/limit),
-and that 404s on ``fetch_content`` are surfaced as ``None`` rather than
-exceptions (some pages 404 because they were retracted — Tal's guide
-calls this out).
+The real curl_cffi session is constructed via ``GovIlClient()`` and
+patched in tests with a MagicMock that records call args. Tests pass
+``warmup=False`` so the lazy cookie-warmup GET doesn't touch the network
+(and doesn't perturb the ``get`` call count) — except the dedicated
+warmup test, which asserts the warmup fires.
+
+We assert the (post-2026-05-migration) gateway URL shape, params
+(CollectorType list, Type GUID, skip/limit), the required ``x-client-id``
+header, that 404s on ``fetch_content`` surface as ``None``, and that a
+non-JSON 200 body raises ``GovIlApiError`` instead of an opaque
+JSONDecodeError.
 """
 from __future__ import annotations
 
@@ -14,15 +19,29 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from botnim.document_parser.gov_il_decisions.api import (
+    DEFAULT_CLIENT_ID,
     GOV_RESOLUTIONS_TYPE,
     GovIlClient,
+    _WARMUP_URL,
 )
+from botnim.document_parser.gov_il_decisions.exceptions import GovIlApiError
 
 
-def _ok_json(payload):
+def _ok_json(payload, ctype="application/json; charset=utf-8"):
     resp = MagicMock()
     resp.json.return_value = payload
     resp.status_code = 200
+    resp.headers = {"content-type": ctype}
+    resp.text = "{}"
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _html(status=200, body="<!DOCTYPE html><html><head></head></html>"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = {"content-type": "text/html; charset=utf-8"}
+    resp.text = body
     resp.raise_for_status = MagicMock()
     return resp
 
@@ -36,7 +55,7 @@ def _status(code, content=b""):
 
 
 def test_list_decisions_url_and_params():
-    client = GovIlClient()
+    client = GovIlClient(warmup=False)
     fake_session = MagicMock()
     fake_session.get.return_value = _ok_json({"total": 25800, "results": []})
     client._session = fake_session
@@ -46,7 +65,10 @@ def test_list_decisions_url_and_params():
     assert out == {"total": 25800, "results": []}
     fake_session.get.assert_called_once()
     args, kwargs = fake_session.get.call_args
-    assert args[0] == "https://www.gov.il/CollectorsWebApi/api/DataCollector/GetResults"
+    assert args[0] == (
+        "https://openapi-gc.digital.gov.il/pub/cio/govil/rest"
+        "/collectors/v1/api/DataCollector/GetResults"
+    )
     assert kwargs["params"]["CollectorType"] == ["policy", "pmopolicy"]
     assert kwargs["params"]["Type"] == GOV_RESOLUTIONS_TYPE
     assert kwargs["params"]["skip"] == 100
@@ -54,8 +76,36 @@ def test_list_decisions_url_and_params():
     assert kwargs["params"]["culture"] == "he"
 
 
+def test_requests_carry_client_id_and_origin_headers():
+    client = GovIlClient(warmup=False)
+    fake_session = MagicMock()
+    fake_session.get.return_value = _ok_json({"total": 0, "results": []})
+    client._session = fake_session
+
+    client.list_decisions(skip=0, limit=5)
+
+    _, kwargs = fake_session.get.call_args
+    headers = kwargs["headers"]
+    assert headers["x-client-id"] == DEFAULT_CLIENT_ID
+    assert headers["Referer"] == "https://www.gov.il/"
+    assert headers["Origin"] == "https://www.gov.il"
+
+
+def test_client_id_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("GOV_IL_CLIENT_ID", "ROTATED-KEY-123")
+    client = GovIlClient(warmup=False)
+    fake_session = MagicMock()
+    fake_session.get.return_value = _ok_json({"total": 0, "results": []})
+    client._session = fake_session
+
+    client.list_decisions(skip=0, limit=5)
+
+    _, kwargs = fake_session.get.call_args
+    assert kwargs["headers"]["x-client-id"] == "ROTATED-KEY-123"
+
+
 def test_fetch_content_url():
-    client = GovIlClient()
+    client = GovIlClient(warmup=False)
     fake_session = MagicMock()
     fake_session.get.return_value = _ok_json({"contentMain": {"htmlContents": []}})
     client._session = fake_session
@@ -64,12 +114,15 @@ def test_fetch_content_url():
 
     assert out == {"contentMain": {"htmlContents": []}}
     args, kwargs = fake_session.get.call_args
-    assert args[0] == "https://www.gov.il/ContentPageWebApi/api/content-pages/dec3994-2026"
+    assert args[0] == (
+        "https://openapi-gc.digital.gov.il/pub/cio/govil/rest"
+        "/contentpage/v1/api/content-pages/dec3994-2026"
+    )
     assert kwargs["params"]["culture"] == "he"
 
 
 def test_fetch_content_404_returns_none():
-    client = GovIlClient()
+    client = GovIlClient(warmup=False)
     fake_session = MagicMock()
     fake_session.get.return_value = _status(404)
     client._session = fake_session
@@ -77,8 +130,31 @@ def test_fetch_content_404_returns_none():
     assert client.fetch_content("dec-deleted") is None
 
 
+def test_list_decisions_non_json_raises_gov_il_api_error():
+    """A 200 with an HTML body (endpoint moved / WAF block) must raise a
+    clear GovIlApiError, NOT the opaque JSONDecodeError that hid the
+    2026-05 migration for a month."""
+    client = GovIlClient(warmup=False)
+    fake_session = MagicMock()
+    fake_session.get.return_value = _html()
+    client._session = fake_session
+
+    with pytest.raises(GovIlApiError, match="non-JSON"):
+        client.list_decisions(skip=0, limit=5)
+
+
+def test_fetch_content_non_json_raises_gov_il_api_error():
+    client = GovIlClient(warmup=False)
+    fake_session = MagicMock()
+    fake_session.get.return_value = _html()
+    client._session = fake_session
+
+    with pytest.raises(GovIlApiError, match="non-JSON"):
+        client.fetch_content("dec3994-2026")
+
+
 def test_download_attachment_returns_bytes():
-    client = GovIlClient()
+    client = GovIlClient(warmup=False)
     fake_session = MagicMock()
     fake_session.get.return_value = _status(200, content=b"%PDF-1.4 test")
     client._session = fake_session
@@ -88,9 +164,37 @@ def test_download_attachment_returns_bytes():
     assert out == b"%PDF-1.4 test"
 
 
+def test_warmup_seeds_cookie_once_before_first_call():
+    """warmup=True: the first real call issues a warmup GET to the gateway
+    root first, and it happens exactly once across multiple calls."""
+    client = GovIlClient(warmup=True, delay_seconds=0)
+    fake_session = MagicMock()
+    fake_session.get.return_value = _ok_json({"total": 0, "results": []})
+    client._session = fake_session
+
+    client.list_decisions(skip=0, limit=5)
+    assert fake_session.get.call_count == 2  # warmup + listing
+    assert fake_session.get.call_args_list[0].args[0] == _WARMUP_URL
+
+    client.list_decisions(skip=5, limit=5)
+    assert fake_session.get.call_count == 3  # +listing only, no 2nd warmup
+
+
+def test_warmup_failure_is_non_fatal():
+    """A raising warmup GET must not abort the run — the real call proceeds."""
+    client = GovIlClient(warmup=True, delay_seconds=0)
+    fake_session = MagicMock()
+    fake_session.get.side_effect = [
+        ConnectionError("warmup boom"),
+        _ok_json({"total": 1, "results": []}),
+    ]
+    client._session = fake_session
+
+    out = client.list_decisions(skip=0, limit=5)
+    assert out == {"total": 1, "results": []}
+
+
 def test_session_uses_chrome_impersonation():
     # The constructor must build a curl_cffi Session with impersonate="chrome".
-    # We verify by inspecting the wrapper attribute set on the session — see
-    # api.py for how this is exposed.
-    client = GovIlClient()
+    client = GovIlClient(warmup=False)
     assert client._impersonate == "chrome"

--- a/tests/document_parser/gov_il_decisions/test_aurora_writer.py
+++ b/tests/document_parser/gov_il_decisions/test_aurora_writer.py
@@ -388,3 +388,36 @@ def test_batched_respects_embedding_batch_size(aurora_db, fake_batch_openai):
     assert result["chunks_written"] == 5
     # 3 batches of sizes [2, 2, 1]
     assert [len(c) for c in fake_batch_openai.batch_calls] == [2, 2, 1]
+
+
+def test_newest_publish_date(aurora_db, fake_embedder):
+    """newest_publish_date returns the max parseable publish_date and is
+    robust to malformed values (regex guard) and empty contexts."""
+    from datetime import date
+
+    from botnim.document_parser.gov_il_decisions.aurora_writer import (
+        get_or_create_context,
+        newest_publish_date,
+        write_decision,
+    )
+
+    cid = get_or_create_context("unified", "government_decisions")
+
+    # Empty context -> None.
+    assert newest_publish_date(cid) is None
+
+    write_decision(
+        cid, page_id="dec-a", title="a", text="גוף החלטה א",
+        metadata={"publish_date": "01.04.2026"}, environment="staging",
+    )
+    write_decision(
+        cid, page_id="dec-b", title="b", text="גוף החלטה ב",
+        metadata={"publish_date": "15.05.2026"}, environment="staging",
+    )
+    # Malformed publish_date must be ignored (regex guard), not error.
+    write_decision(
+        cid, page_id="dec-c", title="c", text="גוף החלטה ג",
+        metadata={"publish_date": "not-a-date"}, environment="staging",
+    )
+
+    assert newest_publish_date(cid) == date(2026, 5, 15)

--- a/tests/document_parser/gov_il_decisions/test_process.py
+++ b/tests/document_parser/gov_il_decisions/test_process.py
@@ -56,11 +56,13 @@ def mocked_writers():
     """Patch aurora_writer functions used by process.py."""
     with patch("botnim.document_parser.gov_il_decisions.process.get_or_create_context") as goc, \
          patch("botnim.document_parser.gov_il_decisions.process.existing_page_ids") as ex, \
+         patch("botnim.document_parser.gov_il_decisions.process.newest_publish_date") as npd, \
          patch("botnim.document_parser.gov_il_decisions.process.write_decision") as wd:
         goc.return_value = "00000000-0000-0000-0000-000000000001"
         ex.return_value = set()
+        npd.return_value = None  # freshness check skips when context is empty
         wd.return_value = 1
-        yield {"goc": goc, "existing": ex, "write": wd}
+        yield {"goc": goc, "existing": ex, "write": wd, "newest": npd}
 
 
 @pytest.fixture
@@ -187,3 +189,48 @@ def test_decision_metadata_shape(mocked_writers, mocked_categorize, mocked_clien
     assert md["office"] == "ראש הממשלה"
     assert md["has_attachment"] is False
     assert md["attachment_urls"] == []
+
+
+def test_freshness_alarm_fires_when_stale(mocked_writers, mocked_categorize, mocked_client_class):
+    """A loud, greppable GOV_IL_DECISIONS_STALE error fires when the newest
+    decision we hold is older than the threshold (the silent-rot guard)."""
+    from datetime import date, timedelta
+
+    from botnim.document_parser.gov_il_decisions import process as proc
+
+    mocked_writers["existing"].return_value = {"dec-OLD"}
+    mocked_writers["newest"].return_value = date.today() - timedelta(days=60)
+    mocked_client_class.list_decisions.side_effect = [
+        {"total": 1, "results": [_make_listing_item("dec-OLD")]},
+        {"total": 1, "results": []},
+    ]
+
+    with patch.object(proc, "logger") as log:
+        proc.process_gov_il_decisions_source(
+            environment="staging", page_size=50, max_pages=2, stale_after_days=30,
+        )
+
+    error_msgs = [c.args[0] for c in log.error.call_args_list]
+    assert any("GOV_IL_DECISIONS_STALE" in m for m in error_msgs)
+
+
+def test_freshness_alarm_silent_when_fresh(mocked_writers, mocked_categorize, mocked_client_class):
+    """No STALE alarm when the newest decision is within the threshold."""
+    from datetime import date, timedelta
+
+    from botnim.document_parser.gov_il_decisions import process as proc
+
+    mocked_writers["existing"].return_value = {"dec-OLD"}
+    mocked_writers["newest"].return_value = date.today() - timedelta(days=2)
+    mocked_client_class.list_decisions.side_effect = [
+        {"total": 1, "results": [_make_listing_item("dec-OLD")]},
+        {"total": 1, "results": []},
+    ]
+
+    with patch.object(proc, "logger") as log:
+        proc.process_gov_il_decisions_source(
+            environment="staging", page_size=50, max_pages=2, stale_after_days=30,
+        )
+
+    error_msgs = [c.args[0] for c in log.error.call_args_list]
+    assert not any("GOV_IL_DECISIONS_STALE" in m for m in error_msgs)


### PR DESCRIPTION
## Why

`government_decisions` stopped ingesting after **2026-05-05** (newest cabinet decision stuck at 2026-04-27) even though every scheduled fap-sync kept reporting success.

**Root cause:** gov.il **migrated its decisions API** off `www.gov.il` to the `openapi-gc.digital.gov.il` gateway. Our hardcoded `www.gov.il/CollectorsWebApi` + `ContentPageWebApi` paths now fall through to the gov.il SPA and return **HTTP 200 `text/html`**. `list_decisions()` called `.json()` on that HTML → opaque `JSONDecodeError`; `raise_for_status()` passed (200), so it wasn't an HTTP error. The exception was swallowed by `fetch_and_process`'s per-context isolation (WARNING + skip) → **silent rot for a month**.

Confirmed via live network capture of the gov.il SPA: it now calls `openapi-gc.digital.gov.il/pub/cio/govil/rest/collectors/v1/api/DataCollector/GetResults`, sending an `x-client-id` header.

## What

- **`api.py`** — point `GovIlClient` at the new gateway (`/pub/cio/govil/rest/{collectors,contentpage}/v1/api`), send the required `x-client-id` header (the SPA's public key, overridable via `GOV_IL_CLIENT_ID`) + `Referer`/`Origin`, and do a **lazy warmup GET** to seed the session cookie the gateway needs (bare session → HTTP 500; warmed → 200). `curl_cffi impersonate="chrome"` still clears the Cloudflare TLS check — **no browser required**. The JSON shape is identical, so all downstream parsing is unchanged.
- **`exceptions.py`** — new `GovIlApiError`.
- **`_json_or_raise` content-type guard** — raises a clear `GovIlApiError` on a non-JSON 200 instead of the opaque `JSONDecodeError` that hid this for a month.
- **`process.py` + `aurora_writer.newest_publish_date()`** — freshness alarm: a loud, greppable `GOV_IL_DECISIONS_STALE` ERROR when the newest in-context decision is older than `stale_after_days` (default 30).

## Verification

- **37 gov_il tests pass** (added: content-type guard, warmup-once, env-override, freshness fires/silent, `newest_publish_date` real-DB).
- **Live end-to-end** with the real client: listing `total=25951`, newest `dec4187 / 01.06.2026` (newest-first), content extraction works, `404 → None`.

## Deploy note

On deploy, the existing skip-already-seen delta backfills the ~6 weeks of decisions accumulated during the outage (bounded categorize + embed; not a cold scrape — 2176 rows already seeded).

## Follow-up

Wire a CloudWatch metric-filter alarm on `GOV_IL_DECISIONS_STALE` so any future upstream change (e.g. gov.il rotating the `x-client-id`) pages instead of rotting silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
