### PR TITLE
Israeli Open Law Book → single source of statutory law (israeli_laws)

### DIFF
--- a/.github/workflows/scrape-wikitext.yml
+++ b/.github/workflows/scrape-wikitext.yml
@@ -31,6 +31,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           botnim fetch-and-process all all wikitext
+          botnim fetch-and-process all all wikisource_law_book
       - name: set git user
         run: |
           git config --global user.email "adam.kariv@gmail.com"

--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -426,19 +426,33 @@ def _collect_raw_streams_files(config_dir: Path, source):
     return [(f.name, f.open('rb'), 'text/markdown', {}) for f in files]
 
 
+def _split_json_file(filename: Path):
+    with open(filename, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    document_name = data.get('metadata', {}).get('document_name', '')
+    if not document_name:
+        input_file = data.get('metadata', {}).get('input_file', '')
+        document_name = Path(input_file).stem
+    document_name = sanitize_filename(document_name)
+    structure = data.get('structure', [])
+    markdown_dict = generate_markdown_dict(structure, document_name)
+    return [(fname, content, 'text/markdown', {}) for fname, content in markdown_dict.items()]
+
+
 def _collect_raw_streams_split(config_dir: Path, context_name, source, offset=0):
+    # Glob support: a source containing '*' expands to every matching file —
+    # the israeli_laws (law-book) context points at
+    # extraction/law_book/*_structure_content.json instead of listing ~2000
+    # laws in config.yaml. generate_markdown_dict prefixes every chunk filename
+    # with the per-law document_name, so chunks never collide across laws.
+    if '*' in str(source):
+        results = []
+        for path in sorted(config_dir.glob(str(source))):
+            results.extend(_split_json_file(path))
+        return results
     filename = config_dir / source
     if filename.suffix == '.json':
-        with open(filename, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-        document_name = data.get('metadata', {}).get('document_name', '')
-        if not document_name:
-            input_file = data.get('metadata', {}).get('input_file', '')
-            document_name = Path(input_file).stem
-        document_name = sanitize_filename(document_name)
-        structure = data.get('structure', [])
-        markdown_dict = generate_markdown_dict(structure, document_name)
-        return [(fname, content, 'text/markdown', {}) for fname, content in markdown_dict.items()]
+        return _split_json_file(filename)
     else:
         content = filename.read_text()
         parts = content.split('\n---\n')

--- a/botnim/document_parser/wikisource_law_book/classify.py
+++ b/botnim/document_parser/wikisource_law_book/classify.py
@@ -1,0 +1,22 @@
+"""Classify a WikiSource page title as primary law, secondary regulation, or noise.
+
+Classification by leading token is deliberate: it doubles as the noise filter
+(navigation / Help / project pages never start with a statute keyword) and
+needs no network call.
+"""
+
+# Primary legislation
+_LAW_PREFIXES = ("חוק ", "חוק-יסוד", "חוק יסוד", "פקודת ", "פקודה ")
+# Secondary legislation
+_REGULATION_PREFIXES = ("תקנות ", "צו ", "צווי ", "כללי ", "כללים ", "הוראות ", "תקנון ")
+
+
+def classify_title(title: str) -> str:
+    t = (title or "").strip()
+    for p in _LAW_PREFIXES:
+        if t.startswith(p):
+            return "law"
+    for p in _REGULATION_PREFIXES:
+        if t.startswith(p):
+            return "regulation"
+    return "other"

--- a/botnim/document_parser/wikisource_law_book/classify.py
+++ b/botnim/document_parser/wikisource_law_book/classify.py
@@ -9,6 +9,12 @@ needs no network call.
 _LAW_PREFIXES = ("חוק ", "חוק-יסוד", "חוק יסוד", "פקודת ", "פקודה ")
 # Secondary legislation
 _REGULATION_PREFIXES = ("תקנות ", "צו ", "צווי ", "כללי ", "כללים ", "הוראות ", "תקנון ")
+# Carry-over items from the legal_text context that classify as "other" by
+# leading token (they start with החלט…) but must be ingested into israeli_laws
+# for the single-source consolidation. Kept as an explicit, narrow allow-list —
+# we deliberately do NOT broaden to all החלטות/הנחיות, which would pull in
+# government decisions and other noise.
+_CARRYOVER_REGULATION_PREFIXES = ("החלטת שכר חברי הכנסת",)
 
 
 def classify_title(title: str) -> str:
@@ -17,6 +23,9 @@ def classify_title(title: str) -> str:
         if t.startswith(p):
             return "law"
     for p in _REGULATION_PREFIXES:
+        if t.startswith(p):
+            return "regulation"
+    for p in _CARRYOVER_REGULATION_PREFIXES:
         if t.startswith(p):
             return "regulation"
     return "other"

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -1,0 +1,86 @@
+"""Enumerate every law/regulation in ספר החוקים הפתוח from the WikiSource index.
+
+Network surface is exactly one function (`fetch_index_titles`) so tests stay
+hermetic. The MediaWiki `parse&prop=links` call returns every main-namespace
+page linked from the index (transclusions followed), which we classify by
+leading token and filter through the legal_text skip-list.
+"""
+from pathlib import Path
+import requests
+
+from ...config import get_logger
+from .classify import classify_title
+from .manifest import LawBookEntry
+from .skip_list import legal_text_skip_titles
+
+logger = get_logger(__name__)
+
+API_URL = "https://he.wikisource.org/w/api.php"
+INDEX_PAGE = "ספר_החוקים_הפתוח"
+_HEADERS = {"User-Agent": "botnim-law-book/1.0 (+https://botnim.build-up.team)"}
+
+
+class CoverageShrinkError(Exception):
+    """Discovery returned materially fewer items than expected — refuse to
+    overwrite a good manifest with a truncated one."""
+
+
+def url_for_title(title: str) -> str:
+    # Keep Hebrew (non-ASCII) characters unencoded — MediaWiki and browsers accept them;
+    # only encode ASCII special chars. Spaces become underscores per wiki convention.
+    return "https://he.wikisource.org/wiki/" + title.replace(" ", "_")
+
+
+def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> list[str]:
+    """Return all main-namespace (ns==0) page titles linked from the index."""
+    resp = requests.get(api_url, headers=_HEADERS, params={
+        "action": "parse", "page": index_page, "prop": "links", "format": "json",
+    }, timeout=60)
+    resp.raise_for_status()
+    links = resp.json()["parse"]["links"]
+    return [l["*"] for l in links if l.get("ns") == 0 and "exists" in l]
+
+
+def discover_law_pages(config_dir, *, include_regulations: bool,
+                       min_expected_laws: int = 200,
+                       prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
+    config_dir = Path(config_dir)
+    skip = legal_text_skip_titles(config_dir)
+    raw_titles = fetch_index_titles()
+
+    wanted = {"law", "regulation"} if include_regulations else {"law"}
+    entries: list[LawBookEntry] = []
+    laws_found = regs_found = skipped = 0
+    seen: set[str] = set()
+    for title in raw_titles:
+        kind = classify_title(title)
+        if kind == "law":
+            laws_found += 1
+        elif kind == "regulation":
+            regs_found += 1
+        if kind not in wanted:
+            continue
+        if title in skip:
+            skipped += 1
+            continue
+        if title in seen:
+            continue
+        seen.add(title)
+        entries.append(LawBookEntry(title=title, url=url_for_title(title), kind=kind))
+
+    logger.info("LAW_BOOK_DISCOVER laws_found=%d regulations_found=%d skipped=%d selected=%d",
+                laws_found, regs_found, skipped, len(entries))
+
+    # Guard #1: absolute floor — a broken enumerator returns ~0.
+    if laws_found < min_expected_laws:
+        raise CoverageShrinkError(
+            f"only {laws_found} laws discovered (< floor {min_expected_laws}); "
+            f"refusing to overwrite manifest")
+    # Guard #2: relative shrink vs. last committed manifest.
+    if prior:
+        prior_count = len([e for e in prior if e.kind in wanted])
+        if prior_count and len(entries) < prior_count * 0.9:
+            raise CoverageShrinkError(
+                f"discovery shrank to {len(entries)} from {prior_count} (>10% drop); "
+                f"refusing to overwrite manifest")
+    return entries

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -43,14 +43,9 @@ def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> 
 
 def discover_law_pages(config_dir, *, include_regulations: bool,
                        min_expected_laws: int = 200,
-                       apply_skip_list: bool = True,
                        prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
     config_dir = Path(config_dir)
-    # The skip-list is derived from the legal_text context so israeli_laws does
-    # not double-index those laws. During the single-source consolidation we set
-    # apply_skip_list=False so israeli_laws finally ingests the legal_text laws
-    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
-    skip = legal_text_skip_titles(config_dir) if apply_skip_list else set()
+    skip = legal_text_skip_titles(config_dir)
     raw_titles = fetch_index_titles()
 
     wanted = {"law", "regulation"} if include_regulations else {"law"}

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -43,9 +43,14 @@ def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> 
 
 def discover_law_pages(config_dir, *, include_regulations: bool,
                        min_expected_laws: int = 200,
+                       apply_skip_list: bool = True,
                        prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
     config_dir = Path(config_dir)
-    skip = legal_text_skip_titles(config_dir)
+    # The skip-list is derived from the legal_text context so israeli_laws does
+    # not double-index those laws. During the single-source consolidation we set
+    # apply_skip_list=False so israeli_laws finally ingests the legal_text laws
+    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
+    skip = legal_text_skip_titles(config_dir) if apply_skip_list else set()
     raw_titles = fetch_index_titles()
 
     wanted = {"law", "regulation"} if include_regulations else {"law"}

--- a/botnim/document_parser/wikisource_law_book/manifest.py
+++ b/botnim/document_parser/wikisource_law_book/manifest.py
@@ -1,0 +1,37 @@
+"""Committed coverage manifest for the law-book corpus.
+
+One row per discovered statute/regulation. Committing it makes the corpus
+reviewable and diffable, and decouples enumeration from extraction (an
+operator can run discovery, eyeball the CSV, then extract).
+"""
+import csv
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+MANIFEST_COLUMNS = ["title", "url", "kind", "status"]
+
+
+@dataclass
+class LawBookEntry:
+    title: str
+    url: str
+    kind: str          # 'law' | 'regulation'
+    status: str = "pending"   # 'pending' | 'ok' | 'failed' | 'skipped'
+
+
+def write_manifest(path: Path, entries: list[LawBookEntry]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=MANIFEST_COLUMNS)
+        w.writeheader()
+        for e in entries:
+            w.writerow(asdict(e))
+
+
+def read_manifest(path: Path) -> list[LawBookEntry]:
+    path = Path(path)
+    if not path.exists():
+        return []
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        return [LawBookEntry(**row) for row in csv.DictReader(f)]

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -21,7 +21,6 @@ LAW_BOOK_SUBDIR = "law_book"
 def process_law_book_source(environment: str, config_dir: Path, *,
                             include_regulations: bool = True,
                             min_expected_laws: int = 200,
-                            apply_skip_list: bool = True,
                             rate_limit_seconds: float = 0.3,
                             **_ignored) -> None:
     config_dir = Path(config_dir)
@@ -31,8 +30,7 @@ def process_law_book_source(environment: str, config_dir: Path, *,
     prior = read_manifest(manifest_path)
     entries = discover_law_pages(
         config_dir, include_regulations=include_regulations,
-        min_expected_laws=min_expected_laws, apply_skip_list=apply_skip_list,
-        prior=prior or None,
+        min_expected_laws=min_expected_laws, prior=prior or None,
     )
     # Persist the discovered set (all 'pending') BEFORE extraction so a crash
     # mid-corpus still leaves a reviewable manifest.

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -41,7 +41,7 @@ def process_law_book_source(environment: str, config_dir: Path, *,
         try:
             cfg = WikitextProcessorConfig(
                 input_url=entry.url, output_base_dir=out_dir,
-                content_type="סעיף", environment=environment,
+                content_type="סעיף", environment=Environment(environment),
                 model="gpt-4.1-mini", max_tokens=None,
             )
             entry.status = "ok" if WikitextProcessor(cfg).run(generate_markdown=False) else "failed"

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -21,6 +21,7 @@ LAW_BOOK_SUBDIR = "law_book"
 def process_law_book_source(environment: str, config_dir: Path, *,
                             include_regulations: bool = True,
                             min_expected_laws: int = 200,
+                            apply_skip_list: bool = True,
                             rate_limit_seconds: float = 0.3,
                             **_ignored) -> None:
     config_dir = Path(config_dir)
@@ -30,7 +31,8 @@ def process_law_book_source(environment: str, config_dir: Path, *,
     prior = read_manifest(manifest_path)
     entries = discover_law_pages(
         config_dir, include_regulations=include_regulations,
-        min_expected_laws=min_expected_laws, prior=prior or None,
+        min_expected_laws=min_expected_laws, apply_skip_list=apply_skip_list,
+        prior=prior or None,
     )
     # Persist the discovered set (all 'pending') BEFORE extraction so a crash
     # mid-corpus still leaves a reviewable manifest.

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -1,0 +1,60 @@
+# botnim/document_parser/wikisource_law_book/process.py
+"""fap driver: discover the law-book corpus, then extract each item through the
+existing WikitextProcessor (one *_structure_content.json per law under
+extraction/law_book/). Reusing WikitextProcessor is mandatory — it writes the
+html_sha256 + extractor-version metadata that makes re-faps cheap (cache skip).
+"""
+import time
+from pathlib import Path
+
+from ...config import get_logger
+from ..wikitext.pipeline_config import Environment, WikitextProcessorConfig
+from ..wikitext.process_document import WikitextProcessor
+from .enumerate_laws import discover_law_pages
+from .manifest import LawBookEntry, read_manifest, write_manifest
+
+logger = get_logger(__name__)
+
+LAW_BOOK_SUBDIR = "law_book"
+
+
+def process_law_book_source(environment: str, config_dir: Path, *,
+                            include_regulations: bool = True,
+                            min_expected_laws: int = 200,
+                            rate_limit_seconds: float = 0.3,
+                            **_ignored) -> None:
+    config_dir = Path(config_dir)
+    out_dir = config_dir / "extraction" / LAW_BOOK_SUBDIR
+    manifest_path = out_dir / "manifest.csv"
+
+    prior = read_manifest(manifest_path)
+    entries = discover_law_pages(
+        config_dir, include_regulations=include_regulations,
+        min_expected_laws=min_expected_laws, prior=prior or None,
+    )
+    # Persist the discovered set (all 'pending') BEFORE extraction so a crash
+    # mid-corpus still leaves a reviewable manifest.
+    write_manifest(manifest_path, entries)
+
+    ok = failed = 0
+    for i, entry in enumerate(entries):
+        try:
+            cfg = WikitextProcessorConfig(
+                input_url=entry.url, output_base_dir=out_dir,
+                content_type="סעיף", environment=environment,
+                model="gpt-4.1-mini", max_tokens=None,
+            )
+            entry.status = "ok" if WikitextProcessor(cfg).run(generate_markdown=False) else "failed"
+        except Exception as e:  # per-item isolation — one bad page never aborts the corpus
+            logger.warning("LAW_BOOK_ITEM_FAILED title=%s url=%s err=%s: %s",
+                           entry.title, entry.url, type(e).__name__, e)
+            entry.status = "failed"
+        ok += entry.status == "ok"
+        failed += entry.status == "failed"
+        if (i + 1) % 25 == 0:
+            write_manifest(manifest_path, entries)   # checkpoint progress
+        if rate_limit_seconds:
+            time.sleep(rate_limit_seconds)
+
+    write_manifest(manifest_path, entries)
+    logger.info("LAW_BOOK_DONE total=%d ok=%d failed=%d", len(entries), ok, failed)

--- a/botnim/document_parser/wikisource_law_book/skip_list.py
+++ b/botnim/document_parser/wikisource_law_book/skip_list.py
@@ -1,0 +1,27 @@
+"""Derive the set of laws already covered by the `legal_text` context so the
+bulk law-book ingestion can skip them (no double-indexing). Sourced from
+config.yaml at runtime so it can never drift from reality.
+"""
+from pathlib import Path
+from urllib.parse import unquote
+import yaml
+
+
+def title_from_url(url: str) -> str:
+    """`.../wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA` -> `חוק הכנסת`."""
+    tail = unquote(url).split("/wiki/")[-1]
+    return tail.replace("_", " ").strip()
+
+
+def legal_text_skip_titles(config_dir: Path) -> set[str]:
+    cfg = yaml.safe_load((Path(config_dir) / "config.yaml").read_text(encoding="utf-8"))
+    titles: set[str] = set()
+    for ctx in cfg.get("context", []):
+        if ctx.get("slug") != "legal_text":
+            continue
+        for src in ctx.get("sources", []):
+            fetcher = src.get("fetcher") or {}
+            url = fetcher.get("input_url")
+            if url:
+                titles.add(title_from_url(url))
+    return titles

--- a/botnim/document_parser/wikitext/pipeline_config.py
+++ b/botnim/document_parser/wikitext/pipeline_config.py
@@ -35,6 +35,17 @@ def sanitize_filename(filename):
     filename = re.sub(r'[_\s]+', '_', filename)
     # Remove leading/trailing underscores
     filename = filename.strip('_')
+    # Cap length: a filename is limited to 255 BYTES. With the
+    # "_structure_content.json" suffix and multi-byte Hebrew, long regulation
+    # titles (e.g. צו איסור הלבנת הון (חובות זיהוי, דיווח...)) exceed that and
+    # raise OSError(ENAMETOOLONG). Truncate to a safe byte budget and append a
+    # short stable hash of the full name to preserve uniqueness across titles
+    # that share a long common prefix.
+    MAX_BYTES = 180
+    if len(filename.encode('utf-8')) > MAX_BYTES:
+        digest = hashlib.sha1(filename.encode('utf-8')).hexdigest()[:8]
+        truncated = filename.encode('utf-8')[:MAX_BYTES].decode('utf-8', 'ignore').rstrip('_')
+        filename = f'{truncated}_{digest}'
     return filename
 
 

--- a/botnim/fetch_and_process.py
+++ b/botnim/fetch_and_process.py
@@ -128,6 +128,16 @@ def fetch_and_process_source(environment, config_dir, context_name, source, kind
         # context_snapshots so /admin/sources reflects this context.
         from .document_parser.gov_il_decisions.process import process_gov_il_decisions_source
         process_gov_il_decisions_source(environment=environment, **fetcher)
+    elif fetcher_kind == 'wikisource_law_book':
+        # Index-driven bulk ingestion of ספר החוקים הפתוח. Unlike `wikitext`
+        # (one law per source entry), this discovers ~all laws/regulations
+        # from the WikiSource index and runs each through WikitextProcessor,
+        # writing one *_structure_content.json per item under
+        # extraction/law_book/. The israeli_laws context reads them via a
+        # glob `split` source. `source['source']` (the glob) is unused here —
+        # the driver owns its output paths.
+        from .document_parser.wikisource_law_book.process import process_law_book_source
+        process_law_book_source(environment, config_dir, **fetcher)
 
 def fetch_and_process_context(environment, context, config_dir: Path, kind):
     context_name = context['name']

--- a/scripts/backfill-law-name.py
+++ b/scripts/backfill-law-name.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Backfill a normalized `law_name` field into israeli_laws document metadata.
+
+`law_name` = the base law title (DocumentTitle's prefix before " - "), which
+collapses the section/chapter title variants ("תקנון הכנסת", "תקנון הכנסת - חלק
+ד׳…", "תקנון הכנסת - הליך החקיקה" → all "תקנון הכנסת"). This is what the
+israeli_laws retrieve op's `metadata_filter={"law_name":"<law>"}` matches via
+JSONB exact containment, scoping a search to ONE law and eliminating cross-law
+section-number collisions (hundreds of laws share a "סעיף 86").
+
+Metadata-only UPDATE — does not touch embeddings or content_hash. Run after an
+israeli_laws sync (the gap laws / rich-metadata docs gain DocumentTitle; the
+embed-only thin docs have none and are skipped). Reads DATABASE_URL from env;
+defaults to the local aurora-local container.
+
+    DATABASE_URL=postgresql://botnim:botnim@localhost:54320/botnim_local \\
+        python scripts/backfill-law-name.py
+"""
+import os
+import psycopg
+
+DSN = os.environ.get("DATABASE_URL", "postgresql://botnim:botnim@localhost:54320/botnim_local")
+# session.py-style normalisation: psycopg connects with a plain libpq DSN
+if DSN.startswith("postgresql+psycopg://"):
+    DSN = "postgresql://" + DSN[len("postgresql+psycopg://"):]
+
+conn = psycopg.connect(DSN, autocommit=True)
+n = conn.execute("""
+    UPDATE documents d
+    SET metadata = d.metadata || jsonb_build_object(
+        'law_name', trim(split_part(d.metadata->>'DocumentTitle', ' - ', 1)))
+    FROM contexts c
+    WHERE d.context_id = c.id AND c.name = 'israeli_laws'
+      AND d.metadata ? 'DocumentTitle'
+      AND coalesce(d.metadata->>'DocumentTitle', '') <> ''
+""").rowcount
+print(f"backfilled law_name on {n} israeli_laws documents")

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -161,7 +161,7 @@
     },
     "/botnim/retrieve/unified/israeli_laws__dev": {
       "get": {
-        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). Use for ANY question about what an Israeli statute says, who it applies to, its definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק הגנת הפרטיות, חוק חופש המידע, פקודת מס הכנסה. Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when the user references a specific סעיף by number. NOTE: this is the consolidated text as maintained on ויקיטקסט — not the official רשומות, and not a substitute for legal advice. This is the general-law corpus; for Knesset internal procedure use the takanon/legal_text tools instead.",
+        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). This is the SINGLE source for Israeli statutory law — INCLUDING תקנון הכנסת (Knesset bylaws), the Knesset laws (חוק הכנסת, חוק־יסוד: הכנסת, חוק חסינות חברי הכנסת…), and כללי אתיקה לחברי הכנסת. Use for ANY question about what a law says, who it applies to, its definitions, offences, penalties, and procedures — including Knesset internal procedure (e.g. תקנון הכנסת סעיף 86, הקמת ועדת חקירה פרלמנטרית). Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when a specific סעיף is referenced. For a question about a SPECIFIC named law, ALSO pass metadata_filter={\"law_name\":\"<exact law name>\"} to scope the search to that law and avoid cross-law section-number collisions (hundreds of laws have a 'סעיף 86'). NOTE: consolidated text as maintained on ויקיטקסט — not the official רשומות, not legal advice.",
         "operationId": "search_unified__israeli_laws__dev",
         "parameters": [
           {
@@ -197,6 +197,15 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 50
+            }
+          },
+          {
+            "name": "metadata_filter",
+            "in": "query",
+            "description": "JSON object for a JSONB exact-match filter on document metadata. Use {\"law_name\":\"<exact base law name>\"} to scope the search to ONE law and eliminate cross-law section-number collisions — STRONGLY recommended for any named-law or תקנון query (e.g. {\"law_name\":\"תקנון הכנסת\"}, {\"law_name\":\"חוק האזנת סתר\"}, {\"law_name\":\"כללי אתיקה לחברי הכנסת\"}). law_name is the base law title only — no chapter/section suffix. Omit for broad 'what does any law say' searches across the whole corpus.",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -115,50 +115,6 @@
         "deprecated": false
       }
     },
-    "/botnim/retrieve/unified/legal_text__dev": {
-      "get": {
-        "description": "Search laws, bylaws and regulations in the unified legal knowledge base",
-        "operationId": "search_unified__legal_text__dev",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "description": "Free text search query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search_mode",
-            "in": "query",
-            "description": "Search mode for different types of queries",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "SECTION_NUMBER",
-                "REGULAR",
-                "METADATA_BROWSE"
-              ],
-              "default": "REGULAR"
-            }
-          },
-          {
-            "name": "num_results",
-            "in": "query",
-            "description": "Number of results to return",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50
-            }
-          }
-        ],
-        "deprecated": false
-      }
-    },
     "/botnim/retrieve/unified/israeli_laws__dev": {
       "get": {
         "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). This is the SINGLE source for Israeli statutory law — INCLUDING תקנון הכנסת (Knesset bylaws), the Knesset laws (חוק הכנסת, חוק־יסוד: הכנסת, חוק חסינות חברי הכנסת…), and כללי אתיקה לחברי הכנסת. Use for ANY question about what a law says, who it applies to, its definitions, offences, penalties, and procedures — including Knesset internal procedure (e.g. תקנון הכנסת סעיף 86, הקמת ועדת חקירה פרלמנטרית). Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when a specific סעיף is referenced. For a question about a SPECIFIC named law, ALSO pass metadata_filter={\"law_name\":\"<exact law name>\"} to scope the search to that law and avoid cross-law section-number collisions (hundreds of laws have a 'סעיף 86'). NOTE: consolidated text as maintained on ויקיטקסט — not the official רשומות, not legal advice.",

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -159,6 +159,50 @@
         "deprecated": false
       }
     },
+    "/botnim/retrieve/unified/israeli_laws__dev": {
+      "get": {
+        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). Use for ANY question about what an Israeli statute says, who it applies to, its definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק הגנת הפרטיות, חוק חופש המידע, פקודת מס הכנסה. Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when the user references a specific סעיף by number. NOTE: this is the consolidated text as maintained on ויקיטקסט — not the official רשומות, and not a substitute for legal advice. This is the general-law corpus; for Knesset internal procedure use the takanon/legal_text tools instead.",
+        "operationId": "search_unified__israeli_laws__dev",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Free text search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search_mode",
+            "in": "query",
+            "description": "Search mode for different types of queries",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "SECTION_NUMBER",
+                "REGULAR",
+                "METADATA_BROWSE"
+              ],
+              "default": "REGULAR"
+            }
+          },
+          {
+            "name": "num_results",
+            "in": "query",
+            "description": "Number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          }
+        ],
+        "deprecated": false
+      }
+    },
     "/botnim/retrieve/unified/legal_advisor_opinions__dev": {
       "get": {
         "description": "Search formal legal opinions by Knesset legal advisor. THREE modes — choose by intent: (a) 'מה ההנחיות/חוות הדעת האחרונות', 'הכי עדכניות', 'הכי חדשות', 'מה התפרסם לאחרונה' → use search_mode=RECENCY_BROWSE: returns the calendar-newest documents in pure date-desc order (no similarity ranking, immune to query-phrasing bias). (b) 'אילו חוות דעת יש על X', 'תן לי רשימה של…', browse/enumerate intent on a TOPIC → search_mode=METADATA_BROWSE: similarity-ranked summaries (25 docs). (c) substantive content question requiring full text → leave search_mode=REGULAR (default). For (a) and (b), present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results — they are already newest-first.",

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -1,7 +1,8 @@
 slug: unified
 name: בוטנים
-description: עונה על שאלות מתוך תקנון הכנסת וחוקים נלווים וכן על שאלות בנושאי תקציב
-  המדינה, הכנסות המדינה, התקשרויות ותמיכות תקציביות
+description: עונה על שאלות מתוך תקנון הכנסת וחוקים נלווים, מתוך ספר החוקים הפתוח
+  (החקיקה הראשית והמשנית של מדינת ישראל), וכן על שאלות בנושאי תקציב המדינה,
+  הכנסות המדינה, התקשרויות ותמיכות תקציביות
 tools:
 - code-interpreter
 - budgetkey
@@ -88,6 +89,30 @@ context:
     fetcher:
       kind: wikitext
       input_url: https://he.wikisource.org/wiki/%D7%94%D7%97%D7%9C%D7%98%D7%AA_%D7%A9%D7%9B%D7%A8_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA_(%D7%94%D7%A2%D7%A0%D7%A7%D7%95%D7%AA_%D7%95%D7%AA%D7%A9%D7%9C%D7%95%D7%9E%D7%99%D7%9D)
+- slug: israeli_laws
+  name: ספר החוקים הפתוח — חקיקה ראשית ומשנית של מדינת ישראל
+  description: 'Search the full text of Israeli primary and secondary legislation
+    (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח).
+    Use for: any question about what an Israeli statute says, who it applies to,
+    definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק
+    הגנת הפרטיות, חוק חופש המידע. Each result is one section (סעיף) with its
+    chapter context. Cite the law name + section + the WikiSource source_url.
+    NOTE: this is the consolidated text as maintained on ויקיטקסט — not the
+    official רשומות, and not a substitute for legal advice.'
+  examples: 'האם חוק האזנת סתר חל על אזרחים, מה העונש על האזנת סתר, הגדרת מידע
+    לפי חוק הגנת הפרטיות, מתי מותר לרשות לסרב לבקשת חופש מידע'
+  # Title-rich Hebrew legal corpus — verbatim law-name queries rank far better
+  # under trigram/BM25 than text-embedding-3-small cosine. Same rationale as
+  # legal_text (see its block above) and the legal_advisor contexts.
+  use_lexical_search: true
+  lexical_strategy: trigram
+  sources:
+  - type: split
+    source: extraction/law_book/*_structure_content.json
+    fetcher:
+      kind: wikisource_law_book
+      include_regulations: true
+      min_expected_laws: 200
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -25,70 +25,12 @@ context:
     source: extraction/lexicon.csv
     fetcher:
       kind: lexicon
-  - type: split
-    source: extraction/כללי_אתיקה_לחברי_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%9B%D7%9C%D7%9C%D7%99_%D7%90%D7%AA%D7%99%D7%A7%D7%94_%D7%9C%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_הפרשנות_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%A4%D7%A8%D7%A9%D7%A0%D7%95%D7%AA
-- slug: legal_text
-  name: Knesset Bylaws (תקנון הכנסת) and related laws
-  # Hebrew-friendly retrieval. The default `tsquery` BM25 strategy uses PG's
-  # `simple` tsconfig which has no Hebrew analyzer — so construct-state
-  # alternation (ועדת↔ועדה↔ועדות) is invisible and procedural-question
-  # queries miss the relevant sections. Switched to `trigram` (pg_trgm
-  # word_similarity, GIN-indexed via migration 0015) on 2026-05-13.
-  # Local A/B on prod-equivalent query "מה הדרך ליזום ועדת חקירה ממלכתית":
-  #   tsquery: 0/3 prod-cited sections in top-8 (§22 / §129 / §135)
-  #   trigram: 3/3 prod-cited sections in top-8
-  # See vector_store_aurora.py _LEXICAL_STRATEGY_* for full rationale.
-  use_lexical_search: true
-  lexical_strategy: trigram
-  sources:
-  - type: split
-    source: extraction/חוק_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_משכן_הכנסת,_רחבתו_ומשמר_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%9E%D7%A9%D7%9B%D7%9F_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA,_%D7%A8%D7%97%D7%91%D7%AA%D7%95_%D7%95%D7%9E%D7%A9%D7%9E%D7%A8_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק-יסוד_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7-%D7%99%D7%A1%D7%95%D7%93:_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_חסינות_חברי_הכנסת,_זכויותיהם_וחובותיהם_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%97%D7%A1%D7%99%D7%A0%D7%95%D7%AA_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA,_%D7%96%D7%9B%D7%95%D7%99%D7%95%D7%AA%D7%99%D7%94%D7%9D_%D7%95%D7%97%D7%95%D7%91%D7%95%D7%AA%D7%99%D7%94%D7%9D
-  - type: split
-    source: extraction/חוק_לציון_מידע_בדבר_השפעת_חקיקה_על_זכויות_הילד_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%9C%D7%A6%D7%99%D7%95%D7%9F_%D7%9E%D7%99%D7%93%D7%A2_%D7%91%D7%93%D7%91%D7%A8_%D7%94%D7%A9%D7%A4%D7%A2%D7%AA_%D7%97%D7%A7%D7%99%D7%A7%D7%94_%D7%A2%D7%9C_%D7%96%D7%9B%D7%95%D7%99%D7%95%D7%AA_%D7%94%D7%99%D7%9C%D7%93
-  - type: split
-    source: extraction/חוק_רציפות_הדיון_בהצעות_חוק_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%A8%D7%A6%D7%99%D7%A4%D7%95%D7%AA_%D7%94%D7%93%D7%99%D7%95%D7%9F_%D7%91%D7%94%D7%A6%D7%A2%D7%95%D7%AA_%D7%97%D7%95%D7%A7
-  - type: split
-    source: extraction/תקנון_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%AA%D7%A7%D7%A0%D7%95%D7%9F_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/החלטת_שכר_חברי_הכנסת_(הענקות_ותשלומים)_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%94%D7%97%D7%9C%D7%98%D7%AA_%D7%A9%D7%9B%D7%A8_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA_(%D7%94%D7%A2%D7%A0%D7%A7%D7%95%D7%AA_%D7%95%D7%AA%D7%A9%D7%9C%D7%95%D7%9E%D7%99%D7%9D)
+  # Law content (כללי אתיקה, חוק הפרשנות) moved to israeli_laws (single source
+  # of statutory law). This context is glossary-only now.
+# legal_text retired 2026-06-22 — israeli_laws (the open law book) is now the
+# single source of statutory law. All 8 of its laws (תקנון הכנסת, חוק הכנסת,
+# חוק־יסוד: הכנסת, חוק חסינות, …, החלטת שכר) live in israeli_laws; the gold-set
+# §86 / ועדת חקירה queries pass at parity-or-better via metadata_filter law_name.
 - slug: israeli_laws
   name: ספר החוקים הפתוח — חקיקה ראשית ומשנית של מדינת ישראל
   description: 'Search the full text of Israeli primary and secondary legislation

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -113,10 +113,6 @@ context:
       kind: wikisource_law_book
       include_regulations: true
       min_expected_laws: 200
-      # Single-source consolidation: ingest the legal_text laws (incl. תקנון
-      # הכנסת) into israeli_laws too. legal_text still exists during the parity
-      # gate; once it is retired the skip-list is empty anyway.
-      apply_skip_list: false
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -113,6 +113,10 @@ context:
       kind: wikisource_law_book
       include_regulations: true
       min_expected_laws: 200
+      # Single-source consolidation: ingest the legal_text laws (incl. תקנון
+      # הכנסת) into israeli_laws too. legal_text still exists during the parity
+      # gate; once it is retired the skip-list is empty anyway.
+      apply_skip_list: false
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -276,3 +276,37 @@ def test_csv_content_hash_stable_across_file_last_updated_change(tmp_path):
     assert content_a == content_b, "content must not vary with file_last_updated"
     h = lambda s: _hashlib.sha256(s.strip().encode("utf-8")).hexdigest()
     assert h(content_a) == h(content_b)
+
+
+# -----------------------------------------------------------------------------
+# Glob support in _collect_raw_streams_split (Task 7 — israeli_laws context)
+# -----------------------------------------------------------------------------
+
+import json as _json  # noqa: E402
+
+from botnim.collect_sources import _collect_raw_streams_split  # noqa: E402
+
+
+def _write_law_json(path: Path, document_name: str, section_name: str, content: str):
+    path.write_text(_json.dumps({
+        "metadata": {"document_name": document_name},
+        "structure": [{"depth": 1, "section_name": section_name,
+                       "section_type": "סעיף", "content": content, "children": []}],
+    }, ensure_ascii=False), encoding="utf-8")
+
+
+def test_split_glob_reads_all_law_jsons(tmp_path: Path):
+    d = tmp_path / "extraction" / "law_book"
+    d.mkdir(parents=True)
+    _write_law_json(d / "חוק_א_structure_content.json", "חוק א", "סעיף 1", "תוכן א")
+    _write_law_json(d / "חוק_ב_structure_content.json", "חוק ב", "סעיף 1", "תוכן ב")
+
+    out = _collect_raw_streams_split(tmp_path, "israeli_laws",
+                                     "extraction/law_book/*_structure_content.json")
+    names = sorted(fname for fname, _c, _t, _m in out)
+    # document_name prefixes every chunk filename → no collision across laws.
+    # sanitize_filename converts spaces to underscores in both document_name
+    # and section_name components, so "חוק א" + "סעיף 1" → "חוק_א_סעיף_1.md".
+    assert names == ["חוק_א_סעיף_1.md", "חוק_ב_סעיף_1.md"]
+    bodies = " ".join(c for _f, c, _t, _m in out)
+    assert "תוכן א" in bodies and "תוכן ב" in bodies

--- a/tests/test_config_israeli_laws.py
+++ b/tests/test_config_israeli_laws.py
@@ -1,0 +1,17 @@
+# tests/test_config_israeli_laws.py
+from pathlib import Path
+import yaml
+from botnim.config import SPECS
+
+
+def test_israeli_laws_context_registered():
+    cfg = yaml.safe_load((SPECS / "unified" / "config.yaml").read_text(encoding="utf-8"))
+    ctx = {c["slug"]: c for c in cfg["context"]}
+    assert "israeli_laws" in ctx
+    il = ctx["israeli_laws"]
+    assert il.get("use_lexical_search") is True
+    assert il.get("lexical_strategy") == "trigram"
+    srcs = il["sources"]
+    assert any(s.get("type") == "split" and "*" in s.get("source", "") for s in srcs)
+    fetcher = next(s["fetcher"] for s in srcs if s.get("fetcher"))
+    assert fetcher["kind"] == "wikisource_law_book"

--- a/tests/test_fetch_and_process_dispatch.py
+++ b/tests/test_fetch_and_process_dispatch.py
@@ -138,3 +138,16 @@ def test_indexed_pdf_end_to_end_empty_index(tmp_path: Path):
     # 0-row index + no pre-existing output → the empty-out branch wrote
     # extraction/x.csv with just the header.
     assert (tmp_path / "extraction" / "x.csv").exists()
+
+
+def test_dispatch_wikisource_law_book(tmp_path: Path):
+    src = {"source": "extraction/law_book/*_structure_content.json",
+           "fetcher": {"kind": "wikisource_law_book", "include_regulations": True}}
+    with patch(
+        "botnim.document_parser.wikisource_law_book.process.process_law_book_source"
+    ) as mock_inner:
+        from botnim.fetch_and_process import fetch_and_process_source
+        fetch_and_process_source("local", tmp_path, "ctx", src, "all")
+        mock_inner.assert_called_once()
+        # environment + config_dir positional; include_regulations forwarded
+        assert mock_inner.call_args.kwargs.get("include_regulations") is True

--- a/tests/test_law_book_classify.py
+++ b/tests/test_law_book_classify.py
@@ -12,10 +12,16 @@ from botnim.document_parser.wikisource_law_book.classify import classify_title
     ("תקנות הגנת הפרטיות (אבטחת מידע)", "regulation"),
     ("צו המועצות המקומיות", "regulation"),
     ("כללי לשכת עורכי הדין", "regulation"),
+    ("תקנון הכנסת", "regulation"),
     ("ויקיטקסט:אודות", "other"),
     ("עזרה:תוכן", "other"),
     ("מדיניות הפרטיות", "other"),
     ("", "other"),
+    # legal_text carry-over: starts with החלט (→ "other" by default) but must be
+    # ingested into israeli_laws for the single-source consolidation.
+    ("החלטת שכר חברי הכנסת (הענקות ותשלומים)", "regulation"),
+    # guard: the carry-over allow-list stays narrow — generic החלטות stay "other".
+    ("החלטת ממשלה מספר 550", "other"),
 ])
 def test_classify_title(title, expected):
     assert classify_title(title) == expected

--- a/tests/test_law_book_classify.py
+++ b/tests/test_law_book_classify.py
@@ -1,0 +1,21 @@
+import pytest
+from botnim.document_parser.wikisource_law_book.classify import classify_title
+
+
+@pytest.mark.parametrize("title,expected", [
+    ("חוק האזנת סתר", "law"),
+    ("חוק הגנת הפרטיות", "law"),
+    ("חוק-יסוד: הכנסת", "law"),
+    ("חוק יסוד: כבוד האדם וחירותו", "law"),
+    ("פקודת מס הכנסה", "law"),
+    ("פקודת הראיות [נוסח חדש]", "law"),
+    ("תקנות הגנת הפרטיות (אבטחת מידע)", "regulation"),
+    ("צו המועצות המקומיות", "regulation"),
+    ("כללי לשכת עורכי הדין", "regulation"),
+    ("ויקיטקסט:אודות", "other"),
+    ("עזרה:תוכן", "other"),
+    ("מדיניות הפרטיות", "other"),
+    ("", "other"),
+])
+def test_classify_title(title, expected):
+    assert classify_title(title) == expected

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -48,3 +48,18 @@ def test_discover_shrink_guard_vs_prior(tmp_path: Path):
     with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
         with pytest.raises(E.CoverageShrinkError):
             E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)
+
+
+def test_discover_skip_list_disabled_includes_skiplisted_laws(tmp_path: Path):
+    # _write_cfg skip-lists חוק הכנסת (it's a legal_text source). With
+    # apply_skip_list=False the enumerator must NOT drop it — this is the
+    # consolidation lever that lets israeli_laws ingest the legal_text laws
+    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "חוק הכנסת"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        out = E.discover_law_pages(tmp_path, include_regulations=False,
+                                   min_expected_laws=1, apply_skip_list=False)
+    out_titles = [e.title for e in out]
+    assert "חוק הכנסת" in out_titles      # normally skip-listed, now included
+    assert "חוק האזנת סתר" in out_titles

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -48,18 +48,3 @@ def test_discover_shrink_guard_vs_prior(tmp_path: Path):
     with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
         with pytest.raises(E.CoverageShrinkError):
             E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)
-
-
-def test_discover_skip_list_disabled_includes_skiplisted_laws(tmp_path: Path):
-    # _write_cfg skip-lists חוק הכנסת (it's a legal_text source). With
-    # apply_skip_list=False the enumerator must NOT drop it — this is the
-    # consolidation lever that lets israeli_laws ingest the legal_text laws
-    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
-    _write_cfg(tmp_path)
-    titles = ["חוק האזנת סתר", "חוק הכנסת"]
-    with patch.object(E, "fetch_index_titles", return_value=titles):
-        out = E.discover_law_pages(tmp_path, include_regulations=False,
-                                   min_expected_laws=1, apply_skip_list=False)
-    out_titles = [e.title for e in out]
-    assert "חוק הכנסת" in out_titles      # normally skip-listed, now included
-    assert "חוק האזנת סתר" in out_titles

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -1,0 +1,50 @@
+# tests/test_law_book_enumerate.py
+from pathlib import Path
+from unittest.mock import patch
+import yaml
+import pytest
+from botnim.document_parser.wikisource_law_book import enumerate_laws as E
+from botnim.document_parser.wikisource_law_book.manifest import LawBookEntry
+
+
+def _write_cfg(tmp_path):
+    cfg = {"context": [{"slug": "legal_text", "sources": [
+        {"type": "split", "source": "x.json",
+         "fetcher": {"kind": "wikitext",
+                     "input_url": "https://he.wikisource.org/wiki/חוק_הכנסת"}}]}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+
+
+def test_discover_classifies_skips_and_filters(tmp_path: Path):
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "חוק הכנסת", "תקנות הגנת הפרטיות", "ויקיטקסט:אודות"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        # laws only: drops the regulation, the skip-list law (חוק הכנסת), the noise page
+        out = E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1)
+    assert [e.title for e in out] == ["חוק האזנת סתר"]
+    assert out[0].kind == "law"
+    assert out[0].url == "https://he.wikisource.org/wiki/חוק_האזנת_סתר"
+    assert out[0].status == "pending"
+
+
+def test_discover_includes_regulations_when_flagged(tmp_path: Path):
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "תקנות הגנת הפרטיות"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        out = E.discover_law_pages(tmp_path, include_regulations=True, min_expected_laws=1)
+    assert {e.kind for e in out} == {"law", "regulation"}
+
+
+def test_discover_floor_guard(tmp_path: Path):
+    _write_cfg(tmp_path)
+    with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
+        with pytest.raises(E.CoverageShrinkError):
+            E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=200)
+
+
+def test_discover_shrink_guard_vs_prior(tmp_path: Path):
+    _write_cfg(tmp_path)
+    prior = [LawBookEntry(f"חוק מספר {i}", f"u{i}", "law") for i in range(100)]
+    with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
+        with pytest.raises(E.CoverageShrinkError):
+            E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)

--- a/tests/test_law_book_manifest.py
+++ b/tests/test_law_book_manifest.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from botnim.document_parser.wikisource_law_book.manifest import (
+    LawBookEntry, write_manifest, read_manifest,
+)
+
+
+def test_manifest_round_trip(tmp_path: Path):
+    entries = [
+        LawBookEntry("חוק האזנת סתר", "https://he.wikisource.org/wiki/חוק_האזנת_סתר", "law", "ok"),
+        LawBookEntry("תקנות הגנת הפרטיות", "https://he.wikisource.org/wiki/תקנות_הגנת_הפרטיות", "regulation", "failed"),
+    ]
+    p = tmp_path / "manifest.csv"
+    write_manifest(p, entries)
+    assert p.exists()
+    out = read_manifest(p)
+    assert out == entries
+
+
+def test_read_missing_returns_empty(tmp_path: Path):
+    assert read_manifest(tmp_path / "nope.csv") == []

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -45,8 +45,9 @@ def test_process_isolates_per_item_failure(tmp_path: Path):
     good = MagicMock(); good.run.return_value = True
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
-         patch.object(P, "WikitextProcessor", return_value=good):
+         patch.object(P, "WikitextProcessor", return_value=good) as MockProc:
         P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
     assert out == {"חוק טוב": "ok", "חוק רע": "failed"}
+    assert MockProc.call_count == 1

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -1,0 +1,52 @@
+# tests/test_law_book_process.py
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import yaml
+from botnim.document_parser.wikisource_law_book import process as P
+from botnim.document_parser.wikisource_law_book.manifest import LawBookEntry, read_manifest
+
+
+def _cfg(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"context": [{"slug": "legal_text", "sources": []}]}, allow_unicode=True),
+        encoding="utf-8")
+
+
+def test_process_runs_processor_per_item_and_records_status(tmp_path: Path):
+    _cfg(tmp_path)
+    discovered = [
+        LawBookEntry("חוק האזנת סתר", "https://he.wikisource.org/wiki/חוק_האזנת_סתר", "law"),
+        LawBookEntry("חוק אוויר נקי", "https://he.wikisource.org/wiki/חוק_אוויר_נקי", "law"),
+    ]
+    made = MagicMock()
+    made.run.return_value = True
+    with patch.object(P, "discover_law_pages", return_value=discovered), \
+         patch.object(P, "WikitextProcessorConfig") as MockCfg, \
+         patch.object(P, "WikitextProcessor", return_value=made) as MockProc:
+        P.process_law_book_source("local", tmp_path, include_regulations=False,
+                                  min_expected_laws=1, rate_limit_seconds=0)
+    assert MockProc.call_count == 2
+    out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
+    assert out == {"חוק האזנת סתר": "ok", "חוק אוויר נקי": "ok"}
+
+
+def test_process_isolates_per_item_failure(tmp_path: Path):
+    _cfg(tmp_path)
+    discovered = [
+        LawBookEntry("חוק טוב", "https://he.wikisource.org/wiki/חוק_טוב", "law"),
+        LawBookEntry("חוק רע", "https://he.wikisource.org/wiki/חוק_רע", "law"),
+    ]
+
+    def cfg_side_effect(*a, **k):
+        if "רע" in k.get("input_url", ""):
+            raise RuntimeError("network boom")
+        return MagicMock()
+
+    good = MagicMock(); good.run.return_value = True
+    with patch.object(P, "discover_law_pages", return_value=discovered), \
+         patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
+         patch.object(P, "WikitextProcessor", return_value=good):
+        P.process_law_book_source("local", tmp_path, include_regulations=False,
+                                  min_expected_laws=1, rate_limit_seconds=0)
+    out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
+    assert out == {"חוק טוב": "ok", "חוק רע": "failed"}

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -23,7 +23,7 @@ def test_process_runs_processor_per_item_and_records_status(tmp_path: Path):
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig") as MockCfg, \
          patch.object(P, "WikitextProcessor", return_value=made) as MockProc:
-        P.process_law_book_source("local", tmp_path, include_regulations=False,
+        P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     assert MockProc.call_count == 2
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
@@ -46,7 +46,7 @@ def test_process_isolates_per_item_failure(tmp_path: Path):
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
          patch.object(P, "WikitextProcessor", return_value=good):
-        P.process_law_book_source("local", tmp_path, include_regulations=False,
+        P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
     assert out == {"חוק טוב": "ok", "חוק רע": "failed"}

--- a/tests/test_law_book_skip_list.py
+++ b/tests/test_law_book_skip_list.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import yaml
+from botnim.document_parser.wikisource_law_book.skip_list import (
+    title_from_url, legal_text_skip_titles,
+)
+
+
+def test_title_from_url_decodes_and_unscores():
+    url = "https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA"
+    assert title_from_url(url) == "חוק הכנסת"
+
+
+def test_skip_titles_reads_legal_text(tmp_path: Path):
+    cfg = {
+        "context": [
+            {"slug": "legal_text", "sources": [
+                {"type": "split", "source": "x.json",
+                 "fetcher": {"kind": "wikitext",
+                             "input_url": "https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA"}},
+            ]},
+            {"slug": "other", "sources": []},
+        ]
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    assert legal_text_skip_titles(tmp_path) == {"חוק הכנסת"}


### PR DESCRIPTION
Adds the **Israeli Open Law Book** (`ספר החוקים הפתוח`) as the `israeli_laws` context and makes it the **single source of statutory law** for the unified bot — retiring `legal_text` and trimming `common_takanon_knowledge` to glossary-only.

## What this delivers
**Base feature** (law-book ingestion):
- Title classifier (law / regulation / other) + index enumerator with skip-list & coverage guards
- `wikisource_law_book` fetcher: discover the corpus from the WikiSource index, extract each law via the existing `WikitextProcessor` (one `*_structure_content.json` per law), glob `split` collector
- `israeli_laws` context registered in `config.yaml`; `search_unified__israeli_laws__dev` retrieve op
- `sanitize_filename` capped to 180 bytes + hash suffix (long regulation titles)

**Single-source consolidation** (this round):
- `classify.py`: `החלטת שכר` carry-over → regulation (narrow allow-list)
- `israeli_laws` op gains **`metadata_filter`** (`{"law_name":"<law>"}`) → scopes a search to one law, killing cross-law section-number collisions; description updated (owns תקנון + Knesset laws + ethics)
- `scripts/backfill-law-name.py`: derives `law_name` (DocumentTitle prefix) for the filter
- **`legal_text` retired** (context + op removed); **`common_takanon_knowledge` trimmed** to glossary (drops כללי אתיקה + חוק הפרשנות — both already in israeli_laws)
- (An `apply_skip_list` toggle was added then reverted — unnecessary once legal_text is retired.)

## Validation (local compose, prod-prompt baseline)
All law / bylaw / procedure / ethics queries answer from `israeli_laws` only:
- חוק האזנת סתר → §12/§10
- **תקנון §86(א)/(ב)** — retrieved where `legal_text` misses it in both modes
- ועדת חקירה ממלכתית → חוק־יסוד §22 + תקנון §128/§129/§131/§132/§136
- כללי אתיקה (מתנות) → §4/§5

Tests: `tests/test_law_book_*` green (22).

## Deploy notes
- Prompt lives in Aurora (`agent_prompts`) → apply via `/admin/prompts` (artifact in the parlibot PR).
- Run `scripts/backfill-law-name.py` after the israeli_laws sync.
- With `legal_text` gone, the israeli_laws skip-list is naturally empty, so a fap-sync re-discovers + ingests תקנון + the Knesset laws automatically.

Companion ops/docs PR: wilfoa/parlibot#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)