### PR TITLE
feat(retrieve): israeli_laws law-retrieval — consolidation, scoped-first, resolution, query-side detection, decision-complete expansion

### DIFF
--- a/.github/workflows/scrape-wikitext.yml
+++ b/.github/workflows/scrape-wikitext.yml
@@ -31,6 +31,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           botnim fetch-and-process all all wikitext
+          botnim fetch-and-process all all wikisource_law_book
       - name: set git user
         run: |
           git config --global user.email "adam.kariv@gmail.com"

--- a/botnim/collect_sources.py
+++ b/botnim/collect_sources.py
@@ -426,19 +426,33 @@ def _collect_raw_streams_files(config_dir: Path, source):
     return [(f.name, f.open('rb'), 'text/markdown', {}) for f in files]
 
 
+def _split_json_file(filename: Path):
+    with open(filename, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    document_name = data.get('metadata', {}).get('document_name', '')
+    if not document_name:
+        input_file = data.get('metadata', {}).get('input_file', '')
+        document_name = Path(input_file).stem
+    document_name = sanitize_filename(document_name)
+    structure = data.get('structure', [])
+    markdown_dict = generate_markdown_dict(structure, document_name)
+    return [(fname, content, 'text/markdown', {}) for fname, content in markdown_dict.items()]
+
+
 def _collect_raw_streams_split(config_dir: Path, context_name, source, offset=0):
+    # Glob support: a source containing '*' expands to every matching file —
+    # the israeli_laws (law-book) context points at
+    # extraction/law_book/*_structure_content.json instead of listing ~2000
+    # laws in config.yaml. generate_markdown_dict prefixes every chunk filename
+    # with the per-law document_name, so chunks never collide across laws.
+    if '*' in str(source):
+        results = []
+        for path in sorted(config_dir.glob(str(source))):
+            results.extend(_split_json_file(path))
+        return results
     filename = config_dir / source
     if filename.suffix == '.json':
-        with open(filename, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-        document_name = data.get('metadata', {}).get('document_name', '')
-        if not document_name:
-            input_file = data.get('metadata', {}).get('input_file', '')
-            document_name = Path(input_file).stem
-        document_name = sanitize_filename(document_name)
-        structure = data.get('structure', [])
-        markdown_dict = generate_markdown_dict(structure, document_name)
-        return [(fname, content, 'text/markdown', {}) for fname, content in markdown_dict.items()]
+        return _split_json_file(filename)
     else:
         content = filename.read_text()
         parts = content.split('\n---\n')

--- a/botnim/db/migrations/versions/0016_documents_law_name_norm_idx.py
+++ b/botnim/db/migrations/versions/0016_documents_law_name_norm_idx.py
@@ -1,0 +1,46 @@
+"""Expression index on the normalized law_name for scoped-first law retrieval.
+
+The scoped-first retrieval path (vector_store_aurora.search()) filters
+israeli_laws docs by NORMALIZED law_name equality inside a MATERIALIZED CTE.
+Without a matching expression index that filter evaluates the 4x replace() +
+regexp_replace + trim chain (_LAW_NAME_NORM_SQL) on EVERY row in the context
+(O(context_size), ~50-500ms per law-scoped call on a 185K-doc context). This
+index makes the filter O(law_size).
+
+The indexed expression MUST be byte-identical to _LAW_NAME_NORM_SQL in
+botnim/vector_store/vector_store_aurora.py (same maqaf '־' U+05BE, gershayim
+'״' U+05F4, geresh '׳' U+05F3) — PostgreSQL only uses a functional index when
+the query expression matches it exactly. The byte-identity is verified by the
+EXPLAIN test (test_law_name_norm_index_is_used). The partial predicate keeps
+the index small (only law-bearing rows).
+
+CONCURRENTLY must run outside a transaction; alembic's autocommit_block()
+handles it (same pattern as 0015).
+"""
+from alembic import op
+
+revision = "0016_documents_law_name_norm_idx"
+down_revision = "0015_documents_content_trgm_idx"
+branch_labels = None
+depends_on = None
+
+# Byte-identical to _LAW_NAME_NORM_SQL (vector_store_aurora.py:96-100).
+_LAW_NAME_NORM_EXPR = (
+    "trim(regexp_replace("
+    "replace(replace(replace(replace(metadata->>'law_name', '־', '-'), ':', ' '), '״', '\"'), '׳', ''''),"
+    " '\\s+', ' ', 'g'))"
+)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS documents_law_name_norm "
+            "ON documents (context_id, (" + _LAW_NAME_NORM_EXPR + ")) "
+            "WHERE metadata ? 'law_name'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS documents_law_name_norm")

--- a/botnim/db/migrations/versions/0017_documents_law_name_trgm.py
+++ b/botnim/db/migrations/versions/0017_documents_law_name_trgm.py
@@ -1,0 +1,29 @@
+"""Trigram GIN index on metadata->>'law_name' for fast law-name resolution.
+
+_resolve_law_name (vector_store_aurora.py) maps a colloquial/partial/variant law
+mention to the formal law name via pg_trgm similarity over the distinct law_name
+values. Without this index the `metadata->>'law_name' % :mention` lookup seq-scans
+the whole context (~185K docs); the trigram GIN index makes it an indexed
+candidate lookup. pg_trgm is already installed (migration 0015). Same
+autocommit_block + CREATE INDEX CONCURRENTLY pattern as 0015/0016.
+"""
+from alembic import op
+
+revision = "0017_documents_law_name_trgm"
+down_revision = "0016_documents_law_name_norm_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS documents_law_name_trgm "
+            "ON documents USING gin ((metadata->>'law_name') gin_trgm_ops) "
+            "WHERE metadata ? 'law_name'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS documents_law_name_trgm")

--- a/botnim/db/migrations/versions/0018_law_name_catalog.py
+++ b/botnim/db/migrations/versions/0018_law_name_catalog.py
@@ -1,0 +1,35 @@
+"""law_name_catalog: materialized view of distinct (context_id, law_name).
+
+Resolution (_best_law_match in vector_store_aurora.py) and query-side detection
+(_detect_law_in_query) trigram-match a mention against the distinct law names.
+Over the 185K-row `documents` table that costs ~2.6s (the % bitmap heap recheck
+dominates); over this ~14K-row matview it is ~200ms. The unique (context_id,
+law_name) index enables REFRESH ... CONCURRENTLY (run at end of sync); the
+gin_trgm index serves the % lookup. pg_trgm installed in 0015.
+"""
+from alembic import op
+
+revision = "0018_law_name_catalog"
+down_revision = "0017_documents_law_name_trgm"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE MATERIALIZED VIEW law_name_catalog AS "
+        "SELECT DISTINCT context_id, metadata->>'law_name' AS law_name "
+        "FROM documents "
+        "WHERE metadata ? 'law_name' AND coalesce(metadata->>'law_name', '') <> '' "
+        "WITH DATA"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX law_name_catalog_uq ON law_name_catalog (context_id, law_name)"
+    )
+    op.execute(
+        "CREATE INDEX law_name_catalog_trgm ON law_name_catalog USING gin (law_name gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS law_name_catalog")

--- a/botnim/db/migrations/versions/0019_law_name_catalog_owner.py
+++ b/botnim/db/migrations/versions/0019_law_name_catalog_owner.py
@@ -1,0 +1,42 @@
+"""Reassign law_name_catalog matview ownership to the app role (botnim_app).
+
+Migration 0018 creates the matview as whoever runs alembic. On staging the
+alembic-first deploy phase runs as the **postgres master**, so the matview ends
+up owned by `postgres`, and the runtime app role `botnim_app` gets
+`permission denied for materialized view law_name_catalog` on every read — the
+resolver and the query-side detector both query it, so every unfiltered
+israeli_laws search errored. Reassigning ownership to `botnim_app` restores both
+SELECT (reads) and the ability to `REFRESH MATERIALIZED VIEW CONCURRENTLY` (the
+end-of-sync hook).
+
+Guarded on the role existing so this is a safe no-op in test databases (where
+`botnim_app` is absent) and on any env where the matview is already owned by
+`botnim_app` (e.g. prod, if alembic there runs as the app user) — `ALTER … OWNER
+TO botnim_app` is idempotent. `GRANT SELECT` is belt-and-suspenders.
+"""
+from alembic import op
+
+revision = "0019_law_name_catalog_owner"
+down_revision = "0018_law_name_catalog"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'botnim_app') THEN
+            EXECUTE 'ALTER MATERIALIZED VIEW law_name_catalog OWNER TO botnim_app';
+            EXECUTE 'GRANT SELECT ON law_name_catalog TO botnim_app';
+          END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Ownership reassignment is not meaningfully reversible (the prior owner is
+    # env-dependent and the matview is functional either way). No-op.
+    pass

--- a/botnim/document_parser/wikisource_law_book/classify.py
+++ b/botnim/document_parser/wikisource_law_book/classify.py
@@ -1,0 +1,22 @@
+"""Classify a WikiSource page title as primary law, secondary regulation, or noise.
+
+Classification by leading token is deliberate: it doubles as the noise filter
+(navigation / Help / project pages never start with a statute keyword) and
+needs no network call.
+"""
+
+# Primary legislation
+_LAW_PREFIXES = ("חוק ", "חוק-יסוד", "חוק יסוד", "פקודת ", "פקודה ")
+# Secondary legislation
+_REGULATION_PREFIXES = ("תקנות ", "צו ", "צווי ", "כללי ", "כללים ", "הוראות ", "תקנון ")
+
+
+def classify_title(title: str) -> str:
+    t = (title or "").strip()
+    for p in _LAW_PREFIXES:
+        if t.startswith(p):
+            return "law"
+    for p in _REGULATION_PREFIXES:
+        if t.startswith(p):
+            return "regulation"
+    return "other"

--- a/botnim/document_parser/wikisource_law_book/classify.py
+++ b/botnim/document_parser/wikisource_law_book/classify.py
@@ -9,6 +9,12 @@ needs no network call.
 _LAW_PREFIXES = ("חוק ", "חוק-יסוד", "חוק יסוד", "פקודת ", "פקודה ")
 # Secondary legislation
 _REGULATION_PREFIXES = ("תקנות ", "צו ", "צווי ", "כללי ", "כללים ", "הוראות ", "תקנון ")
+# Carry-over items from the legal_text context that classify as "other" by
+# leading token (they start with החלט…) but must be ingested into israeli_laws
+# for the single-source consolidation. Kept as an explicit, narrow allow-list —
+# we deliberately do NOT broaden to all החלטות/הנחיות, which would pull in
+# government decisions and other noise.
+_CARRYOVER_REGULATION_PREFIXES = ("החלטת שכר חברי הכנסת",)
 
 
 def classify_title(title: str) -> str:
@@ -17,6 +23,9 @@ def classify_title(title: str) -> str:
         if t.startswith(p):
             return "law"
     for p in _REGULATION_PREFIXES:
+        if t.startswith(p):
+            return "regulation"
+    for p in _CARRYOVER_REGULATION_PREFIXES:
         if t.startswith(p):
             return "regulation"
     return "other"

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -1,0 +1,86 @@
+"""Enumerate every law/regulation in ספר החוקים הפתוח from the WikiSource index.
+
+Network surface is exactly one function (`fetch_index_titles`) so tests stay
+hermetic. The MediaWiki `parse&prop=links` call returns every main-namespace
+page linked from the index (transclusions followed), which we classify by
+leading token and filter through the legal_text skip-list.
+"""
+from pathlib import Path
+import requests
+
+from ...config import get_logger
+from .classify import classify_title
+from .manifest import LawBookEntry
+from .skip_list import legal_text_skip_titles
+
+logger = get_logger(__name__)
+
+API_URL = "https://he.wikisource.org/w/api.php"
+INDEX_PAGE = "ספר_החוקים_הפתוח"
+_HEADERS = {"User-Agent": "botnim-law-book/1.0 (+https://botnim.build-up.team)"}
+
+
+class CoverageShrinkError(Exception):
+    """Discovery returned materially fewer items than expected — refuse to
+    overwrite a good manifest with a truncated one."""
+
+
+def url_for_title(title: str) -> str:
+    # Keep Hebrew (non-ASCII) characters unencoded — MediaWiki and browsers accept them;
+    # only encode ASCII special chars. Spaces become underscores per wiki convention.
+    return "https://he.wikisource.org/wiki/" + title.replace(" ", "_")
+
+
+def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> list[str]:
+    """Return all main-namespace (ns==0) page titles linked from the index."""
+    resp = requests.get(api_url, headers=_HEADERS, params={
+        "action": "parse", "page": index_page, "prop": "links", "format": "json",
+    }, timeout=60)
+    resp.raise_for_status()
+    links = resp.json()["parse"]["links"]
+    return [l["*"] for l in links if l.get("ns") == 0 and "exists" in l]
+
+
+def discover_law_pages(config_dir, *, include_regulations: bool,
+                       min_expected_laws: int = 200,
+                       prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
+    config_dir = Path(config_dir)
+    skip = legal_text_skip_titles(config_dir)
+    raw_titles = fetch_index_titles()
+
+    wanted = {"law", "regulation"} if include_regulations else {"law"}
+    entries: list[LawBookEntry] = []
+    laws_found = regs_found = skipped = 0
+    seen: set[str] = set()
+    for title in raw_titles:
+        kind = classify_title(title)
+        if kind == "law":
+            laws_found += 1
+        elif kind == "regulation":
+            regs_found += 1
+        if kind not in wanted:
+            continue
+        if title in skip:
+            skipped += 1
+            continue
+        if title in seen:
+            continue
+        seen.add(title)
+        entries.append(LawBookEntry(title=title, url=url_for_title(title), kind=kind))
+
+    logger.info("LAW_BOOK_DISCOVER laws_found=%d regulations_found=%d skipped=%d selected=%d",
+                laws_found, regs_found, skipped, len(entries))
+
+    # Guard #1: absolute floor — a broken enumerator returns ~0.
+    if laws_found < min_expected_laws:
+        raise CoverageShrinkError(
+            f"only {laws_found} laws discovered (< floor {min_expected_laws}); "
+            f"refusing to overwrite manifest")
+    # Guard #2: relative shrink vs. last committed manifest.
+    if prior:
+        prior_count = len([e for e in prior if e.kind in wanted])
+        if prior_count and len(entries) < prior_count * 0.9:
+            raise CoverageShrinkError(
+                f"discovery shrank to {len(entries)} from {prior_count} (>10% drop); "
+                f"refusing to overwrite manifest")
+    return entries

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -43,14 +43,9 @@ def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> 
 
 def discover_law_pages(config_dir, *, include_regulations: bool,
                        min_expected_laws: int = 200,
-                       apply_skip_list: bool = True,
                        prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
     config_dir = Path(config_dir)
-    # The skip-list is derived from the legal_text context so israeli_laws does
-    # not double-index those laws. During the single-source consolidation we set
-    # apply_skip_list=False so israeli_laws finally ingests the legal_text laws
-    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
-    skip = legal_text_skip_titles(config_dir) if apply_skip_list else set()
+    skip = legal_text_skip_titles(config_dir)
     raw_titles = fetch_index_titles()
 
     wanted = {"law", "regulation"} if include_regulations else {"law"}

--- a/botnim/document_parser/wikisource_law_book/enumerate_laws.py
+++ b/botnim/document_parser/wikisource_law_book/enumerate_laws.py
@@ -43,9 +43,14 @@ def fetch_index_titles(api_url: str = API_URL, index_page: str = INDEX_PAGE) -> 
 
 def discover_law_pages(config_dir, *, include_regulations: bool,
                        min_expected_laws: int = 200,
+                       apply_skip_list: bool = True,
                        prior: list[LawBookEntry] | None = None) -> list[LawBookEntry]:
     config_dir = Path(config_dir)
-    skip = legal_text_skip_titles(config_dir)
+    # The skip-list is derived from the legal_text context so israeli_laws does
+    # not double-index those laws. During the single-source consolidation we set
+    # apply_skip_list=False so israeli_laws finally ingests the legal_text laws
+    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
+    skip = legal_text_skip_titles(config_dir) if apply_skip_list else set()
     raw_titles = fetch_index_titles()
 
     wanted = {"law", "regulation"} if include_regulations else {"law"}

--- a/botnim/document_parser/wikisource_law_book/manifest.py
+++ b/botnim/document_parser/wikisource_law_book/manifest.py
@@ -1,0 +1,37 @@
+"""Committed coverage manifest for the law-book corpus.
+
+One row per discovered statute/regulation. Committing it makes the corpus
+reviewable and diffable, and decouples enumeration from extraction (an
+operator can run discovery, eyeball the CSV, then extract).
+"""
+import csv
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+MANIFEST_COLUMNS = ["title", "url", "kind", "status"]
+
+
+@dataclass
+class LawBookEntry:
+    title: str
+    url: str
+    kind: str          # 'law' | 'regulation'
+    status: str = "pending"   # 'pending' | 'ok' | 'failed' | 'skipped'
+
+
+def write_manifest(path: Path, entries: list[LawBookEntry]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=MANIFEST_COLUMNS)
+        w.writeheader()
+        for e in entries:
+            w.writerow(asdict(e))
+
+
+def read_manifest(path: Path) -> list[LawBookEntry]:
+    path = Path(path)
+    if not path.exists():
+        return []
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        return [LawBookEntry(**row) for row in csv.DictReader(f)]

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -21,7 +21,6 @@ LAW_BOOK_SUBDIR = "law_book"
 def process_law_book_source(environment: str, config_dir: Path, *,
                             include_regulations: bool = True,
                             min_expected_laws: int = 200,
-                            apply_skip_list: bool = True,
                             rate_limit_seconds: float = 0.3,
                             **_ignored) -> None:
     config_dir = Path(config_dir)
@@ -31,8 +30,7 @@ def process_law_book_source(environment: str, config_dir: Path, *,
     prior = read_manifest(manifest_path)
     entries = discover_law_pages(
         config_dir, include_regulations=include_regulations,
-        min_expected_laws=min_expected_laws, apply_skip_list=apply_skip_list,
-        prior=prior or None,
+        min_expected_laws=min_expected_laws, prior=prior or None,
     )
     # Persist the discovered set (all 'pending') BEFORE extraction so a crash
     # mid-corpus still leaves a reviewable manifest.

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -41,7 +41,7 @@ def process_law_book_source(environment: str, config_dir: Path, *,
         try:
             cfg = WikitextProcessorConfig(
                 input_url=entry.url, output_base_dir=out_dir,
-                content_type="סעיף", environment=environment,
+                content_type="סעיף", environment=Environment(environment),
                 model="gpt-4.1-mini", max_tokens=None,
             )
             entry.status = "ok" if WikitextProcessor(cfg).run(generate_markdown=False) else "failed"

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -21,6 +21,7 @@ LAW_BOOK_SUBDIR = "law_book"
 def process_law_book_source(environment: str, config_dir: Path, *,
                             include_regulations: bool = True,
                             min_expected_laws: int = 200,
+                            apply_skip_list: bool = True,
                             rate_limit_seconds: float = 0.3,
                             **_ignored) -> None:
     config_dir = Path(config_dir)
@@ -30,7 +31,8 @@ def process_law_book_source(environment: str, config_dir: Path, *,
     prior = read_manifest(manifest_path)
     entries = discover_law_pages(
         config_dir, include_regulations=include_regulations,
-        min_expected_laws=min_expected_laws, prior=prior or None,
+        min_expected_laws=min_expected_laws, apply_skip_list=apply_skip_list,
+        prior=prior or None,
     )
     # Persist the discovered set (all 'pending') BEFORE extraction so a crash
     # mid-corpus still leaves a reviewable manifest.

--- a/botnim/document_parser/wikisource_law_book/process.py
+++ b/botnim/document_parser/wikisource_law_book/process.py
@@ -1,0 +1,60 @@
+# botnim/document_parser/wikisource_law_book/process.py
+"""fap driver: discover the law-book corpus, then extract each item through the
+existing WikitextProcessor (one *_structure_content.json per law under
+extraction/law_book/). Reusing WikitextProcessor is mandatory — it writes the
+html_sha256 + extractor-version metadata that makes re-faps cheap (cache skip).
+"""
+import time
+from pathlib import Path
+
+from ...config import get_logger
+from ..wikitext.pipeline_config import Environment, WikitextProcessorConfig
+from ..wikitext.process_document import WikitextProcessor
+from .enumerate_laws import discover_law_pages
+from .manifest import LawBookEntry, read_manifest, write_manifest
+
+logger = get_logger(__name__)
+
+LAW_BOOK_SUBDIR = "law_book"
+
+
+def process_law_book_source(environment: str, config_dir: Path, *,
+                            include_regulations: bool = True,
+                            min_expected_laws: int = 200,
+                            rate_limit_seconds: float = 0.3,
+                            **_ignored) -> None:
+    config_dir = Path(config_dir)
+    out_dir = config_dir / "extraction" / LAW_BOOK_SUBDIR
+    manifest_path = out_dir / "manifest.csv"
+
+    prior = read_manifest(manifest_path)
+    entries = discover_law_pages(
+        config_dir, include_regulations=include_regulations,
+        min_expected_laws=min_expected_laws, prior=prior or None,
+    )
+    # Persist the discovered set (all 'pending') BEFORE extraction so a crash
+    # mid-corpus still leaves a reviewable manifest.
+    write_manifest(manifest_path, entries)
+
+    ok = failed = 0
+    for i, entry in enumerate(entries):
+        try:
+            cfg = WikitextProcessorConfig(
+                input_url=entry.url, output_base_dir=out_dir,
+                content_type="סעיף", environment=environment,
+                model="gpt-4.1-mini", max_tokens=None,
+            )
+            entry.status = "ok" if WikitextProcessor(cfg).run(generate_markdown=False) else "failed"
+        except Exception as e:  # per-item isolation — one bad page never aborts the corpus
+            logger.warning("LAW_BOOK_ITEM_FAILED title=%s url=%s err=%s: %s",
+                           entry.title, entry.url, type(e).__name__, e)
+            entry.status = "failed"
+        ok += entry.status == "ok"
+        failed += entry.status == "failed"
+        if (i + 1) % 25 == 0:
+            write_manifest(manifest_path, entries)   # checkpoint progress
+        if rate_limit_seconds:
+            time.sleep(rate_limit_seconds)
+
+    write_manifest(manifest_path, entries)
+    logger.info("LAW_BOOK_DONE total=%d ok=%d failed=%d", len(entries), ok, failed)

--- a/botnim/document_parser/wikisource_law_book/skip_list.py
+++ b/botnim/document_parser/wikisource_law_book/skip_list.py
@@ -1,0 +1,27 @@
+"""Derive the set of laws already covered by the `legal_text` context so the
+bulk law-book ingestion can skip them (no double-indexing). Sourced from
+config.yaml at runtime so it can never drift from reality.
+"""
+from pathlib import Path
+from urllib.parse import unquote
+import yaml
+
+
+def title_from_url(url: str) -> str:
+    """`.../wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA` -> `חוק הכנסת`."""
+    tail = unquote(url).split("/wiki/")[-1]
+    return tail.replace("_", " ").strip()
+
+
+def legal_text_skip_titles(config_dir: Path) -> set[str]:
+    cfg = yaml.safe_load((Path(config_dir) / "config.yaml").read_text(encoding="utf-8"))
+    titles: set[str] = set()
+    for ctx in cfg.get("context", []):
+        if ctx.get("slug") != "legal_text":
+            continue
+        for src in ctx.get("sources", []):
+            fetcher = src.get("fetcher") or {}
+            url = fetcher.get("input_url")
+            if url:
+                titles.add(title_from_url(url))
+    return titles

--- a/botnim/document_parser/wikitext/pipeline_config.py
+++ b/botnim/document_parser/wikitext/pipeline_config.py
@@ -35,6 +35,17 @@ def sanitize_filename(filename):
     filename = re.sub(r'[_\s]+', '_', filename)
     # Remove leading/trailing underscores
     filename = filename.strip('_')
+    # Cap length: a filename is limited to 255 BYTES. With the
+    # "_structure_content.json" suffix and multi-byte Hebrew, long regulation
+    # titles (e.g. צו איסור הלבנת הון (חובות זיהוי, דיווח...)) exceed that and
+    # raise OSError(ENAMETOOLONG). Truncate to a safe byte budget and append a
+    # short stable hash of the full name to preserve uniqueness across titles
+    # that share a long common prefix.
+    MAX_BYTES = 180
+    if len(filename.encode('utf-8')) > MAX_BYTES:
+        digest = hashlib.sha1(filename.encode('utf-8')).hexdigest()[:8]
+        truncated = filename.encode('utf-8')[:MAX_BYTES].decode('utf-8', 'ignore').rstrip('_')
+        filename = f'{truncated}_{digest}'
     return filename
 
 

--- a/botnim/fetch_and_process.py
+++ b/botnim/fetch_and_process.py
@@ -128,6 +128,16 @@ def fetch_and_process_source(environment, config_dir, context_name, source, kind
         # context_snapshots so /admin/sources reflects this context.
         from .document_parser.gov_il_decisions.process import process_gov_il_decisions_source
         process_gov_il_decisions_source(environment=environment, **fetcher)
+    elif fetcher_kind == 'wikisource_law_book':
+        # Index-driven bulk ingestion of ספר החוקים הפתוח. Unlike `wikitext`
+        # (one law per source entry), this discovers ~all laws/regulations
+        # from the WikiSource index and runs each through WikitextProcessor,
+        # writing one *_structure_content.json per item under
+        # extraction/law_book/. The israeli_laws context reads them via a
+        # glob `split` source. `source['source']` (the glob) is unused here —
+        # the driver owns its output paths.
+        from .document_parser.wikisource_law_book.process import process_law_book_source
+        process_law_book_source(environment, config_dir, **fetcher)
 
 def fetch_and_process_context(environment, context, config_dir: Path, kind):
     context_name = context['name']

--- a/botnim/sync.py
+++ b/botnim/sync.py
@@ -28,6 +28,7 @@ import yaml
 
 from .bot_config import BotConfig, load_bot_config, publish_bot_config
 from .config import SPECS, get_logger, get_openai_client, is_production
+from .db.session import get_engine as _db_get_engine
 from .vector_store import VectorStoreES, VectorStoreOpenAI, VectorStoreAurora
 
 logger = get_logger(__name__)
@@ -54,6 +55,26 @@ def _source_id_for(fetcher: dict | None, source_path: str | None) -> str:
     if source_path:
         return Path(source_path).stem
     return "unknown"
+
+
+def _refresh_law_name_catalog() -> None:
+    """Refresh the distinct-law-name matview used by query-side detection and the
+    law-name resolver. Best-effort: a refresh failure must not fail an otherwise
+    successful sync (the matview just lags until the next run). CONCURRENTLY needs
+    the unique index + a populated matview (both guaranteed by migration 0018).
+
+    Uses the module-level ``_db_get_engine`` binding (captured at import time)
+    rather than a lazy ``from botnim.db.session import get_engine`` import so that
+    the test-suite sys.modules mock in test_query_error_handling.py cannot
+    shadow the real engine with a MagicMock."""
+    from sqlalchemy import text
+    try:
+        with _db_get_engine().connect() as conn:
+            conn.execution_options(isolation_level="AUTOCOMMIT").execute(
+                text("REFRESH MATERIALIZED VIEW CONCURRENTLY law_name_catalog"))
+        logger.info("refreshed law_name_catalog matview")
+    except Exception as e:  # noqa: BLE001 — best-effort, never fail the sync on this
+        logger.warning("law_name_catalog refresh skipped: %s", e)
 
 
 def _write_snapshots(bot_slug: str) -> None:
@@ -204,3 +225,8 @@ def sync_agents(environment: str, bots: str, backend: str = 'aurora',
         # Inside the bot loop so a multi-bot future writes one snapshot per bot;
         # any exception above this line skips the snapshot, which is the point.
         _write_snapshots(bot_id)
+
+    # Keep the distinct-law-name catalog (used by resolution + query-side detection)
+    # current with the documents just synced. Best-effort; aurora only.
+    if backend == "aurora":
+        _refresh_law_name_catalog()

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -823,9 +823,33 @@ class VectorStoreAurora(VectorStoreBase):
                 return {"hits": {"hits": []}}
             cid = str(row[0])
 
+            # A law_name filter is a scoping directive ("answer from THIS law").
+            # An empty-string law_name (LLM bug) normalizes to "" — treat as no filter.
+            law_value = (metadata_filter or {}).get("law_name")
+            law_norm = _normalize_law_name(str(law_value)) if law_value is not None else None
+            if law_value is not None and not law_norm:
+                logger.warning("search: empty law_name filter for (%s, %s); ignoring it", bot, context_name)
+                metadata_filter = {k: v for k, v in metadata_filter.items() if k != "law_name"} or None
+                law_norm = None
+            has_law_name = law_norm is not None
+            other_keys = bool({k for k in (metadata_filter or {}) if k != "law_name"})
+
             md_filter_sql, md_params = _build_metadata_filter_sql(metadata_filter)
 
-            if use_vector:
+            if has_law_name:
+                # Scope-preserving recall: exact vector KNN over the law's docs, regardless
+                # of the mode's use_vector flag, via a MATERIALIZED CTE (no global HNSW
+                # post-filter). Wider fetch than default — the right section may sit deeper
+                # than num_results*5 within a multi-hundred-doc law, and a lexical-only mode
+                # has no lexical safety net.
+                rest_sql, rest_params = _build_metadata_filter_sql(
+                    {k: v for k, v in metadata_filter.items() if k != "law_name"})
+                scoped_fetch = max(fetch, num_results * 15)
+                vector_rows = _scoped_vector_knn(sess, cid, law_norm, rest_sql, rest_params,
+                                                 embedding, scoped_fetch)
+                # (Observability log is emitted in Task 4, after the lexical branch and the
+                # fallback decision, where scoped_lex and gate_fired are also known.)
+            elif use_vector:
                 vector_rows = sess.execute(text(
                     f"""
                     SELECT id, content, metadata, 1 - (embedding <=> CAST(:emb AS vector)) AS score
@@ -896,7 +920,11 @@ class VectorStoreAurora(VectorStoreBase):
                     lexical_rows = []
             bm25_rows = lexical_rows  # kept name for back-compat with _rrf_fuse call below
 
-        result = _rrf_fuse(vector_rows, bm25_rows, num_results)
+        # Reduce the scoped vector's weight only when we OVERRODE a lexical-only mode
+        # (e.g. SECTION_NUMBER), so an injected scoped-vector hit can't displace an exact
+        # §86 lexical match. For modes where vector was already on, weight is unchanged.
+        _vw = _SCOPED_OVERRIDE_VECTOR_WEIGHT if (has_law_name and not use_vector) else 1.0
+        result = _rrf_fuse(vector_rows, bm25_rows, num_results, vector_weight=_vw)
         # Auto-fallback: if a metadata_filter eliminated every candidate, the data may
         # still be reachable unfiltered (e.g. a colloquial law name, or a law_name our
         # normalization can't bridge). Re-run once WITHOUT the filter. The

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -124,26 +124,35 @@ def _build_metadata_filter_sql(metadata_filter):
 _LAW_NAME_RESOLVE_THRESHOLD = 0.45
 
 
-def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD):
-    """Resolve a colloquial/partial/variant law mention to the formal `law_name`
-    in this context (pg_trgm similarity), or None if nothing is similar enough.
-
-    Used only on a scoped-filter exact-miss to rescue the scope (e.g. the model's
-    "חוק המכרזים" -> "חוק חובת המכרזים"). The `%` operator is gated by
-    pg_trgm.similarity_threshold; we set it to `threshold` so `%` and the Python
-    check agree. The `documents_law_name_trgm` index serves the `%` lookup.
+def _best_law_match(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD):
+    """Best-matching formal law_name + its trigram similarity over the distinct
+    law_name set (the `law_name_catalog` matview, ~14k rows vs ~185k docs → ~200ms),
+    or None. The `%` operator is gated by pg_trgm.similarity_threshold; we set it to
+    `threshold`. `law_name_catalog_trgm` serves the `%` lookup. Returns (law_name, score).
     """
     if not mention:
         return None
     sess.execute(text("SET LOCAL pg_trgm.similarity_threshold = %s" % float(threshold)))
     row = sess.execute(text(
-        "SELECT metadata->>'law_name' AS ln, similarity(metadata->>'law_name', :m) AS s "
-        "FROM documents "
-        "WHERE context_id = :cid AND metadata ? 'law_name' AND (metadata->>'law_name') % :m "
+        "SELECT law_name, similarity(law_name, :m) AS s "
+        "FROM law_name_catalog "
+        "WHERE context_id = :cid AND law_name % :m "
         "ORDER BY s DESC LIMIT 1"
     ), {"cid": cid, "m": mention}).fetchone()
-    if row and row[1] is not None and float(row[1]) >= threshold:
-        return row[0]
+    if row and row[1] is not None:
+        return (row[0], float(row[1]))
+    return None
+
+
+def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD):
+    """Resolve a colloquial/partial/variant law mention to the formal `law_name`
+    in this context (pg_trgm similarity over law_name_catalog), or None if nothing
+    is similar enough. Used on a scoped-filter exact-miss to rescue the scope
+    (e.g. the model's "חוק המכרזים" -> "חוק חובת המכרזים").
+    """
+    m = _best_law_match(sess, cid, mention, threshold)
+    if m is not None and m[1] >= threshold:
+        return m[0]
     return None
 
 

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -958,6 +958,17 @@ class VectorStoreAurora(VectorStoreBase):
             logger.info("search scoped: law_name=%r scoped_vec=%d scoped_lex=%d gate_fired=%s (%s, %s)",
                         law_norm, len(vector_rows), len(bm25_rows), gate_fired, bot, context_name)
         if gate_fired:
+            with get_session() as rs:
+                resolved = _resolve_law_name(rs, cid, law_norm, _LAW_NAME_RESOLVE_THRESHOLD)
+            if resolved and resolved != law_norm:
+                logger.info("search: law_name=%r resolved to %r in (%s, %s); re-scoping",
+                            law_norm, resolved, bot, context_name)
+                rf = self.search(context_name, query_text, search_mode, embedding,
+                                 num_results=num_results, explain=explain,
+                                 metadata_filter={"law_name": resolved})
+                for hit in rf["hits"]["hits"]:
+                    hit.setdefault("_source", {}).setdefault("metadata", {})["_resolved_from"] = law_norm
+                return rf
             fb = self.search(context_name, query_text, search_mode, embedding,
                              num_results=num_results, explain=explain, metadata_filter=None)
             for hit in fb["hits"]["hits"]:

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -1063,6 +1063,15 @@ class VectorStoreAurora(VectorStoreBase):
             for hit in fb["hits"]["hits"]:
                 hit.setdefault("_source", {}).setdefault("metadata", {})["_fallback_reason"] = "law_name_absent"
             return fb
+        # Decision-complete retrieval: for the interpretive/decision corpora, hand the
+        # LLM the whole decision/opinion a chunk belongs to (same DocumentTitle) instead
+        # of a fragment. Opt-in per context; runs on the final fused result; own session
+        # (the search session is already closed here). Best-effort inside the helper.
+        if ctx_cfg and ctx_cfg.get("expand_to_document") and result["hits"]["hits"]:
+            _ecap = _resolve_int_setting(ctx_cfg, "expand_max_chunks", _EXPAND_MAX_CHUNKS_DEFAULT,
+                                         minimum=1, maximum=200)
+            with get_session() as es:
+                result["hits"]["hits"] = _expand_to_documents(es, cid, result["hits"]["hits"], _ecap)
         return result
 
     def government_distribution(self, context_name: str, decision_number: str) -> list[dict]:

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -121,6 +121,32 @@ def _build_metadata_filter_sql(metadata_filter):
     return "".join(clauses), params
 
 
+_LAW_NAME_RESOLVE_THRESHOLD = 0.45
+
+
+def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD):
+    """Resolve a colloquial/partial/variant law mention to the formal `law_name`
+    in this context (pg_trgm similarity), or None if nothing is similar enough.
+
+    Used only on a scoped-filter exact-miss to rescue the scope (e.g. the model's
+    "חוק המכרזים" -> "חוק חובת המכרזים"). The `%` operator is gated by
+    pg_trgm.similarity_threshold; we set it to `threshold` so `%` and the Python
+    check agree. The `documents_law_name_trgm` index serves the `%` lookup.
+    """
+    if not mention:
+        return None
+    sess.execute(text("SET LOCAL pg_trgm.similarity_threshold = %s" % float(threshold)))
+    row = sess.execute(text(
+        "SELECT metadata->>'law_name' AS ln, similarity(metadata->>'law_name', :m) AS s "
+        "FROM documents "
+        "WHERE context_id = :cid AND metadata ? 'law_name' AND (metadata->>'law_name') % :m "
+        "ORDER BY s DESC LIMIT 1"
+    ), {"cid": cid, "m": mention}).fetchone()
+    if row and row[1] is not None and float(row[1]) >= threshold:
+        return row[0]
+    return None
+
+
 _SCOPED_OVERRIDE_VECTOR_WEIGHT = 0.5
 
 

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -99,6 +99,28 @@ _LAW_NAME_NORM_SQL = (
     " '\\s+', ' ', 'g'))"
 )
 
+def _build_metadata_filter_sql(metadata_filter):
+    """Build the WHERE fragment + params for a metadata_filter.
+
+    `law_name` is matched by NORMALIZED equality (punctuation-insensitive) so the
+    model's "חוק-יסוד: הממשלה" hits the stored "חוק-יסוד הממשלה". Any other keys keep
+    the original JSONB containment (`@>`).
+    """
+    if not metadata_filter:
+        return "", {}
+    clauses = []
+    params = {}
+    rest = dict(metadata_filter)
+    law = rest.pop("law_name", None)
+    if law is not None:
+        clauses.append(f" AND {_LAW_NAME_NORM_SQL} = :law_norm")
+        params["law_norm"] = _normalize_law_name(str(law))
+    if rest:
+        clauses.append(" AND metadata @> CAST(:mfilter AS jsonb)")
+        params["mfilter"] = json.dumps(rest)
+    return "".join(clauses), params
+
+
 # Back-compat aliases for callers that import the old names.
 CHUNK_MAX_TOKENS = _CHUNK_MAX_TOKENS_DEFAULT
 CHUNK_OVERLAP_TOKENS = _CHUNK_OVERLAP_TOKENS_DEFAULT
@@ -764,11 +786,7 @@ class VectorStoreAurora(VectorStoreBase):
                 return {"hits": {"hits": []}}
             cid = str(row[0])
 
-            md_filter_sql = ""
-            md_params = {}
-            if metadata_filter:
-                md_filter_sql = " AND metadata @> CAST(:mfilter AS jsonb)"
-                md_params["mfilter"] = json.dumps(metadata_filter)
+            md_filter_sql, md_params = _build_metadata_filter_sql(metadata_filter)
 
             if use_vector:
                 vector_rows = sess.execute(text(

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -76,6 +76,29 @@ _LEXICAL_STRATEGIES = frozenset({_LEXICAL_STRATEGY_TSQUERY, _LEXICAL_STRATEGY_TR
 # Set via SET LOCAL inside the search txn — never leaks.
 _TRIGRAM_WORD_SIMILARITY_THRESHOLD = 0.1
 
+# Punctuation-only law_name normalization. Applied identically to the query-side
+# filter value (Python) and the stored value (SQL, _LAW_NAME_NORM_SQL) so a model
+# that emits "חוק-יסוד: הממשלה" matches a stored "חוק-יסוד הממשלה" / "חוק־יסוד: ...".
+_LAW_NAME_NORM_TRANSFORMS = [("־", "-"), (":", " "), ("״", '"'), ("׳", "'")]
+
+
+def _normalize_law_name(value):
+    if value is None:
+        return None
+    s = str(value)
+    for src, dst in _LAW_NAME_NORM_TRANSFORMS:
+        s = s.replace(src, dst)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+# Same transform as _normalize_law_name, in SQL, over metadata->>'law_name'.
+# '׳'→'''' is the SQL escaped apostrophe; '\\s+' is the Python-escaped regex \s+.
+_LAW_NAME_NORM_SQL = (
+    "trim(regexp_replace("
+    "replace(replace(replace(replace(metadata->>'law_name', '־', '-'), ':', ' '), '״', '\"'), '׳', ''''),"
+    " '\\s+', ' ', 'g'))"
+)
+
 # Back-compat aliases for callers that import the old names.
 CHUNK_MAX_TOKENS = _CHUNK_MAX_TOKENS_DEFAULT
 CHUNK_OVERLAP_TOKENS = _CHUNK_OVERLAP_TOKENS_DEFAULT

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -1365,15 +1365,22 @@ def _rrf_fuse(
 
 
 _EXPAND_MAX_CHUNKS_DEFAULT = 12
+_EXPAND_TOTAL_CHUNKS_BUDGET = 40  # aggregate cap across all hits in one result (bounds tool-response size)
 
 
-def _expand_to_documents(sess, cid, hits, max_chunks=_EXPAND_MAX_CHUNKS_DEFAULT):
+def _expand_to_documents(sess, cid, hits, max_chunks=_EXPAND_MAX_CHUNKS_DEFAULT, total_budget=_EXPAND_TOTAL_CHUNKS_BUDGET):
     """Replace each hit's content with the FULL decision/opinion it belongs to
     (all chunks sharing its metadata.DocumentTitle, chunk_index-ordered, capped at
     max_chunks), so the LLM reasons over the complete finding instead of a fragment.
     Hits sharing a DocumentTitle collapse to the first (highest-ranked) one; hits
     without a DocumentTitle pass through unchanged. Best-effort: on any error, return
     the original hits.
+
+    total_budget caps the AGGREGATE kept-chunk count across ALL expanded hits in one
+    call. Once used >= total_budget, remaining titled hits pass through un-expanded
+    (in their original RRF position) instead of ballooning the tool response.
+    Hits that pass through (no title, already-seen dedup, or budget-spent) do NOT
+    count against the budget.
     """
     try:
         titles = []
@@ -1394,6 +1401,7 @@ def _expand_to_documents(sess, cid, hits, max_chunks=_EXPAND_MAX_CHUNKS_DEFAULT)
         for row in sess.execute(stmt, {"cid": cid, "titles": titles}).fetchall():
             by_title.setdefault(row[0], []).append(row[1])
         out, seen = [], set()
+        used = 0
         for h in hits:
             t = (h.get("_source", {}).get("metadata", {}) or {}).get("DocumentTitle")
             if not t or t not in by_title:
@@ -1402,8 +1410,12 @@ def _expand_to_documents(sess, cid, hits, max_chunks=_EXPAND_MAX_CHUNKS_DEFAULT)
             if t in seen:
                 continue
             seen.add(t)
+            if used >= total_budget:
+                out.append(h)
+                continue
             chunks = by_title[t]
             kept = chunks[:max_chunks]
+            used += len(kept)
             new_h = {**h, "_source": {**h["_source"],
                      "content": "\n\n".join(c for c in kept if c),
                      "metadata": {**h["_source"].get("metadata", {}),

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -121,6 +121,43 @@ def _build_metadata_filter_sql(metadata_filter):
     return "".join(clauses), params
 
 
+_SCOPED_OVERRIDE_VECTOR_WEIGHT = 0.5
+
+
+def _scoped_vector_knn_sql(rest_sql):
+    """SQL for an EXACT vector KNN over a single law's docs.
+
+    `AS MATERIALIZED` is MANDATORY: Postgres 12+ inlines a single-reference CTE
+    by default, which would let the planner merge the law_name filter with the
+    `ORDER BY embedding <=>` and plan a GLOBAL HNSW scan + post-filter — that can
+    return 0 for a selective law even though its docs exist. Materializing the
+    law's docs first makes the outer ORDER BY ... LIMIT an exact KNN over that
+    small set. `rest_sql` carries any non-law_name filter keys so the scoped set
+    matches the FULL filter.
+    """
+    return (
+        "WITH law_docs AS MATERIALIZED ("
+        " SELECT id, content, metadata, embedding FROM documents"
+        # `metadata ? 'law_name'` is REQUIRED for the planner to use the partial
+        # index documents_law_name_norm (migration 0016) -> O(law) filter. It is
+        # semantically redundant with the norm-equality clause but the planner
+        # cannot infer the implication through the replace/regexp chain.
+        f" WHERE context_id = :cid AND metadata ? 'law_name' AND {_LAW_NAME_NORM_SQL} = :law_norm{rest_sql}"
+        ")"
+        " SELECT id, content, metadata, 1 - (embedding <=> CAST(:emb AS vector)) AS score"
+        " FROM law_docs ORDER BY embedding <=> CAST(:emb AS vector) LIMIT :limit"
+    )
+
+
+def _scoped_vector_knn(sess, cid, law_norm, rest_sql, rest_params, embedding, fetch):
+    """Exact vector KNN over one law's docs (see _scoped_vector_knn_sql). `sess` is
+    the caller's transaction; hnsw.ef_search is irrelevant here (no HNSW on the
+    materialized rows)."""
+    return sess.execute(text(_scoped_vector_knn_sql(rest_sql)), {
+        "cid": cid, "law_norm": law_norm, "emb": str(embedding), "limit": fetch, **rest_params,
+    }).fetchall()
+
+
 # Back-compat aliases for callers that import the old names.
 CHUNK_MAX_TOKENS = _CHUNK_MAX_TOKENS_DEFAULT
 CHUNK_OVERLAP_TOKENS = _CHUNK_OVERLAP_TOKENS_DEFAULT

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -882,6 +882,29 @@ class VectorStoreAurora(VectorStoreBase):
             )
             ctx_strategy = _LEXICAL_STRATEGY_TSQUERY
 
+        # Query-side law detection: when the model leaves israeli_laws unfiltered but
+        # the query names a specific law, detect+resolve it and re-scope (independent of
+        # the model's tool-selection). israeli_laws-only; one level deep — the re-entrant
+        # call carries law_name, so has_law_name is True there and this block is skipped.
+        _q_law = (metadata_filter or {}).get("law_name")
+        _q_no_law = _q_law is None or not _normalize_law_name(str(_q_law))
+        if _q_no_law and context_name == "israeli_laws" and use_vector:
+            with get_session() as ds:
+                _drow = ds.execute(text(
+                    "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
+                ), {"bot": bot, "name": context_name}).fetchone()
+                detected = (_detect_law_in_query(ds, str(_drow[0]), query_text,
+                                                 _QUERY_DETECT_THRESHOLD) if _drow else None)
+            if detected:
+                logger.info("search query-detected: query=%r resolved=%r (%s, %s)",
+                            query_text, detected, bot, context_name)
+                df = self.search(context_name, query_text, search_mode, embedding,
+                                 num_results=num_results, explain=explain,
+                                 metadata_filter={"law_name": detected})
+                for hit in df["hits"]["hits"]:
+                    hit.setdefault("_source", {}).setdefault("metadata", {})["_query_detected_law"] = detected
+                return df
+
         # Resolve context_id from (bot, name) — small extra round-trip but
         # keeps the search call self-contained and resilient to context
         # rows being added/removed mid-process.

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -672,11 +672,7 @@ class VectorStoreAurora(VectorStoreBase):
                 return {"hits": {"hits": []}}
             cid = str(row[0])
 
-            md_filter_sql = ""
-            md_params = {}
-            if metadata_filter:
-                md_filter_sql = " AND metadata @> CAST(:mfilter AS jsonb)"
-                md_params["mfilter"] = json.dumps(metadata_filter)
+            md_filter_sql, md_params = _build_metadata_filter_sql(metadata_filter)
 
             rows = sess.execute(text(f"""
                 WITH dated AS (

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -925,16 +925,22 @@ class VectorStoreAurora(VectorStoreBase):
         # §86 lexical match. For modes where vector was already on, weight is unchanged.
         _vw = _SCOPED_OVERRIDE_VECTOR_WEIGHT if (has_law_name and not use_vector) else 1.0
         result = _rrf_fuse(vector_rows, bm25_rows, num_results, vector_weight=_vw)
-        # Auto-fallback: if a metadata_filter eliminated every candidate, the data may
-        # still be reachable unfiltered (e.g. a colloquial law name, or a law_name our
-        # normalization can't bridge). Re-run once WITHOUT the filter. The
-        # `metadata_filter is not None` guard on this branch means the unfiltered re-run
-        # (metadata_filter=None) cannot recurse — bounded to one level.
-        if metadata_filter is not None and not result["hits"]["hits"]:
-            logger.info("search: metadata_filter %r yielded 0 rows for (%s, %s); retrying unfiltered",
-                        metadata_filter, bot, context_name)
-            return self.search(context_name, query_text, search_mode, embedding,
-                               num_results=num_results, explain=explain, metadata_filter=None)
+        # Spec §D observability + scope-preserving fallback. The fallback fires ONLY when
+        # law_name is the SOLE filter key and the fully-scoped result is empty — i.e. the
+        # named law has zero docs (a genuinely absent colloquial name like "חוק המכרזים").
+        # A compound-filter miss returns empty rather than widening to cross-law. Bounded
+        # to one level (re-run passes metadata_filter=None). bm25_rows / vector_rows are in
+        # function scope here (assigned inside the closed `with get_session()` block).
+        gate_fired = bool(has_law_name and not other_keys and not result["hits"]["hits"])
+        if has_law_name:
+            logger.info("search scoped: law_name=%r scoped_vec=%d scoped_lex=%d gate_fired=%s (%s, %s)",
+                        law_norm, len(vector_rows), len(bm25_rows), gate_fired, bot, context_name)
+        if gate_fired:
+            fb = self.search(context_name, query_text, search_mode, embedding,
+                             num_results=num_results, explain=explain, metadata_filter=None)
+            for hit in fb["hits"]["hits"]:
+                hit.setdefault("_source", {}).setdefault("metadata", {})["_fallback_reason"] = "law_name_absent"
+            return fb
         return result
 
     def government_distribution(self, context_name: str, decision_number: str) -> list[dict]:

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -156,6 +156,61 @@ def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD)
     return None
 
 
+_QUERY_DETECT_THRESHOLD = 0.55
+
+# Legal-title prefix tokens (an optional single leading letter — ה article, ל/ב/כ prepositions — is stripped before matching).
+_LEGAL_PREFIXES = frozenset({
+    "חוק", "חוק-יסוד", "תקנון", "תקנות", "פקודת", "פקודה", "כללי", "צו", "הוראות",
+})
+# Tokens that end a law-name span (question words, conjunctions).
+_SPAN_BOUNDARY = frozenset({
+    "מה", "מהו", "מהי", "האם", "מתי", "איך", "כמה", "מי", "למה", "איזה", "ו", "או", "אבל",
+})
+_DETECT_PUNCT = "?,.!׳״()\"':;"
+
+
+def _detect_law_in_query(sess, cid, query_text, threshold=_QUERY_DETECT_THRESHOLD):
+    """If an unfiltered israeli_laws query names a specific law, return the formal
+    law_name (resolved via _best_law_match over law_name_catalog), else None.
+
+    Gate: the query must contain EXACTLY ONE legal-prefix token (חוק/תקנון/...);
+    zero or more-than-one (ambiguous) -> None. From that prefix, try spans of
+    prefix + 1..3 following content tokens (stopping at a boundary word / punctuation),
+    requiring >=1 content token; resolve each and keep the single best match >= threshold.
+    """
+    if not query_text:
+        return None
+    raw = query_text.split()
+    toks = [t.strip(_DETECT_PUNCT) for t in raw]
+    had_punct = [t != t.strip(_DETECT_PUNCT) for t in raw]  # token carried a trailing/leading boundary mark
+
+    def _is_prefix(tok):
+        # strip a single leading letter (ה=article; ל/ב/כ=prepositions) if the remainder is a legal prefix
+        t = tok[1:] if len(tok) > 1 and tok[1:] in _LEGAL_PREFIXES else tok
+        return t in _LEGAL_PREFIXES
+
+    prefix_idxs = [i for i, t in enumerate(toks) if t and _is_prefix(t)]
+    if len(prefix_idxs) != 1:
+        return None
+    i = prefix_idxs[0]
+
+    best = None  # (law_name, score)
+    for k in (1, 2, 3):
+        end = i + k
+        if end >= len(toks):
+            break
+        nxt = toks[end]
+        if not nxt or nxt in _SPAN_BOUNDARY:
+            break
+        span = " ".join(toks[i:end + 1])
+        m = _best_law_match(sess, cid, span, threshold)
+        if m is not None and m[1] >= threshold and (best is None or m[1] > best[1]):
+            best = m
+        if had_punct[end]:  # this token ended a sentence clause — stop extending
+            break
+    return best[0] if best is not None else None
+
+
 _SCOPED_OVERRIDE_VECTOR_WEIGHT = 0.5
 
 

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -822,6 +822,7 @@ class VectorStoreAurora(VectorStoreBase):
         num_results: int = 7,
         explain: bool = False,
         metadata_filter: dict | None = None,
+        _qd_skip: bool = False,
     ) -> dict:
         """Hybrid retrieval: pgvector cosine + tsvector BM25, fused via
         reciprocal-rank-fusion. Mirrors VectorStoreES.search's return shape
@@ -888,7 +889,7 @@ class VectorStoreAurora(VectorStoreBase):
         # call carries law_name, so has_law_name is True there and this block is skipped.
         _q_law = (metadata_filter or {}).get("law_name")
         _q_no_law = _q_law is None or not _normalize_law_name(str(_q_law))
-        if _q_no_law and context_name == "israeli_laws" and use_vector:
+        if _q_no_law and context_name == "israeli_laws" and use_vector and not _qd_skip:
             with get_session() as ds:
                 _drow = ds.execute(text(
                     "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
@@ -1047,7 +1048,7 @@ class VectorStoreAurora(VectorStoreBase):
         if gate_fired:
             with get_session() as rs:
                 resolved = _resolve_law_name(rs, cid, law_norm, _LAW_NAME_RESOLVE_THRESHOLD)
-            if resolved and resolved != law_norm:
+            if resolved and _normalize_law_name(resolved) != law_norm:
                 logger.info("search: law_name=%r resolved to %r in (%s, %s); re-scoping",
                             law_norm, resolved, bot, context_name)
                 rf = self.search(context_name, query_text, search_mode, embedding,
@@ -1057,7 +1058,8 @@ class VectorStoreAurora(VectorStoreBase):
                     hit.setdefault("_source", {}).setdefault("metadata", {})["_resolved_from"] = law_norm
                 return rf
             fb = self.search(context_name, query_text, search_mode, embedding,
-                             num_results=num_results, explain=explain, metadata_filter=None)
+                             num_results=num_results, explain=explain, metadata_filter=None,
+                             _qd_skip=True)
             for hit in fb["hits"]["hits"]:
                 hit.setdefault("_source", {}).setdefault("metadata", {})["_fallback_reason"] = "law_name_absent"
             return fb

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -859,7 +859,18 @@ class VectorStoreAurora(VectorStoreBase):
                     lexical_rows = []
             bm25_rows = lexical_rows  # kept name for back-compat with _rrf_fuse call below
 
-        return _rrf_fuse(vector_rows, bm25_rows, num_results)
+        result = _rrf_fuse(vector_rows, bm25_rows, num_results)
+        # Auto-fallback: if a metadata_filter eliminated every candidate, the data may
+        # still be reachable unfiltered (e.g. a colloquial law name, or a law_name our
+        # normalization can't bridge). Re-run once WITHOUT the filter. The
+        # `metadata_filter is not None` guard on this branch means the unfiltered re-run
+        # (metadata_filter=None) cannot recurse — bounded to one level.
+        if metadata_filter is not None and not result["hits"]["hits"]:
+            logger.info("search: metadata_filter %r yielded 0 rows for (%s, %s); retrying unfiltered",
+                        metadata_filter, bot, context_name)
+            return self.search(context_name, query_text, search_mode, embedding,
+                               num_results=num_results, explain=explain, metadata_filter=None)
+        return result
 
     def government_distribution(self, context_name: str, decision_number: str) -> list[dict]:
         """One entry per distinct government_number with the given decision_number.

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import tiktoken
 from openai import OpenAI
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
 from ..config import is_production, get_logger, DEFAULT_EMBEDDING_SIZE, DEFAULT_EMBEDDING_MODEL
 from ..db.session import get_engine, get_session
@@ -1353,3 +1353,55 @@ def _rrf_fuse(
         try: span.set_attribute("rrf.returned", len(result["hits"]["hits"]))
         except Exception: pass
         return result
+
+
+_EXPAND_MAX_CHUNKS_DEFAULT = 12
+
+
+def _expand_to_documents(sess, cid, hits, max_chunks=_EXPAND_MAX_CHUNKS_DEFAULT):
+    """Replace each hit's content with the FULL decision/opinion it belongs to
+    (all chunks sharing its metadata.DocumentTitle, chunk_index-ordered, capped at
+    max_chunks), so the LLM reasons over the complete finding instead of a fragment.
+    Hits sharing a DocumentTitle collapse to the first (highest-ranked) one; hits
+    without a DocumentTitle pass through unchanged. Best-effort: on any error, return
+    the original hits.
+    """
+    try:
+        titles = []
+        for h in hits:
+            t = (h.get("_source", {}).get("metadata", {}) or {}).get("DocumentTitle")
+            if t and t not in titles:
+                titles.append(t)
+        if not titles:
+            return hits
+        stmt = text(
+            "SELECT metadata->>'DocumentTitle' AS t, content, "
+            "COALESCE((metadata->>'chunk_index')::int, 0) AS ci "
+            "FROM documents "
+            "WHERE context_id = :cid AND metadata->>'DocumentTitle' IN :titles "
+            "ORDER BY t, ci, id"
+        ).bindparams(bindparam("titles", expanding=True))
+        by_title = {}
+        for row in sess.execute(stmt, {"cid": cid, "titles": titles}).fetchall():
+            by_title.setdefault(row[0], []).append(row[1])
+        out, seen = [], set()
+        for h in hits:
+            t = (h.get("_source", {}).get("metadata", {}) or {}).get("DocumentTitle")
+            if not t or t not in by_title:
+                out.append(h)
+                continue
+            if t in seen:
+                continue
+            seen.add(t)
+            chunks = by_title[t]
+            kept = chunks[:max_chunks]
+            new_h = {**h, "_source": {**h["_source"],
+                     "content": "\n\n".join(c for c in kept if c),
+                     "metadata": {**h["_source"].get("metadata", {}),
+                                  "_expanded_chunks": len(kept),
+                                  "_expanded_truncated": len(chunks) > max_chunks}}}
+            out.append(new_h)
+        return out
+    except Exception as e:  # noqa: BLE001 — expansion must never fail the search
+        logger.warning("decision-complete expansion skipped: %s", e)
+        return hits

--- a/deploy/gold-set.json
+++ b/deploy/gold-set.json
@@ -2,7 +2,7 @@
   {
     "source_excel_row": 0,
     "question": "מה הנחיות היועצת המשפטית לכנסת בעניין הסתייגויות בוועדה",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Knesset legal advisor guidelines on reservations (הסתייגויות) in committee. The topic surfaces multiple memos: budget-reservation memo (8.1.2024), new-topic-via-reservation memo (4.5.2023), and concurrent-meetings memo (28.6.2022). Tests the bot's full-text-search legal retrieval on a topic that is split across many short legal-advisor letters rather than concentrated in a single takanon section.",
     "expected_substrings": [
       "הסתייגות"
@@ -42,7 +42,7 @@
   {
     "source_excel_row": 2,
     "question": "לפי ההחלטות של ועדת האתיקה, ורק לפיהם, האם מותר להוציא חבר כנסת מישיבה בשלוש קריאות רצופות?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Ethics-committee constraint on three consecutive calls-to-order, with the user explicitly scoping the search to ועדת האתיקה decisions only. The 31.10.2006 Limor Livnat vs. David Tal ruling explicitly says calls cannot be back-to-back. Tests the bot's ability to honour an explicit narrow scope.",
     "expected_substrings": [
       "ועדת האתיקה"
@@ -62,7 +62,7 @@
   {
     "source_excel_row": 3,
     "question": "האם מותר להוציא חבר כנסת בשלוש קריאות רצוף?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Same call-to-order question as row 2 but with no scope restriction. Bot historically went to תקנון הכנסת §42(ב)(2) and ועדת הכנסת decisions, missing the directly-on-point ועדת האתיקה ruling. Tests whether the bot recognises that operational rules of the Knesset are partly set by ethics-committee decisions and legal-advisor letters, not only by the takanon.",
     "expected_substrings": [
       "קריאה"
@@ -102,7 +102,7 @@
   {
     "source_excel_row": 5,
     "question": "אחרי שהתחיל הדיון בהצעת חוק בוועדה מסויימת, איך אפשר להעביר את הדיון לוועדה אחרת?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Transferring a bill between committees mid-deliberation. Answer lives in תקנון הכנסת §78(ג). The bot's existing answer was deemed adequate by the goldset author, so this entry mostly guards against regression rather than driving improvement.",
     "expected_substrings": [
       "ועדת הכנסת"
@@ -122,7 +122,7 @@
   {
     "source_excel_row": 6,
     "question": "הגשתי שאילתה אבל עבר המועד הקבוע והשר לא השיב. מה הכלים שיש לי עכשיו?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Tools available to an MK when a minister fails to answer a query (שאילתה) on time — the MK can ask the Speaker to upgrade it to שאילתה דחופה. Existing bot answer was deemed adequate; entry guards against regression.",
     "expected_substrings": [
       "שאילתה"
@@ -142,7 +142,7 @@
   {
     "source_excel_row": 7,
     "question": "מה הדרך ליזום ועדת חקירה ממלכתית דרך הכנסת?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "How to initiate a STATE commission of inquiry (ועדת חקירה ממלכתית) via the Knesset. KNOWN FAILURE: the bot conflates this with ועדת חקירה פרלמנטרית, confidently answers the wrong question, and on follow-up admits it cannot reach חוק ועדות חקירה / חוק מבקר המדינה — both supposedly available in ספר החוקים הפתוח. Tests (a) terminology discipline (state vs. parliamentary) and (b) whether the legal-text corpus actually covers these two laws.",
     "expected_substrings": [
       "ועדת חקירה"
@@ -162,7 +162,7 @@
   {
     "source_excel_row": 8,
     "question": "מה צריך כדי להכריז על חבר כנסת כפורש מסיעה?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Requirements to declare an MK as having defected from their faction (פורש מסיעה). Substantive test under חוק-יסוד: הכנסת + procedural hearing in ועדת הכנסת. Bot historically failed to engage and asked the user to clarify whether they wanted legal or budget info — a deflection. The goldset author also embedded a known-good GPT-4 answer in the additional_notes column for reference.",
     "expected_substrings": [
       "סיעה"
@@ -184,7 +184,7 @@
   {
     "source_excel_row": 9,
     "question": "מי מוסמך להכריז על ראש ממשלה שנבצר ממילוי תפקידו",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "Authority to declare the PM incapacitated. Lives in חוק-יסוד: הממשלה (incapacity provisions). New goldset entry — no prior bot answer documented; included so we can track whether the legal corpus carries חוק-יסוד: הממשלה well enough to cite the right body and procedure.",
     "expected_substrings": [
       "נבצר"
@@ -204,7 +204,7 @@
   {
     "source_excel_row": 10,
     "question": "מהו חוק המכרזים?",
-    "context": "legal_text",
+    "context": "israeli_laws",
     "description": "What is the Tenders Law (חוק חובת המכרזים)? KNOWN FAILURE: even the previous Bonim system could not retrieve this law. Goldset entry left in so we notice if/when retrieval starts working — a green pass here probably means the legal corpus has been broadened.",
     "expected_substrings": [
       "מכרזים"
@@ -258,6 +258,26 @@
       "baseline_answer": "מצאתי בלוח המליאה שתי ישיבות מתוכננות בשבועיים הקרובים לפי התוצאות שהוחזרו:\n\nתאריך\tשעה\tמס’ ישיבה\tסוג\tסעיפים עיקריים בסדר היום\n27/04/2026\t15:00\t386\tישיבת מליאה רגילה\tבין היתר: הצעת חוק שיקום נזקי מלחמה בדרך של התחדשות עירונית, הצעות לסדר בנושא \"הכישלון המדיני\", \"הפקרות בצפון\", הצעה לדיון מהיר בנושא קיצוץ בתקציב לסטודנטים במילואים, והצעות חוק נוספות\n04/05/2026\t11:00\t387\tישיבת מליאה רגילה\tבין היתר: הצעת חוק העמדה לדין בשל אירועי טבח 7 באוקטובר 2023 (טבח שמיני עצרת), התשפ\"ו–2026\n\nמקורות:\n\nישיבת מליאה 27/04/2026 15:00 — תוצאות החיפוש בלוח המליאה\nישיבת מליאה 04/05/2026 11:00 — תוצאות החיפוש בלוח המליאה\n\nהערה: בתוצאות שהוחזרו היו כמה רשומות חוזרות לאותה ישיבה, ולכן ריכזתי אותן לפי תאריך ולקחתי את הסעיפים שנמצאו בפועל. לא הוחזרו תאריכים נוספים מעבר לשתי הישיבות האלה בתוך חלון החיפוש.\n\nאם תרצה, אפשר להמשיך באחת משתי דרכים:\n\nלפרט את כל סעיפי סדר היום לכל אחת מהישיבות.\nלבדוק אם יש ישיבת מליאה נוספת מעבר לשבועיים הקרובים.",
       "followup_answer": null,
       "notes": "Added 2026-05-10 as part of plenary live-tool verification. Backfilled from first sanity-dod run at PR-time. Backfilled 2026-05-10 from prod sanity-dod run /tmp/sanity-dod-vs-2026-05-10-1820.json (HTML at docs/sanity-runs/2026-05-10-1820-prod.html).",
+      "additional_notes": null
+    }
+  },
+  {
+    "source_excel_row": -1,
+    "question": "האם חוק האזנת סתר חל על אזרחים?",
+    "context": "israeli_laws",
+    "description": "Tests the new ספר החוקים הפתוח corpus added by the israeli_laws feature. Verifies that חוק האזנת סתר is retrievable and that the bot can answer who the law applies to: the prohibition on unlawful wiretapping in סעיף 2 applies broadly to anyone (including civilians), while the *authority* to conduct lawful wiretapping is restricted to designated state bodies (security/police, with court order). Synthetic gold-set entry — not drawn from the source Excel; authored to validate the new corpus context.",
+    "expected_substrings": [
+      "האזנת סתר"
+    ],
+    "must_not_contain": [],
+    "expected_behavior": "PASS = the bot answers from חוק האזנת סתר that the prohibition on wiretapping applies broadly — to civilians and anyone (not only state actors) — ideally distinguishing the universal prohibition (סעיף 2, which binds everyone) from the restricted authority to lawfully wiretap (granted only to state security bodies / police / with court approval). FAIL = refusing to answer, claiming no relevant information is available, or asking the user to disambiguate rather than retrieving the law.",
+    "followup_prompt": "תרחיב — צטט את הסעיף הרלוונטי מתוך חוק האזנת סתר",
+    "expected_after_followup": "After the expansion prompt, the bot must cite the relevant section text of חוק האזנת סתר — at minimum a paraphrase or direct quote of the prohibition clause (סעיף 2) that makes clear the law applies to any person who conducts unlawful wiretapping.",
+    "observed": {
+      "routing": null,
+      "baseline_answer": null,
+      "followup_answer": null,
+      "notes": null,
       "additional_notes": null
     }
   },

--- a/scripts/backfill-law-name.py
+++ b/scripts/backfill-law-name.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Backfill a normalized `law_name` field into israeli_laws document metadata.
+
+`law_name` = the base law title (DocumentTitle's prefix before " - "), which
+collapses the section/chapter title variants ("תקנון הכנסת", "תקנון הכנסת - חלק
+ד׳…", "תקנון הכנסת - הליך החקיקה" → all "תקנון הכנסת"). This is what the
+israeli_laws retrieve op's `metadata_filter={"law_name":"<law>"}` matches via
+JSONB exact containment, scoping a search to ONE law and eliminating cross-law
+section-number collisions (hundreds of laws share a "סעיף 86").
+
+Metadata-only UPDATE — does not touch embeddings or content_hash. Run after an
+israeli_laws sync (the gap laws / rich-metadata docs gain DocumentTitle; the
+embed-only thin docs have none and are skipped). Reads DATABASE_URL from env;
+defaults to the local aurora-local container.
+
+    DATABASE_URL=postgresql://botnim:botnim@localhost:54320/botnim_local \\
+        python scripts/backfill-law-name.py
+"""
+import os
+import psycopg
+
+DSN = os.environ.get("DATABASE_URL", "postgresql://botnim:botnim@localhost:54320/botnim_local")
+# session.py-style normalisation: psycopg connects with a plain libpq DSN
+if DSN.startswith("postgresql+psycopg://"):
+    DSN = "postgresql://" + DSN[len("postgresql+psycopg://"):]
+
+conn = psycopg.connect(DSN, autocommit=True)
+n = conn.execute("""
+    UPDATE documents d
+    SET metadata = d.metadata || jsonb_build_object(
+        'law_name', trim(split_part(d.metadata->>'DocumentTitle', ' - ', 1)))
+    FROM contexts c
+    WHERE d.context_id = c.id AND c.name = 'israeli_laws'
+      AND d.metadata ? 'DocumentTitle'
+      AND coalesce(d.metadata->>'DocumentTitle', '') <> ''
+""").rowcount
+print(f"backfilled law_name on {n} israeli_laws documents")

--- a/scripts/ensure-partial-hnsw-indexes.py
+++ b/scripts/ensure-partial-hnsw-indexes.py
@@ -1,0 +1,71 @@
+"""Ensure per-context partial HNSW indexes on documents.embedding.
+
+WHY: pgvector's HNSW index cannot filter by `context_id` during graph traversal.
+A vector search on the shared `documents` table (all contexts under one global
+HNSW index) therefore applies `context_id` as a POST-filter and over-traverses
+the global graph to collect enough matches for one context — slow on large
+contexts. A *partial* HNSW index `WHERE context_id = <ctx>` makes the search
+traverse only that context's vectors (no post-filter). Verified on staging
+2026-06-29: israeli_laws vector search dropped from a global-graph scan to ~1.7s.
+
+This is the durable, reproducible companion to the manual index built on staging.
+Run it on any env (staging/prod) and after any DB rebuild. Idempotent — it skips
+indexes that already exist.
+
+USAGE (inside the botnim-api task, e.g. via `aws ecs run-task` overrides or
+ECS Exec — see parlibot/.claude/skills/botnim-ad-hoc-task):
+    python scripts/ensure-partial-hnsw-indexes.py
+
+Env overrides: HNSW_M (default 32), HNSW_EF_CONSTRUCTION (256),
+INDEX_MAINTENANCE_WORK_MEM (1GB).
+"""
+import os
+from botnim.db.session import get_engine
+from sqlalchemy import text
+
+# (bot, context_name, index_name). Add large/hot contexts whose filtered vector
+# searches are slow. israeli_laws (~185K docs) is the confirmed offender.
+TARGETS = [
+    ("unified", "israeli_laws", "documents_embedding_hnsw_il"),
+]
+M = int(os.environ.get("HNSW_M", "32"))
+EFC = int(os.environ.get("HNSW_EF_CONSTRUCTION", "256"))
+MWM = os.environ.get("INDEX_MAINTENANCE_WORK_MEM", "1GB")
+
+
+def main() -> None:
+    eng = get_engine()
+    with eng.connect() as conn:
+        c = conn.execution_options(isolation_level="AUTOCOMMIT")  # CONCURRENTLY needs no txn
+        try:
+            c.execute(text(f"SET maintenance_work_mem='{MWM}'"))
+        except Exception as e:  # noqa: BLE001 - non-fatal tuning
+            print(f"warn: could not set maintenance_work_mem: {str(e)[:120]}", flush=True)
+        for bot, name, idx in TARGETS:
+            cid = c.execute(
+                text("SELECT id FROM contexts WHERE bot=:b AND name=:n"),
+                {"b": bot, "n": name},
+            ).scalar()
+            if not cid:
+                print(f"[skip] context {bot}/{name} not found — sync it first", flush=True)
+                continue
+            exists = c.execute(
+                text("SELECT 1 FROM pg_class WHERE relname=:i AND relkind='i'"),
+                {"i": idx},
+            ).scalar()
+            if exists:
+                print(f"[ok] {idx} already exists for {bot}/{name}", flush=True)
+                continue
+            print(f"[build] {idx} for {bot}/{name} (context_id={cid}) — this takes minutes...", flush=True)
+            c.execute(text(
+                f"CREATE INDEX CONCURRENTLY {idx} ON documents USING hnsw "
+                f"(embedding vector_cosine_ops) WITH (m={M}, ef_construction={EFC}) "
+                f"WHERE context_id = '{cid}'"
+            ))
+            valid = c.execute(text(
+                "SELECT indisvalid FROM pg_index WHERE indexrelid=:i::regclass"), {"i": idx}).scalar()
+            print(f"[done] {idx} created (valid={valid})", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -161,7 +161,7 @@
     },
     "/botnim/retrieve/unified/israeli_laws__dev": {
       "get": {
-        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). Use for ANY question about what an Israeli statute says, who it applies to, its definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק הגנת הפרטיות, חוק חופש המידע, פקודת מס הכנסה. Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when the user references a specific סעיף by number. NOTE: this is the consolidated text as maintained on ויקיטקסט — not the official רשומות, and not a substitute for legal advice. This is the general-law corpus; for Knesset internal procedure use the takanon/legal_text tools instead.",
+        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). This is the SINGLE source for Israeli statutory law — INCLUDING תקנון הכנסת (Knesset bylaws), the Knesset laws (חוק הכנסת, חוק־יסוד: הכנסת, חוק חסינות חברי הכנסת…), and כללי אתיקה לחברי הכנסת. Use for ANY question about what a law says, who it applies to, its definitions, offences, penalties, and procedures — including Knesset internal procedure (e.g. תקנון הכנסת סעיף 86, הקמת ועדת חקירה פרלמנטרית). Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when a specific סעיף is referenced. For a question about a SPECIFIC named law, ALSO pass metadata_filter={\"law_name\":\"<exact law name>\"} to scope the search to that law and avoid cross-law section-number collisions (hundreds of laws have a 'סעיף 86'). NOTE: consolidated text as maintained on ויקיטקסט — not the official רשומות, not legal advice.",
         "operationId": "search_unified__israeli_laws__dev",
         "parameters": [
           {
@@ -197,6 +197,15 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 50
+            }
+          },
+          {
+            "name": "metadata_filter",
+            "in": "query",
+            "description": "JSON object for a JSONB exact-match filter on document metadata. Use {\"law_name\":\"<exact base law name>\"} to scope the search to ONE law and eliminate cross-law section-number collisions — STRONGLY recommended for any named-law or תקנון query (e.g. {\"law_name\":\"תקנון הכנסת\"}, {\"law_name\":\"חוק האזנת סתר\"}, {\"law_name\":\"כללי אתיקה לחברי הכנסת\"}). law_name is the base law title only — no chapter/section suffix. Omit for broad 'what does any law say' searches across the whole corpus.",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -115,50 +115,6 @@
         "deprecated": false
       }
     },
-    "/botnim/retrieve/unified/legal_text__dev": {
-      "get": {
-        "description": "Search laws, bylaws and regulations in the unified legal knowledge base",
-        "operationId": "search_unified__legal_text__dev",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "description": "Free text search query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "search_mode",
-            "in": "query",
-            "description": "Search mode for different types of queries",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "SECTION_NUMBER",
-                "REGULAR",
-                "METADATA_BROWSE"
-              ],
-              "default": "REGULAR"
-            }
-          },
-          {
-            "name": "num_results",
-            "in": "query",
-            "description": "Number of results to return",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50
-            }
-          }
-        ],
-        "deprecated": false
-      }
-    },
     "/botnim/retrieve/unified/israeli_laws__dev": {
       "get": {
         "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). This is the SINGLE source for Israeli statutory law — INCLUDING תקנון הכנסת (Knesset bylaws), the Knesset laws (חוק הכנסת, חוק־יסוד: הכנסת, חוק חסינות חברי הכנסת…), and כללי אתיקה לחברי הכנסת. Use for ANY question about what a law says, who it applies to, its definitions, offences, penalties, and procedures — including Knesset internal procedure (e.g. תקנון הכנסת סעיף 86, הקמת ועדת חקירה פרלמנטרית). Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when a specific סעיף is referenced. For a question about a SPECIFIC named law, ALSO pass metadata_filter={\"law_name\":\"<exact law name>\"} to scope the search to that law and avoid cross-law section-number collisions (hundreds of laws have a 'סעיף 86'). NOTE: consolidated text as maintained on ויקיטקסט — not the official רשומות, not legal advice.",

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -159,6 +159,50 @@
         "deprecated": false
       }
     },
+    "/botnim/retrieve/unified/israeli_laws__dev": {
+      "get": {
+        "description": "Search the full text of Israeli primary and secondary legislation (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח). Use for ANY question about what an Israeli statute says, who it applies to, its definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק הגנת הפרטיות, חוק חופש המידע, פקודת מס הכנסה. Each result is one section (סעיף) with its chapter context. Cite the law name + section + the source_url verbatim. Use search_mode=SECTION_NUMBER when the user references a specific סעיף by number. NOTE: this is the consolidated text as maintained on ויקיטקסט — not the official רשומות, and not a substitute for legal advice. This is the general-law corpus; for Knesset internal procedure use the takanon/legal_text tools instead.",
+        "operationId": "search_unified__israeli_laws__dev",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Free text search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search_mode",
+            "in": "query",
+            "description": "Search mode for different types of queries",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "SECTION_NUMBER",
+                "REGULAR",
+                "METADATA_BROWSE"
+              ],
+              "default": "REGULAR"
+            }
+          },
+          {
+            "name": "num_results",
+            "in": "query",
+            "description": "Number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          }
+        ],
+        "deprecated": false
+      }
+    },
     "/botnim/retrieve/unified/legal_advisor_opinions__dev": {
       "get": {
         "description": "Search formal legal opinions by Knesset legal advisor. THREE modes — choose by intent: (a) 'מה ההנחיות/חוות הדעת האחרונות', 'הכי עדכניות', 'הכי חדשות', 'מה התפרסם לאחרונה' → use search_mode=RECENCY_BROWSE: returns the calendar-newest documents in pure date-desc order (no similarity ranking, immune to query-phrasing bias). (b) 'אילו חוות דעת יש על X', 'תן לי רשימה של…', browse/enumerate intent on a TOPIC → search_mode=METADATA_BROWSE: similarity-ranked summaries (25 docs). (c) substantive content question requiring full text → leave search_mode=REGULAR (default). For (a) and (b), present 3–5 items with title, date, one-line subject, and קישור_למקור; do not re-sort RECENCY_BROWSE results — they are already newest-first.",

--- a/specs/openapi/botnim.yaml
+++ b/specs/openapi/botnim.yaml
@@ -158,7 +158,7 @@
           {
             "name": "metadata_filter",
             "in": "query",
-            "description": "JSON object for a JSONB exact-match filter on document metadata. Use {\"law_name\":\"<exact base law name>\"} to scope the search to ONE law and eliminate cross-law section-number collisions — STRONGLY recommended for any named-law or תקנון query (e.g. {\"law_name\":\"תקנון הכנסת\"}, {\"law_name\":\"חוק האזנת סתר\"}, {\"law_name\":\"כללי אתיקה לחברי הכנסת\"}). law_name is the base law title only — no chapter/section suffix. Omit for broad 'what does any law say' searches across the whole corpus.",
+            "description": "JSON object for a JSONB exact-match filter on document metadata. Use {\"law_name\":\"<exact base law name>\"} to scope the search to ONE law and eliminate cross-law section-number collisions — STRONGLY recommended for any named-law or תקנון query (e.g. {\"law_name\":\"תקנון הכנסת\"}, {\"law_name\":\"חוק האזנת סתר\"}, {\"law_name\":\"כללי אתיקה לחברי הכנסת\"}). law_name is the base law title only — no chapter/section suffix. Pass law_name whenever the user names or asks about a SPECIFIC law — even colloquially, partially, or approximately (e.g. {\"law_name\":\"חוק המכרזים\"} for the formal חוק חובת המכרזים); the system resolves an approximate name to the formal law and scopes to it. Omit ONLY for genuinely cross-law topical searches ('what does any law say about X').",
             "required": false,
             "schema": {
               "type": "string"

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -1,7 +1,8 @@
 slug: unified
 name: בוטנים
-description: עונה על שאלות מתוך תקנון הכנסת וחוקים נלווים וכן על שאלות בנושאי תקציב
-  המדינה, הכנסות המדינה, התקשרויות ותמיכות תקציביות
+description: עונה על שאלות מתוך תקנון הכנסת וחוקים נלווים, מתוך ספר החוקים הפתוח
+  (החקיקה הראשית והמשנית של מדינת ישראל), וכן על שאלות בנושאי תקציב המדינה,
+  הכנסות המדינה, התקשרויות ותמיכות תקציביות
 tools:
 - code-interpreter
 - budgetkey
@@ -88,6 +89,30 @@ context:
     fetcher:
       kind: wikitext
       input_url: https://he.wikisource.org/wiki/%D7%94%D7%97%D7%9C%D7%98%D7%AA_%D7%A9%D7%9B%D7%A8_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA_(%D7%94%D7%A2%D7%A0%D7%A7%D7%95%D7%AA_%D7%95%D7%AA%D7%A9%D7%9C%D7%95%D7%9E%D7%99%D7%9D)
+- slug: israeli_laws
+  name: ספר החוקים הפתוח — חקיקה ראשית ומשנית של מדינת ישראל
+  description: 'Search the full text of Israeli primary and secondary legislation
+    (laws, ordinances, regulations) from the open law book (ספר החוקים הפתוח).
+    Use for: any question about what an Israeli statute says, who it applies to,
+    definitions, offences, penalties, and procedures — e.g. חוק האזנת סתר, חוק
+    הגנת הפרטיות, חוק חופש המידע. Each result is one section (סעיף) with its
+    chapter context. Cite the law name + section + the WikiSource source_url.
+    NOTE: this is the consolidated text as maintained on ויקיטקסט — not the
+    official רשומות, and not a substitute for legal advice.'
+  examples: 'האם חוק האזנת סתר חל על אזרחים, מה העונש על האזנת סתר, הגדרת מידע
+    לפי חוק הגנת הפרטיות, מתי מותר לרשות לסרב לבקשת חופש מידע'
+  # Title-rich Hebrew legal corpus — verbatim law-name queries rank far better
+  # under trigram/BM25 than text-embedding-3-small cosine. Same rationale as
+  # legal_text (see its block above) and the legal_advisor contexts.
+  use_lexical_search: true
+  lexical_strategy: trigram
+  sources:
+  - type: split
+    source: extraction/law_book/*_structure_content.json
+    fetcher:
+      kind: wikisource_law_book
+      include_regulations: true
+      min_expected_laws: 200
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -25,70 +25,12 @@ context:
     source: extraction/lexicon.csv
     fetcher:
       kind: lexicon
-  - type: split
-    source: extraction/כללי_אתיקה_לחברי_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%9B%D7%9C%D7%9C%D7%99_%D7%90%D7%AA%D7%99%D7%A7%D7%94_%D7%9C%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_הפרשנות_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%A4%D7%A8%D7%A9%D7%A0%D7%95%D7%AA
-- slug: legal_text
-  name: Knesset Bylaws (תקנון הכנסת) and related laws
-  # Hebrew-friendly retrieval. The default `tsquery` BM25 strategy uses PG's
-  # `simple` tsconfig which has no Hebrew analyzer — so construct-state
-  # alternation (ועדת↔ועדה↔ועדות) is invisible and procedural-question
-  # queries miss the relevant sections. Switched to `trigram` (pg_trgm
-  # word_similarity, GIN-indexed via migration 0015) on 2026-05-13.
-  # Local A/B on prod-equivalent query "מה הדרך ליזום ועדת חקירה ממלכתית":
-  #   tsquery: 0/3 prod-cited sections in top-8 (§22 / §129 / §135)
-  #   trigram: 3/3 prod-cited sections in top-8
-  # See vector_store_aurora.py _LEXICAL_STRATEGY_* for full rationale.
-  use_lexical_search: true
-  lexical_strategy: trigram
-  sources:
-  - type: split
-    source: extraction/חוק_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_משכן_הכנסת,_רחבתו_ומשמר_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%9E%D7%A9%D7%9B%D7%9F_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA,_%D7%A8%D7%97%D7%91%D7%AA%D7%95_%D7%95%D7%9E%D7%A9%D7%9E%D7%A8_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק-יסוד_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7-%D7%99%D7%A1%D7%95%D7%93:_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/חוק_חסינות_חברי_הכנסת,_זכויותיהם_וחובותיהם_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%97%D7%A1%D7%99%D7%A0%D7%95%D7%AA_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA,_%D7%96%D7%9B%D7%95%D7%99%D7%95%D7%AA%D7%99%D7%94%D7%9D_%D7%95%D7%97%D7%95%D7%91%D7%95%D7%AA%D7%99%D7%94%D7%9D
-  - type: split
-    source: extraction/חוק_לציון_מידע_בדבר_השפעת_חקיקה_על_זכויות_הילד_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%9C%D7%A6%D7%99%D7%95%D7%9F_%D7%9E%D7%99%D7%93%D7%A2_%D7%91%D7%93%D7%91%D7%A8_%D7%94%D7%A9%D7%A4%D7%A2%D7%AA_%D7%97%D7%A7%D7%99%D7%A7%D7%94_%D7%A2%D7%9C_%D7%96%D7%9B%D7%95%D7%99%D7%95%D7%AA_%D7%94%D7%99%D7%9C%D7%93
-  - type: split
-    source: extraction/חוק_רציפות_הדיון_בהצעות_חוק_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%A8%D7%A6%D7%99%D7%A4%D7%95%D7%AA_%D7%94%D7%93%D7%99%D7%95%D7%9F_%D7%91%D7%94%D7%A6%D7%A2%D7%95%D7%AA_%D7%97%D7%95%D7%A7
-  - type: split
-    source: extraction/תקנון_הכנסת_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%AA%D7%A7%D7%A0%D7%95%D7%9F_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA
-  - type: split
-    source: extraction/החלטת_שכר_חברי_הכנסת_(הענקות_ותשלומים)_structure_content.json
-    fetcher:
-      kind: wikitext
-      input_url: https://he.wikisource.org/wiki/%D7%94%D7%97%D7%9C%D7%98%D7%AA_%D7%A9%D7%9B%D7%A8_%D7%97%D7%91%D7%A8%D7%99_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA_(%D7%94%D7%A2%D7%A0%D7%A7%D7%95%D7%AA_%D7%95%D7%AA%D7%A9%D7%9C%D7%95%D7%9E%D7%99%D7%9D)
+  # Law content (כללי אתיקה, חוק הפרשנות) moved to israeli_laws (single source
+  # of statutory law). This context is glossary-only now.
+# legal_text retired 2026-06-22 — israeli_laws (the open law book) is now the
+# single source of statutory law. All 8 of its laws (תקנון הכנסת, חוק הכנסת,
+# חוק־יסוד: הכנסת, חוק חסינות, …, החלטת שכר) live in israeli_laws; the gold-set
+# §86 / ועדת חקירה queries pass at parity-or-better via metadata_filter law_name.
 - slug: israeli_laws
   name: ספר החוקים הפתוח — חקיקה ראשית ומשנית של מדינת ישראל
   description: 'Search the full text of Israeli primary and secondary legislation

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -43,11 +43,19 @@ context:
     official רשומות, and not a substitute for legal advice.'
   examples: 'האם חוק האזנת סתר חל על אזרחים, מה העונש על האזנת סתר, הגדרת מידע
     לפי חוק הגנת הפרטיות, מתי מותר לרשות לסרב לבקשת חופש מידע'
-  # Title-rich Hebrew legal corpus — verbatim law-name queries rank far better
-  # under trigram/BM25 than text-embedding-3-small cosine. Same rationale as
-  # legal_text (see its block above) and the legal_advisor contexts.
+  # Title-rich Hebrew legal corpus — verbatim law-name queries need a lexical
+  # signal alongside vector cosine. lexical_strategy was `trigram`, but
+  # pg_trgm's word-similarity operator (`%>`) is NOT index-able: on the 185K-doc
+  # open law book it forces a full parallel seq scan computing word_similarity()
+  # per row (~20s, EXPLAIN-verified 2026-06-29), blowing the 12s retrieve
+  # deadline → 504s. Switched to `tsquery`, which uses the documents_tsv_gin GIN
+  # index (@@, ~0.8s) and ranks on DocumentTitle (tsv weight A, migration 0004)
+  # — now populated across all 185K docs by the 2026-06-28 re-extraction, so the
+  # original "simple tsv has no title signal" reason for trigram no longer holds.
+  # Vector recall for Hebrew construct-state variants is covered by the
+  # per-context partial HNSW index (documents_embedding_hnsw_il).
   use_lexical_search: true
-  lexical_strategy: trigram
+  lexical_strategy: tsquery
   sources:
   - type: split
     source: extraction/law_book/*_structure_content.json

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -113,10 +113,6 @@ context:
       kind: wikisource_law_book
       include_regulations: true
       min_expected_laws: 200
-      # Single-source consolidation: ingest the legal_text laws (incl. תקנון
-      # הכנסת) into israeli_laws too. legal_text still exists during the parity
-      # gate; once it is retired the skip-list is empty anyway.
-      apply_skip_list: false
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -72,6 +72,7 @@ context:
   # correctly where text-embedding-3-small cosine fails. Opt back into the
   # lexical RRF branch; mode default (false) does not apply here.
   use_lexical_search: true
+  expand_to_document: true
   sources:
   - type: csv
     source: extraction/legal_advisor_opinions/index.csv
@@ -175,6 +176,7 @@ context:
   examples: מכתב בעניין פנייה, תשובה על שאלה, בירור משפטי
   # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
   use_lexical_search: true
+  expand_to_document: true
   sources:
   - type: csv
     source: extraction/legal_advisor_letters/index.csv
@@ -278,6 +280,7 @@ context:
   examples: החלטת ועדת הכנסת על נוהל, החלטה פרוצדורלית, הסדר עבודה
   # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
   use_lexical_search: true
+  expand_to_document: true
   sources:
   - type: csv
     source: extraction/committee_decisions/index.csv
@@ -363,6 +366,7 @@ context:
   examples: תרומה לחבר כנסת, ניגוד עניינים, הפרת כללי אתיקה, סנקציות
   # Title-rich Hebrew document corpus — opt into BM25 alongside vector.
   use_lexical_search: true
+  expand_to_document: true
   sources:
   - type: csv
     source: extraction/ethics_decisions/index.csv

--- a/specs/unified/config.yaml
+++ b/specs/unified/config.yaml
@@ -113,6 +113,10 @@ context:
       kind: wikisource_law_book
       include_regulations: true
       min_expected_laws: 200
+      # Single-source consolidation: ingest the legal_text laws (incl. תקנון
+      # הכנסת) into israeli_laws too. legal_text still exists during the parity
+      # gate; once it is retired the skip-list is empty anyway.
+      apply_skip_list: false
 - slug: legal_advisor_opinions
   name: חוות דעת היועצת המשפטית לכנסת
   description: 'Search formal legal opinions by Knesset legal advisor. Use for: legal

--- a/tests/test_collect_sources.py
+++ b/tests/test_collect_sources.py
@@ -276,3 +276,37 @@ def test_csv_content_hash_stable_across_file_last_updated_change(tmp_path):
     assert content_a == content_b, "content must not vary with file_last_updated"
     h = lambda s: _hashlib.sha256(s.strip().encode("utf-8")).hexdigest()
     assert h(content_a) == h(content_b)
+
+
+# -----------------------------------------------------------------------------
+# Glob support in _collect_raw_streams_split (Task 7 — israeli_laws context)
+# -----------------------------------------------------------------------------
+
+import json as _json  # noqa: E402
+
+from botnim.collect_sources import _collect_raw_streams_split  # noqa: E402
+
+
+def _write_law_json(path: Path, document_name: str, section_name: str, content: str):
+    path.write_text(_json.dumps({
+        "metadata": {"document_name": document_name},
+        "structure": [{"depth": 1, "section_name": section_name,
+                       "section_type": "סעיף", "content": content, "children": []}],
+    }, ensure_ascii=False), encoding="utf-8")
+
+
+def test_split_glob_reads_all_law_jsons(tmp_path: Path):
+    d = tmp_path / "extraction" / "law_book"
+    d.mkdir(parents=True)
+    _write_law_json(d / "חוק_א_structure_content.json", "חוק א", "סעיף 1", "תוכן א")
+    _write_law_json(d / "חוק_ב_structure_content.json", "חוק ב", "סעיף 1", "תוכן ב")
+
+    out = _collect_raw_streams_split(tmp_path, "israeli_laws",
+                                     "extraction/law_book/*_structure_content.json")
+    names = sorted(fname for fname, _c, _t, _m in out)
+    # document_name prefixes every chunk filename → no collision across laws.
+    # sanitize_filename converts spaces to underscores in both document_name
+    # and section_name components, so "חוק א" + "סעיף 1" → "חוק_א_סעיף_1.md".
+    assert names == ["חוק_א_סעיף_1.md", "חוק_ב_סעיף_1.md"]
+    bodies = " ".join(c for _f, c, _t, _m in out)
+    assert "תוכן א" in bodies and "תוכן ב" in bodies

--- a/tests/test_config_israeli_laws.py
+++ b/tests/test_config_israeli_laws.py
@@ -1,0 +1,17 @@
+# tests/test_config_israeli_laws.py
+from pathlib import Path
+import yaml
+from botnim.config import SPECS
+
+
+def test_israeli_laws_context_registered():
+    cfg = yaml.safe_load((SPECS / "unified" / "config.yaml").read_text(encoding="utf-8"))
+    ctx = {c["slug"]: c for c in cfg["context"]}
+    assert "israeli_laws" in ctx
+    il = ctx["israeli_laws"]
+    assert il.get("use_lexical_search") is True
+    assert il.get("lexical_strategy") == "trigram"
+    srcs = il["sources"]
+    assert any(s.get("type") == "split" and "*" in s.get("source", "") for s in srcs)
+    fetcher = next(s["fetcher"] for s in srcs if s.get("fetcher"))
+    assert fetcher["kind"] == "wikisource_law_book"

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -95,3 +95,41 @@ def test_expand_caps_chunks(aurora_db_filter, database_url):
         out = _expand_to_documents(c, cid, [_hit("החלטה ג", "c0")], max_chunks=3)
     assert out[0]["_source"]["metadata"]["_expanded_chunks"] == 3
     assert out[0]["_source"]["metadata"]["_expanded_truncated"] is True
+
+
+class _FakeEmbed:
+    def embed(self, text):
+        return [1.0] * 1536
+
+
+def test_search_expands_for_optin_context(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    # config marks 'dctx' as expand_to_document; 'plain' is not opted in
+    store = VectorStoreAurora(config={"slug": "unified", "name": "U", "context": [
+        {"slug": "dctx", "expand_to_document": True}, {"slug": "plain"}]},
+        config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "dctx"}, "dctx", False)
+    _seed_chunk(database_url, cid, "הכלל: רשאי להוציא לאחר שלוש קריאות", "החלטה ד", 0)
+    _seed_chunk(database_url, cid, "אולם לא באופן רצוף — שהות לתקן", "החלטה ד", 2)
+    emb = [1.0] * 1536
+    res = store.search(context_name="dctx", query_text="שלוש קריאות לסדר",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5)
+    blob = " ".join(h["_source"]["content"] for h in res["hits"]["hits"])
+    assert "לא באופן רצוף" in blob                                   # the qualifier chunk is now present
+    assert any(h["_source"]["metadata"].get("_expanded_chunks") for h in res["hits"]["hits"])
+
+
+def test_search_no_expand_for_plain_context(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "U", "context": [{"slug": "plain"}]},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "plain"}, "plain", False)
+    _seed_chunk(database_url, cid, "rule chunk", "כותרת", 0)
+    _seed_chunk(database_url, cid, "qualifier chunk", "כותרת", 2)
+    res = store.search(context_name="plain", query_text="rule",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=[1.0] * 1536, num_results=5)
+    assert not any(h["_source"]["metadata"].get("_expanded_chunks") for h in res["hits"]["hits"])

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -133,3 +133,22 @@ def test_search_no_expand_for_plain_context(aurora_db_filter, database_url, monk
     res = store.search(context_name="plain", query_text="rule",
                        search_mode=DEFAULT_SEARCH_MODE, embedding=[1.0] * 1536, num_results=5)
     assert not any(h["_source"]["metadata"].get("_expanded_chunks") for h in res["hits"]["hits"])
+
+
+def test_expand_respects_total_budget(aurora_db_filter, database_url):
+    from botnim.vector_store.vector_store_aurora import _expand_to_documents
+    cid = _ctx(database_url)
+    # three decisions, 3 chunks each; a small total budget should expand the first
+    # (in RRF order) and pass the rest through un-expanded
+    for d in ("דא", "דב", "דג"):
+        for i in range(3):
+            _seed_chunk(database_url, cid, "%s-c%d" % (d, i), d, i)
+    hits = [_hit("דא", "דא-c0", 0.9), _hit("דב", "דב-c0", 0.8), _hit("דג", "דג-c0", 0.7)]
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        out = _expand_to_documents(c, cid, hits, max_chunks=12, total_budget=3)
+    # first decision expanded (3 chunks == budget), later ones passed through un-expanded
+    assert out[0]["_source"]["metadata"].get("_expanded_chunks") == 3
+    assert not out[1]["_source"]["metadata"].get("_expanded_chunks")
+    assert not out[2]["_source"]["metadata"].get("_expanded_chunks")
+    assert len(out) == 3                                  # budget-spent hits are passed through, not dropped

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+# `database_url` is a conftest fixture (auto-available). Define a SELF-CONTAINED
+# per-test-DB fixture here (same mechanism as tests/test_law_name_filter.py) rather
+# than importing it cross-module, which is brittle across pytest import modes.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def aurora_db_filter(database_url, monkeypatch):
+    alembic_bin = str(_REPO_ROOT / ".venv" / "bin" / "alembic")
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run([alembic_bin, "--config", "alembic.ini", "upgrade", "head"],
+                   cwd=_REPO_ROOT, env=env, check=True, capture_output=True)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-test")
+    from botnim.db import session as s
+    s._engine = None
+    yield database_url
+    s._engine = None
+
+
+def _seed_chunk(database_url, cid, content, title, chunk_index, embedding="[" + ",".join(["0.1"] * 1536) + "]"):
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        c.execute(text(
+            "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+            "VALUES (gen_random_uuid(), :cid, :content, :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+            {"cid": cid, "content": content, "h": "%s#%d" % (title, chunk_index),
+             "m": '{"DocumentTitle": "%s", "chunk_index": %d}' % (title, chunk_index), "e": embedding})
+
+
+def _ctx(database_url, name="dctx"):
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        return str(c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', :n) "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id"), {"n": name}).scalar())
+
+
+def _hit(title, content, score=1.0):
+    return {"_id": "x", "_score": score, "_source": {"content": content, "metadata": {"DocumentTitle": title}}}
+
+
+def test_expand_merges_full_decision(aurora_db_filter, database_url):
+    from botnim.vector_store.vector_store_aurora import _expand_to_documents
+    cid = _ctx(database_url)
+    _seed_chunk(database_url, cid, "הכלל: היושב ראש רשאי להוציא לאחר שלוש קריאות לסדר", "החלטה א", 0)
+    _seed_chunk(database_url, cid, "המשך נימוקים", "החלטה א", 1)
+    _seed_chunk(database_url, cid, "אולם הקריאות לא תיעשנה באופן רצוף — תינתן שהות לתקן", "החלטה א", 3)
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        # a single fragment-hit (chunk 0) -> expanded passage contains chunk 3's qualifier
+        out = _expand_to_documents(c, cid, [_hit("החלטה א", "הכלל: היושב ראש רשאי להוציא לאחר שלוש קריאות לסדר")])
+    assert len(out) == 1
+    assert "לא תיעשנה באופן רצוף" in out[0]["_source"]["content"]
+    assert out[0]["_source"]["metadata"]["_expanded_chunks"] == 3
+
+
+def test_expand_dedups_same_title(aurora_db_filter, database_url):
+    from botnim.vector_store.vector_store_aurora import _expand_to_documents
+    cid = _ctx(database_url)
+    _seed_chunk(database_url, cid, "chunk0", "החלטה ב", 0)
+    _seed_chunk(database_url, cid, "chunk1", "החלטה ב", 1)
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        out = _expand_to_documents(c, cid, [_hit("החלטה ב", "chunk0", 0.9), _hit("החלטה ב", "chunk1", 0.5)])
+    assert len(out) == 1                       # two fragment-hits of one decision -> one result
+    assert out[0]["_score"] == 0.9             # keeps the highest-ranked occurrence
+
+
+def test_expand_passthrough_without_title(aurora_db_filter, database_url):
+    from botnim.vector_store.vector_store_aurora import _expand_to_documents
+    cid = _ctx(database_url)
+    eng = create_engine(database_url)
+    h = {"_id": "x", "_score": 1.0, "_source": {"content": "no title here", "metadata": {}}}
+    with eng.connect() as c:
+        out = _expand_to_documents(c, cid, [h])
+    assert out == [h]                          # untouched, no _expanded_chunks tag
+
+
+def test_expand_caps_chunks(aurora_db_filter, database_url):
+    from botnim.vector_store.vector_store_aurora import _expand_to_documents
+    cid = _ctx(database_url)
+    for i in range(6):
+        _seed_chunk(database_url, cid, "c%d" % i, "החלטה ג", i)
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        out = _expand_to_documents(c, cid, [_hit("החלטה ג", "c0")], max_chunks=3)
+    assert out[0]["_source"]["metadata"]["_expanded_chunks"] == 3
+    assert out[0]["_source"]["metadata"]["_expanded_truncated"] is True

--- a/tests/test_fetch_and_process_dispatch.py
+++ b/tests/test_fetch_and_process_dispatch.py
@@ -138,3 +138,16 @@ def test_indexed_pdf_end_to_end_empty_index(tmp_path: Path):
     # 0-row index + no pre-existing output → the empty-out branch wrote
     # extraction/x.csv with just the header.
     assert (tmp_path / "extraction" / "x.csv").exists()
+
+
+def test_dispatch_wikisource_law_book(tmp_path: Path):
+    src = {"source": "extraction/law_book/*_structure_content.json",
+           "fetcher": {"kind": "wikisource_law_book", "include_regulations": True}}
+    with patch(
+        "botnim.document_parser.wikisource_law_book.process.process_law_book_source"
+    ) as mock_inner:
+        from botnim.fetch_and_process import fetch_and_process_source
+        fetch_and_process_source("local", tmp_path, "ctx", src, "all")
+        mock_inner.assert_called_once()
+        # environment + config_dir positional; include_regulations forwarded
+        assert mock_inner.call_args.kwargs.get("include_regulations") is True

--- a/tests/test_law_book_classify.py
+++ b/tests/test_law_book_classify.py
@@ -12,10 +12,16 @@ from botnim.document_parser.wikisource_law_book.classify import classify_title
     ("תקנות הגנת הפרטיות (אבטחת מידע)", "regulation"),
     ("צו המועצות המקומיות", "regulation"),
     ("כללי לשכת עורכי הדין", "regulation"),
+    ("תקנון הכנסת", "regulation"),
     ("ויקיטקסט:אודות", "other"),
     ("עזרה:תוכן", "other"),
     ("מדיניות הפרטיות", "other"),
     ("", "other"),
+    # legal_text carry-over: starts with החלט (→ "other" by default) but must be
+    # ingested into israeli_laws for the single-source consolidation.
+    ("החלטת שכר חברי הכנסת (הענקות ותשלומים)", "regulation"),
+    # guard: the carry-over allow-list stays narrow — generic החלטות stay "other".
+    ("החלטת ממשלה מספר 550", "other"),
 ])
 def test_classify_title(title, expected):
     assert classify_title(title) == expected

--- a/tests/test_law_book_classify.py
+++ b/tests/test_law_book_classify.py
@@ -1,0 +1,21 @@
+import pytest
+from botnim.document_parser.wikisource_law_book.classify import classify_title
+
+
+@pytest.mark.parametrize("title,expected", [
+    ("חוק האזנת סתר", "law"),
+    ("חוק הגנת הפרטיות", "law"),
+    ("חוק-יסוד: הכנסת", "law"),
+    ("חוק יסוד: כבוד האדם וחירותו", "law"),
+    ("פקודת מס הכנסה", "law"),
+    ("פקודת הראיות [נוסח חדש]", "law"),
+    ("תקנות הגנת הפרטיות (אבטחת מידע)", "regulation"),
+    ("צו המועצות המקומיות", "regulation"),
+    ("כללי לשכת עורכי הדין", "regulation"),
+    ("ויקיטקסט:אודות", "other"),
+    ("עזרה:תוכן", "other"),
+    ("מדיניות הפרטיות", "other"),
+    ("", "other"),
+])
+def test_classify_title(title, expected):
+    assert classify_title(title) == expected

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -48,3 +48,18 @@ def test_discover_shrink_guard_vs_prior(tmp_path: Path):
     with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
         with pytest.raises(E.CoverageShrinkError):
             E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)
+
+
+def test_discover_skip_list_disabled_includes_skiplisted_laws(tmp_path: Path):
+    # _write_cfg skip-lists חוק הכנסת (it's a legal_text source). With
+    # apply_skip_list=False the enumerator must NOT drop it — this is the
+    # consolidation lever that lets israeli_laws ingest the legal_text laws
+    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "חוק הכנסת"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        out = E.discover_law_pages(tmp_path, include_regulations=False,
+                                   min_expected_laws=1, apply_skip_list=False)
+    out_titles = [e.title for e in out]
+    assert "חוק הכנסת" in out_titles      # normally skip-listed, now included
+    assert "חוק האזנת סתר" in out_titles

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -48,18 +48,3 @@ def test_discover_shrink_guard_vs_prior(tmp_path: Path):
     with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
         with pytest.raises(E.CoverageShrinkError):
             E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)
-
-
-def test_discover_skip_list_disabled_includes_skiplisted_laws(tmp_path: Path):
-    # _write_cfg skip-lists חוק הכנסת (it's a legal_text source). With
-    # apply_skip_list=False the enumerator must NOT drop it — this is the
-    # consolidation lever that lets israeli_laws ingest the legal_text laws
-    # (incl. תקנון הכנסת) while legal_text still exists for the parity gate.
-    _write_cfg(tmp_path)
-    titles = ["חוק האזנת סתר", "חוק הכנסת"]
-    with patch.object(E, "fetch_index_titles", return_value=titles):
-        out = E.discover_law_pages(tmp_path, include_regulations=False,
-                                   min_expected_laws=1, apply_skip_list=False)
-    out_titles = [e.title for e in out]
-    assert "חוק הכנסת" in out_titles      # normally skip-listed, now included
-    assert "חוק האזנת סתר" in out_titles

--- a/tests/test_law_book_enumerate.py
+++ b/tests/test_law_book_enumerate.py
@@ -1,0 +1,50 @@
+# tests/test_law_book_enumerate.py
+from pathlib import Path
+from unittest.mock import patch
+import yaml
+import pytest
+from botnim.document_parser.wikisource_law_book import enumerate_laws as E
+from botnim.document_parser.wikisource_law_book.manifest import LawBookEntry
+
+
+def _write_cfg(tmp_path):
+    cfg = {"context": [{"slug": "legal_text", "sources": [
+        {"type": "split", "source": "x.json",
+         "fetcher": {"kind": "wikitext",
+                     "input_url": "https://he.wikisource.org/wiki/חוק_הכנסת"}}]}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+
+
+def test_discover_classifies_skips_and_filters(tmp_path: Path):
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "חוק הכנסת", "תקנות הגנת הפרטיות", "ויקיטקסט:אודות"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        # laws only: drops the regulation, the skip-list law (חוק הכנסת), the noise page
+        out = E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1)
+    assert [e.title for e in out] == ["חוק האזנת סתר"]
+    assert out[0].kind == "law"
+    assert out[0].url == "https://he.wikisource.org/wiki/חוק_האזנת_סתר"
+    assert out[0].status == "pending"
+
+
+def test_discover_includes_regulations_when_flagged(tmp_path: Path):
+    _write_cfg(tmp_path)
+    titles = ["חוק האזנת סתר", "תקנות הגנת הפרטיות"]
+    with patch.object(E, "fetch_index_titles", return_value=titles):
+        out = E.discover_law_pages(tmp_path, include_regulations=True, min_expected_laws=1)
+    assert {e.kind for e in out} == {"law", "regulation"}
+
+
+def test_discover_floor_guard(tmp_path: Path):
+    _write_cfg(tmp_path)
+    with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
+        with pytest.raises(E.CoverageShrinkError):
+            E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=200)
+
+
+def test_discover_shrink_guard_vs_prior(tmp_path: Path):
+    _write_cfg(tmp_path)
+    prior = [LawBookEntry(f"חוק מספר {i}", f"u{i}", "law") for i in range(100)]
+    with patch.object(E, "fetch_index_titles", return_value=["חוק האזנת סתר"]):
+        with pytest.raises(E.CoverageShrinkError):
+            E.discover_law_pages(tmp_path, include_regulations=False, min_expected_laws=1, prior=prior)

--- a/tests/test_law_book_manifest.py
+++ b/tests/test_law_book_manifest.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from botnim.document_parser.wikisource_law_book.manifest import (
+    LawBookEntry, write_manifest, read_manifest,
+)
+
+
+def test_manifest_round_trip(tmp_path: Path):
+    entries = [
+        LawBookEntry("חוק האזנת סתר", "https://he.wikisource.org/wiki/חוק_האזנת_סתר", "law", "ok"),
+        LawBookEntry("תקנות הגנת הפרטיות", "https://he.wikisource.org/wiki/תקנות_הגנת_הפרטיות", "regulation", "failed"),
+    ]
+    p = tmp_path / "manifest.csv"
+    write_manifest(p, entries)
+    assert p.exists()
+    out = read_manifest(p)
+    assert out == entries
+
+
+def test_read_missing_returns_empty(tmp_path: Path):
+    assert read_manifest(tmp_path / "nope.csv") == []

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -45,8 +45,9 @@ def test_process_isolates_per_item_failure(tmp_path: Path):
     good = MagicMock(); good.run.return_value = True
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
-         patch.object(P, "WikitextProcessor", return_value=good):
+         patch.object(P, "WikitextProcessor", return_value=good) as MockProc:
         P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
     assert out == {"חוק טוב": "ok", "חוק רע": "failed"}
+    assert MockProc.call_count == 1

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -1,0 +1,52 @@
+# tests/test_law_book_process.py
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import yaml
+from botnim.document_parser.wikisource_law_book import process as P
+from botnim.document_parser.wikisource_law_book.manifest import LawBookEntry, read_manifest
+
+
+def _cfg(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"context": [{"slug": "legal_text", "sources": []}]}, allow_unicode=True),
+        encoding="utf-8")
+
+
+def test_process_runs_processor_per_item_and_records_status(tmp_path: Path):
+    _cfg(tmp_path)
+    discovered = [
+        LawBookEntry("חוק האזנת סתר", "https://he.wikisource.org/wiki/חוק_האזנת_סתר", "law"),
+        LawBookEntry("חוק אוויר נקי", "https://he.wikisource.org/wiki/חוק_אוויר_נקי", "law"),
+    ]
+    made = MagicMock()
+    made.run.return_value = True
+    with patch.object(P, "discover_law_pages", return_value=discovered), \
+         patch.object(P, "WikitextProcessorConfig") as MockCfg, \
+         patch.object(P, "WikitextProcessor", return_value=made) as MockProc:
+        P.process_law_book_source("local", tmp_path, include_regulations=False,
+                                  min_expected_laws=1, rate_limit_seconds=0)
+    assert MockProc.call_count == 2
+    out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
+    assert out == {"חוק האזנת סתר": "ok", "חוק אוויר נקי": "ok"}
+
+
+def test_process_isolates_per_item_failure(tmp_path: Path):
+    _cfg(tmp_path)
+    discovered = [
+        LawBookEntry("חוק טוב", "https://he.wikisource.org/wiki/חוק_טוב", "law"),
+        LawBookEntry("חוק רע", "https://he.wikisource.org/wiki/חוק_רע", "law"),
+    ]
+
+    def cfg_side_effect(*a, **k):
+        if "רע" in k.get("input_url", ""):
+            raise RuntimeError("network boom")
+        return MagicMock()
+
+    good = MagicMock(); good.run.return_value = True
+    with patch.object(P, "discover_law_pages", return_value=discovered), \
+         patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
+         patch.object(P, "WikitextProcessor", return_value=good):
+        P.process_law_book_source("local", tmp_path, include_regulations=False,
+                                  min_expected_laws=1, rate_limit_seconds=0)
+    out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
+    assert out == {"חוק טוב": "ok", "חוק רע": "failed"}

--- a/tests/test_law_book_process.py
+++ b/tests/test_law_book_process.py
@@ -23,7 +23,7 @@ def test_process_runs_processor_per_item_and_records_status(tmp_path: Path):
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig") as MockCfg, \
          patch.object(P, "WikitextProcessor", return_value=made) as MockProc:
-        P.process_law_book_source("local", tmp_path, include_regulations=False,
+        P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     assert MockProc.call_count == 2
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
@@ -46,7 +46,7 @@ def test_process_isolates_per_item_failure(tmp_path: Path):
     with patch.object(P, "discover_law_pages", return_value=discovered), \
          patch.object(P, "WikitextProcessorConfig", side_effect=cfg_side_effect), \
          patch.object(P, "WikitextProcessor", return_value=good):
-        P.process_law_book_source("local", tmp_path, include_regulations=False,
+        P.process_law_book_source("staging", tmp_path, include_regulations=False,
                                   min_expected_laws=1, rate_limit_seconds=0)
     out = {e.title: e.status for e in read_manifest(tmp_path / "extraction" / "law_book" / "manifest.csv")}
     assert out == {"חוק טוב": "ok", "חוק רע": "failed"}

--- a/tests/test_law_book_skip_list.py
+++ b/tests/test_law_book_skip_list.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import yaml
+from botnim.document_parser.wikisource_law_book.skip_list import (
+    title_from_url, legal_text_skip_titles,
+)
+
+
+def test_title_from_url_decodes_and_unscores():
+    url = "https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA"
+    assert title_from_url(url) == "חוק הכנסת"
+
+
+def test_skip_titles_reads_legal_text(tmp_path: Path):
+    cfg = {
+        "context": [
+            {"slug": "legal_text", "sources": [
+                {"type": "split", "source": "x.json",
+                 "fetcher": {"kind": "wikitext",
+                             "input_url": "https://he.wikisource.org/wiki/%D7%97%D7%95%D7%A7_%D7%94%D7%9B%D7%A0%D7%A1%D7%AA"}},
+            ]},
+            {"slug": "other", "sources": []},
+        ]
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    assert legal_text_skip_titles(tmp_path) == {"חוק הכנסת"}

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -230,3 +230,36 @@ def test_search_law_filter_hard_scopes_in_lexical_only_mode(aurora_db_filter, da
     hits = res["hits"]["hits"]
     assert hits, "scoped vector should recall the law's docs even in a lexical-only mode"
     assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק א"}  # never cross-law
+
+
+def test_absent_sole_law_name_falls_back_and_tags(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "absentlaw"}, "absentlaw", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "חוק חובת המכרזים שמירת דינים",
+                  {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
+    # Sole law_name that has ZERO docs -> scoped empty -> unfiltered fallback surfaces the formal law, tagged.
+    res = store.search(context_name="absentlaw", query_text="חוק חובת המכרזים",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק שלא קיים בכלל"})
+    hits = res["hits"]["hits"]
+    assert hits, "absent sole-law_name should fall back unfiltered"
+    assert all(h["_source"]["metadata"].get("_fallback_reason") == "law_name_absent" for h in hits)
+
+
+def test_compound_filter_miss_returns_empty_not_cross_law(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "compound"}, "compound", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "content", {"law_name": "חוק קיים", "DocumentTitle": "חוק קיים"}, emb)
+    # law_name exists but the compound key matches nothing -> scoped empty -> NO cross-law widening.
+    res = store.search(context_name="compound", query_text="content",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק קיים", "no_such_key": "no_such_value"})
+    assert res["hits"]["hits"] == [], "compound miss must not widen to cross-law results"

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -1,0 +1,10 @@
+from botnim.vector_store.vector_store_aurora import _normalize_law_name
+
+
+def test_normalize_collapses_maqaf_colon_and_whitespace():
+    # model emits hyphen+colon; stored basic laws use maqaf+colon — both must normalize equal
+    assert _normalize_law_name("חוק-יסוד: הממשלה") == "חוק-יסוד הממשלה"
+    assert _normalize_law_name("חוק־יסוד: הכנסת") == "חוק-יסוד הכנסת"   # maqaf U+05BE → hyphen
+    assert _normalize_law_name("חוק-יסוד הממשלה") == "חוק-יסוד הממשלה"   # already-normal stored value
+    assert _normalize_law_name("חוק   חובת  המכרזים ") == "חוק חובת המכרזים"
+    assert _normalize_law_name(None) is None

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -346,3 +346,42 @@ def test_resolve_law_name_bridges_colloquial(aurora_db_filter, database_url):
         assert _resolve_law_name(c, str(cid), "חוק המכרזים", _LAW_NAME_RESOLVE_THRESHOLD) == "חוק חובת המכרזים"
         assert _resolve_law_name(c, str(cid), "תקנון הכנסת") == "תקנון הכנסת"
         assert _resolve_law_name(c, str(cid), "כביש חוצה ישראל זזזזז בטטה") is None
+
+
+def test_absent_law_name_resolves_and_rescopes(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "reslaw"}, "reslaw", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "חוק חובת המכרזים חובת מכרז",
+                  {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
+    _seed_law_doc(database_url, cid, "unrelated law content",
+                  {"law_name": "חוק אחר לגמרי", "DocumentTitle": "חוק אחר לגמרי"}, emb)
+    # colloquial sole law_name -> exact-miss -> resolve -> re-scope to חוק חובת המכרזים, tagged
+    res = store.search(context_name="reslaw", query_text="מהו חוק המכרזים",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק המכרזים"})
+    hits = res["hits"]["hits"]
+    assert hits, "should resolve + re-scope to the formal law"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק חובת המכרזים"}
+    assert all(h["_source"]["metadata"].get("_resolved_from") for h in hits)
+
+
+def test_unresolvable_law_name_falls_back_unfiltered(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "noreslaw"}, "noreslaw", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "some law content", {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
+    # a mention similar to NOTHING -> resolver returns None -> existing unfiltered fallback
+    res = store.search(context_name="noreslaw", query_text="some law content",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "זזזז קקקק ססס בטטה לחלוטין"})
+    hits = res["hits"]["hits"]
+    assert hits, "no resolution -> unfiltered fallback returns the seeded doc"
+    assert all(h["_source"]["metadata"].get("_fallback_reason") == "law_name_absent" for h in hits)
+    assert not any(h["_source"]["metadata"].get("_resolved_from") for h in hits)

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -181,9 +181,8 @@ def test_scoped_vector_knn_sql_is_materialized_and_full_filter():
 
 def test_scoped_vector_knn_hard_scopes_and_orders_by_distance(aurora_db_filter, database_url):
     from sqlalchemy import text
-    from botnim.db.session import get_engine
     from botnim.vector_store.vector_store_aurora import _scoped_vector_knn, _build_metadata_filter_sql, _normalize_law_name
-    eng = get_engine()
+    eng = create_engine(database_url)
     with eng.begin() as c:
         cid = c.execute(text(
             "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'sctx') "

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -326,3 +326,23 @@ def test_law_name_trgm_index_is_used(aurora_db_filter, database_url):
             "WHERE metadata ? 'law_name' AND (metadata->>'law_name') % :m"),
             {"m": "חוק המכרזים"}))
     assert "documents_law_name_trgm" in plan, plan
+
+
+def test_resolve_law_name_bridges_colloquial(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    from botnim.vector_store.vector_store_aurora import _resolve_law_name, _LAW_NAME_RESOLVE_THRESHOLD
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'resctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "חוק האזנת סתר", "תקנון הכנסת"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "resh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    with eng.begin() as c:
+        assert _resolve_law_name(c, str(cid), "חוק המכרזים", _LAW_NAME_RESOLVE_THRESHOLD) == "חוק חובת המכרזים"
+        assert _resolve_law_name(c, str(cid), "תקנון הכנסת") == "תקנון הכנסת"
+        assert _resolve_law_name(c, str(cid), "כביש חוצה ישראל זזזזז בטטה") is None

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -385,3 +385,38 @@ def test_unresolvable_law_name_falls_back_unfiltered(aurora_db_filter, database_
     assert hits, "no resolution -> unfiltered fallback returns the seeded doc"
     assert all(h["_source"]["metadata"].get("_fallback_reason") == "law_name_absent" for h in hits)
     assert not any(h["_source"]["metadata"].get("_resolved_from") for h in hits)
+
+
+def test_law_name_catalog_matview(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        assert c.execute(text(
+            "SELECT 1 FROM pg_matviews WHERE matviewname='law_name_catalog'")).fetchone(), \
+            "law_name_catalog matview must exist after alembic upgrade head"
+        idx = {r[0] for r in c.execute(text(
+            "SELECT indexname FROM pg_indexes WHERE tablename='law_name_catalog'")).fetchall()}
+        assert {"law_name_catalog_uq", "law_name_catalog_trgm"} <= idx, idx
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'mvctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "חוק האזנת סתר"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "mvh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    # matview is empty until refreshed (created empty at migration time, before seeding)
+    with eng.begin() as c:
+        c.execute(text("REFRESH MATERIALIZED VIEW law_name_catalog"))
+    with eng.begin() as c:
+        assert c.execute(text("SELECT count(*) FROM law_name_catalog WHERE context_id=:cid"),
+                         {"cid": str(cid)}).scalar() == 2
+        # prove the trigram index serves `%` (drop the competing unique index to isolate it)
+        c.execute(text("DROP INDEX law_name_catalog_uq"))
+        c.execute(text("SET LOCAL pg_trgm.similarity_threshold = 0.45"))
+        c.execute(text("SET LOCAL enable_seqscan = off"))
+        plan = "\n".join(r[0] for r in c.execute(text(
+            "EXPLAIN SELECT law_name FROM law_name_catalog WHERE law_name % :m"),
+            {"m": "חוק המכרזים"}).fetchall())
+        assert "law_name_catalog_trgm" in plan, plan

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -9,6 +9,13 @@ from sqlalchemy import create_engine, text
 
 from botnim.vector_store.vector_store_aurora import _normalize_law_name, _build_metadata_filter_sql, _LAW_NAME_NORM_SQL
 
+# Import botnim.sync at module level so test_query_error_handling.py's
+# module-level sys.modules mock (which runs at collection time and replaces
+# 'botnim.sync' with a MagicMock) cannot break tests that call sync helpers.
+# Alphabetically this file is collected before test_query_error_handling.py,
+# so the import here captures the real module object.
+import botnim.sync as _botnim_sync
+
 
 class _FakeEmbed:
     def embed(self, text):
@@ -522,3 +529,22 @@ def test_search_topical_query_not_rescoped(aurora_db_filter, database_url, monke
                        search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
                        metadata_filter=None)
     assert not any(h["_source"]["metadata"].get("_query_detected_law") for h in res["hits"]["hits"])
+
+
+def test_refresh_law_name_catalog_picks_up_new_law(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'refctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        c.execute(text(
+            "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+            "VALUES (gen_random_uuid(), :cid, 'x', 'refh', CAST(:m AS jsonb), CAST(:e AS vector))"),
+            {"cid": str(cid), "m": '{"law_name": "חוק חדש לגמרי"}', "e": emb})
+    _botnim_sync._refresh_law_name_catalog()
+    with eng.begin() as c:
+        n = c.execute(text("SELECT count(*) FROM law_name_catalog WHERE law_name=:ln"),
+                      {"ln": "חוק חדש לגמרי"}).scalar()
+        assert n == 1, "refresh should add the new law to the catalog"

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -548,3 +548,30 @@ def test_refresh_law_name_catalog_picks_up_new_law(aurora_db_filter, database_ur
         n = c.execute(text("SELECT count(*) FROM law_name_catalog WHERE law_name=:ln"),
                       {"ln": "חוק חדש לגמרי"}).scalar()
         assert n == 1, "refresh should add the new law to the catalog"
+
+
+def test_stale_matview_punctuated_name_does_not_recurse(aurora_db_filter, database_url, monkeypatch):
+    # Reverse staleness: the matview lists a Basic Law (maqaf) whose docs were deleted.
+    # gate_fired fires, the resolver returns the raw matview name, and the raw-vs-normalized
+    # guard must NOT loop forever — it must fall back unfiltered and terminate.
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "סעיף 1", {"law_name": "חוק־יסוד הממשלה", "DocumentTitle": "x"}, emb)
+    _seed_law_doc(database_url, cid, "תוכן אחר", {"law_name": "חוק אחר לגמרי", "DocumentTitle": "y"}, emb)
+    _refresh_law_catalog(database_url)
+    # delete the Basic Law's docs AFTER the matview captured the name → matview now lists a name with no docs
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        c.execute(text("DELETE FROM documents WHERE metadata->>'law_name' = :ln"), {"ln": "חוק־יסוד הממשלה"})
+    # filter by the hyphen form; law_norm == 'חוק-יסוד הממשלה'; matview still has the maqaf form (raw)
+    res = store.search(context_name="israeli_laws", query_text="חוק יסוד הממשלה",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק-יסוד הממשלה"})
+    # must terminate (no RecursionError) and return the unfiltered fallback
+    hits = res["hits"]["hits"]
+    assert all(h["_source"]["metadata"].get("_fallback_reason") == "law_name_absent" for h in hits)
+    assert not any(h["_source"]["metadata"].get("_resolved_from") for h in hits)

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -1,4 +1,4 @@
-from botnim.vector_store.vector_store_aurora import _normalize_law_name
+from botnim.vector_store.vector_store_aurora import _normalize_law_name, _build_metadata_filter_sql
 
 
 def test_normalize_collapses_maqaf_colon_and_whitespace():
@@ -8,3 +8,21 @@ def test_normalize_collapses_maqaf_colon_and_whitespace():
     assert _normalize_law_name("חוק-יסוד הממשלה") == "חוק-יסוד הממשלה"   # already-normal stored value
     assert _normalize_law_name("חוק   חובת  המכרזים ") == "חוק חובת המכרזים"
     assert _normalize_law_name(None) is None
+
+
+def test_build_filter_normalizes_law_name():
+    sql, params = _build_metadata_filter_sql({"law_name": "חוק-יסוד: הממשלה"})
+    assert "metadata->>'law_name'" in sql and ":law_norm" in sql
+    assert params == {"law_norm": "חוק-יסוד הממשלה"}
+    assert "@>" not in sql            # law_name uses normalized equality, not containment
+
+
+def test_build_filter_keeps_containment_for_other_keys():
+    sql, params = _build_metadata_filter_sql({"decision_number": "550"})
+    assert "metadata @> CAST(:mfilter AS jsonb)" in sql
+    assert params == {"mfilter": '{"decision_number": "550"}'}
+
+
+def test_build_filter_empty():
+    assert _build_metadata_filter_sql(None) == ("", {})
+    assert _build_metadata_filter_sql({}) == ("", {})

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -451,3 +451,36 @@ def test_law_name_catalog_matview(aurora_db_filter, database_url):
             "EXPLAIN SELECT law_name FROM law_name_catalog WHERE law_name % :m"),
             {"m": "חוק המכרזים"}).fetchall())
         assert "law_name_catalog_trgm" in plan, plan
+
+
+def _seed_two_laws_and_refresh(database_url):
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'detctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "חוק האזנת סתר"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "dh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    _refresh_law_catalog(database_url)
+    return str(cid)
+
+
+def test_detect_law_in_query(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    from botnim.vector_store.vector_store_aurora import _detect_law_in_query, _QUERY_DETECT_THRESHOLD
+    cid = _seed_two_laws_and_refresh(database_url)
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        # names a law -> detects + resolves to the formal name
+        assert _detect_law_in_query(c, cid, "מהו חוק המכרזים?", _QUERY_DETECT_THRESHOLD) == "חוק חובת המכרזים"
+        # topical, no legal prefix -> None
+        assert _detect_law_in_query(c, cid, "מה אומרים על מכרזים בכנסת?", _QUERY_DETECT_THRESHOLD) is None
+        # two distinct legal prefixes -> ambiguous -> None
+        assert _detect_law_in_query(c, cid, "ההבדל בין חוק המכרזים לחוק האזנת סתר", _QUERY_DETECT_THRESHOLD) is None
+        # bare prefix, no name -> None
+        assert _detect_law_in_query(c, cid, "מה אומר החוק?", _QUERY_DETECT_THRESHOLD) is None

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -19,6 +19,12 @@ def test_normalize_collapses_maqaf_colon_and_whitespace():
     assert _normalize_law_name(None) is None
 
 
+def test_normalize_gershayim_and_geresh():
+    # gershayim ״ (U+05F4) → ASCII double-quote; geresh ׳ (U+05F3) → ASCII single-quote
+    assert _normalize_law_name('חוק הגנת הצרכן״') == 'חוק הגנת הצרכן"'
+    assert _normalize_law_name("חוק ס׳ 5") == "חוק ס' 5"
+
+
 def test_build_filter_normalizes_law_name():
     sql, params = _build_metadata_filter_sql({"law_name": "חוק-יסוד: הממשלה"})
     assert "metadata->>'law_name'" in sql and ":law_norm" in sql
@@ -37,7 +43,7 @@ def test_build_filter_empty():
     assert _build_metadata_filter_sql({}) == ("", {})
 
 
-_PARITY_CASES = ["חוק-יסוד: הממשלה", "חוק־יסוד: הכנסת", "חוק   חובת  המכרזים", "תקנון הכנסת"]
+_PARITY_CASES = ["חוק-יסוד: הממשלה", "חוק־יסוד: הכנסת", "חוק   חובת  המכרזים", "תקנון הכנסת", "חוק ס׳ 5 התש״ך"]
 
 
 @pytest.mark.parametrize("raw", _PARITY_CASES)
@@ -75,7 +81,8 @@ def aurora_db_filter(database_url, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-test")
     from botnim.db import session as s
     s._engine = None
-    return database_url
+    yield database_url
+    s._engine = None
 
 
 def _seed_law_doc(database_url, context_id, content, metadata, embedding):

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -10,6 +10,11 @@ from sqlalchemy import create_engine, text
 from botnim.vector_store.vector_store_aurora import _normalize_law_name, _build_metadata_filter_sql, _LAW_NAME_NORM_SQL
 
 
+class _FakeEmbed:
+    def embed(self, text):
+        return [1.0] * 1536
+
+
 def test_normalize_collapses_maqaf_colon_and_whitespace():
     # model emits hyphen+colon; stored basic laws use maqaf+colon — both must normalize equal
     assert _normalize_law_name("חוק-יסוד: הממשלה") == "חוק-יסוד הממשלה"
@@ -206,3 +211,22 @@ def test_scoped_vector_knn_hard_scopes_and_orders_by_distance(aurora_db_filter, 
     assert law_names and set(law_names) == {"תקנון הכנסת"}, law_names   # hard-scoped, no cross-law
     # nearest-first: the [1.0] doc (distance 0) outranks the [-1.0] doc (both same law)
     assert rows[0][3] > rows[-1][3]
+
+
+def test_search_law_filter_hard_scopes_in_lexical_only_mode(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import SECTION_NUMBER_CONFIG  # use_vector_search=False
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "lawscope"}, "lawscope", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "alpha section content", {"law_name": "חוק א", "DocumentTitle": "חוק א"}, emb)
+    _seed_law_doc(database_url, cid, "beta section content",  {"law_name": "חוק ב", "DocumentTitle": "חוק ב"}, emb)
+    # SECTION_NUMBER => use_vector=False. With the scoped fork, a law_name filter still
+    # recalls within the law (scoped vector), hard-scoped to חוק א only.
+    res = store.search(context_name="lawscope", query_text="zzz no lexical match zzz",
+                       search_mode=SECTION_NUMBER_CONFIG, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק א"})
+    hits = res["hits"]["hits"]
+    assert hits, "scoped vector should recall the law's docs even in a lexical-only mode"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק א"}  # never cross-law

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -484,3 +484,41 @@ def test_detect_law_in_query(aurora_db_filter, database_url):
         assert _detect_law_in_query(c, cid, "ההבדל בין חוק המכרזים לחוק האזנת סתר", _QUERY_DETECT_THRESHOLD) is None
         # bare prefix, no name -> None
         assert _detect_law_in_query(c, cid, "מה אומר החוק?", _QUERY_DETECT_THRESHOLD) is None
+
+
+def test_search_query_detection_rescopes(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "חובת מכרז גוף ציבורי",
+                  {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
+    _seed_law_doc(database_url, cid, "תוכן לא קשור",
+                  {"law_name": "חוק אחר לגמרי", "DocumentTitle": "חוק אחר לגמרי"}, emb)
+    _refresh_law_catalog(database_url)
+    # unfiltered query that NAMES a law -> detect -> re-scope to חוק חובת המכרזים, tagged
+    res = store.search(context_name="israeli_laws", query_text="מהו חוק המכרזים?",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter=None)
+    hits = res["hits"]["hits"]
+    assert hits, "should detect + re-scope"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק חובת המכרזים"}
+    assert all(h["_source"]["metadata"].get("_query_detected_law") == "חוק חובת המכרזים" for h in hits)
+
+
+def test_search_topical_query_not_rescoped(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "חובת מכרז", {"law_name": "חוק חובת המכרזים", "DocumentTitle": "x"}, emb)
+    _refresh_law_catalog(database_url)
+    # topical query with NO legal prefix -> no detection -> no _query_detected_law tag
+    res = store.search(context_name="israeli_laws", query_text="מה אומרים על מכרזים?",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter=None)
+    assert not any(h["_source"]["metadata"].get("_query_detected_law") for h in res["hits"]["hits"])

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -1,4 +1,7 @@
-from botnim.vector_store.vector_store_aurora import _normalize_law_name, _build_metadata_filter_sql
+import pytest
+from sqlalchemy import create_engine, text
+
+from botnim.vector_store.vector_store_aurora import _normalize_law_name, _build_metadata_filter_sql, _LAW_NAME_NORM_SQL
 
 
 def test_normalize_collapses_maqaf_colon_and_whitespace():
@@ -26,3 +29,16 @@ def test_build_filter_keeps_containment_for_other_keys():
 def test_build_filter_empty():
     assert _build_metadata_filter_sql(None) == ("", {})
     assert _build_metadata_filter_sql({}) == ("", {})
+
+
+_PARITY_CASES = ["חוק-יסוד: הממשלה", "חוק־יסוד: הכנסת", "חוק   חובת  המכרזים", "תקנון הכנסת"]
+
+
+@pytest.mark.parametrize("raw", _PARITY_CASES)
+def test_python_and_sql_normalize_match(raw, database_url):
+    # Run the SQL normalize expression over a literal value, compare to Python.
+    sql = "SELECT " + _LAW_NAME_NORM_SQL.replace("metadata->>'law_name'", ":v")
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        got = c.execute(text(sql), {"v": raw}).scalar()
+    assert got == _normalize_law_name(raw)

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -262,3 +262,19 @@ def test_compound_filter_miss_returns_empty_not_cross_law(aurora_db_filter, data
                        search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
                        metadata_filter={"law_name": "חוק קיים", "no_such_key": "no_such_value"})
     assert res["hits"]["hits"] == [], "compound miss must not widen to cross-law results"
+
+
+def test_recency_search_normalizes_law_name(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import SEARCH_MODES
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client", lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"}, config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "recctx"}, "recctx", False)
+    emb = [1.0] * 1536
+    # stored with maqaf U+05BE + a date; query filter uses ASCII hyphen + colon
+    _seed_law_doc(database_url, cid, "c",
+                  {"law_name": "חוק־יסוד: הכנסת", "DocumentTitle": "חוק־יסוד: הכנסת", "תאריך": "2020-01-01"}, emb)
+    recency = SEARCH_MODES["RECENCY_BROWSE"]
+    res = store.search(context_name="recctx", query_text="x", search_mode=recency, embedding=emb,
+                       num_results=5, metadata_filter={"law_name": "חוק-יסוד: הכנסת"})
+    assert res["hits"]["hits"], "RECENCY_BROWSE must match a normalized (maqaf/colon) law_name"

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -1,3 +1,9 @@
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 from sqlalchemy import create_engine, text
 
@@ -42,3 +48,78 @@ def test_python_and_sql_normalize_match(raw, database_url):
     with eng.connect() as c:
         got = c.execute(text(sql), {"v": raw}).scalar()
     assert got == _normalize_law_name(raw)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: auto-fallback when metadata_filter yields 0 rows
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _alembic_upgrade_filter(database_url: str) -> None:
+    alembic_bin = str(_REPO_ROOT / ".venv" / "bin" / "alembic")
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        [alembic_bin, "--config", "alembic.ini", "upgrade", "head"],
+        cwd=_REPO_ROOT, env=env, check=True, capture_output=True,
+    )
+
+
+@pytest.fixture
+def aurora_db_filter(database_url, monkeypatch):
+    """Aurora backend pointed at a fresh per-test DB with schema applied."""
+    _alembic_upgrade_filter(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("OPENAI_API_KEY_STAGING", "sk-test")
+    from botnim.db import session as s
+    s._engine = None
+    return database_url
+
+
+def _seed_law_doc(database_url, context_id, content, metadata, embedding):
+    eng = create_engine(database_url)
+    with eng.connect() as conn:
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        conn.execute(text(
+            "INSERT INTO documents (context_id, content, content_hash, metadata, embedding) "
+            "VALUES (:cid, :c, :h, CAST(:m AS jsonb), CAST(:e AS vector))"
+        ), {"cid": context_id, "c": content, "h": content_hash,
+            "m": json.dumps(metadata), "e": str(embedding)})
+        conn.commit()
+
+
+def test_filter_miss_falls_back_to_unfiltered(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+
+    class _FakeEmbed:
+        def embed(self, text):
+            return [1.0] * 1536
+    monkeypatch.setattr(
+        "botnim.vector_store.vector_store_aurora._get_embedding_client",
+        lambda env: _FakeEmbed(),
+    )
+
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "testlaws"}, "testlaws", False)
+
+    emb = [1.0] * 1536  # non-zero — zero vectors break pgvector cosine
+    _seed_law_doc(database_url, cid,
+                  "חוק חובת המכרזים שמירת דינים",
+                  {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"},
+                  emb)
+
+    # A filter that matches NOTHING → must fall back to unfiltered and still
+    # surface the law lexically (tsv carries DocumentTitle at weight A).
+    res = store.search(
+        context_name="testlaws",
+        query_text="חוק חובת המכרזים",
+        search_mode=DEFAULT_SEARCH_MODE,
+        embedding=emb,
+        num_results=5,
+        metadata_filter={"law_name": "חוק שלא קיים בכלל"},
+    )
+    assert res["hits"]["hits"], "empty filtered result should have fallen back to unfiltered and returned the law"

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -161,3 +161,48 @@ def test_law_name_norm_index_is_used(aurora_db_filter, database_url):
     # AND that the partial predicate `metadata ? 'law_name'` is in the query — without
     # it PostgreSQL cannot prove the partial-index predicate and won't use the index.
     assert "documents_law_name_norm" in plan, plan
+
+
+def test_scoped_vector_knn_sql_is_materialized_and_full_filter():
+    from botnim.vector_store.vector_store_aurora import _scoped_vector_knn_sql, _LAW_NAME_NORM_SQL
+    sql = _scoped_vector_knn_sql(" AND metadata @> CAST(:mfilter AS jsonb)")
+    assert "AS MATERIALIZED" in sql                                  # mandatory keyword
+    assert "metadata ? 'law_name'" in sql                           # partial-index predicate guard
+    assert _LAW_NAME_NORM_SQL + " = :law_norm" in sql                # scoped by normalized law_name
+    assert "metadata @> CAST(:mfilter AS jsonb)" in sql              # full filter (rest keys)
+    assert "ORDER BY embedding <=> CAST(:emb AS vector)" in sql      # exact KNN
+    assert _scoped_vector_knn_sql("").count("AS MATERIALIZED") == 1  # also present with empty rest
+
+
+def test_scoped_vector_knn_hard_scopes_and_orders_by_distance(aurora_db_filter, database_url):
+    from sqlalchemy import text
+    from botnim.db.session import get_engine
+    from botnim.vector_store.vector_store_aurora import _scoped_vector_knn, _build_metadata_filter_sql, _normalize_law_name
+    eng = get_engine()
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'sctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+
+        def seed(h, law, emb_val):
+            emb = "[" + ",".join([str(emb_val)] * 1536) + "]"
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'c', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": h,
+                 "m": '{"law_name": "%s", "DocumentTitle": "%s"}' % (law, law), "e": emb})
+        seed("near", "תקנון הכנסת", 1.0)   # nearest to query emb [1.0]*1536 (distance 0)
+        seed("far",  "תקנון הכנסת", -1.0)  # same law, far
+        seed("other", "חוק אחר", 1.0)      # different law, also near — must be EXCLUDED
+    rest_sql, rest_params = _build_metadata_filter_sql({})  # no non-law_name keys -> ("", {})
+    q_emb = [1.0] * 1536
+    with eng.connect() as c:
+        rows = _scoped_vector_knn(c, str(cid), _normalize_law_name("תקנון הכנסת"),
+                                  rest_sql, rest_params, q_emb, 10)
+    import json as _json
+    def _md(r):  # JSONB may come back as dict or str depending on driver registration
+        return r[2] if isinstance(r[2], dict) else _json.loads(r[2])
+    law_names = [_md(r)["law_name"] for r in rows]
+    assert law_names and set(law_names) == {"תקנון הכנסת"}, law_names   # hard-scoped, no cross-law
+    # nearest-first: the [1.0] doc (distance 0) outranks the [-1.0] doc (both same law)
+    assert rows[0][3] > rows[-1][3]

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -130,3 +130,34 @@ def test_filter_miss_falls_back_to_unfiltered(aurora_db_filter, database_url, mo
         metadata_filter={"law_name": "חוק שלא קיים בכלל"},
     )
     assert res["hits"]["hits"], "empty filtered result should have fallen back to unfiltered and returned the law"
+
+
+def test_law_name_norm_index_is_used(aurora_db_filter, database_url):
+    # Proves the migration's indexed expression is byte-identical to
+    # _LAW_NAME_NORM_SQL: with seqscan disabled, the planner can only use the
+    # index if the WHERE expression matches the index expression exactly.
+    from sqlalchemy import create_engine, text
+    from botnim.vector_store.vector_store_aurora import _LAW_NAME_NORM_SQL
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'idxctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i in range(3):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector)) "
+                "ON CONFLICT (context_id, content_hash) DO NOTHING"),
+                {"cid": str(cid), "h": "idxh%d" % i,
+                 "m": '{"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}', "e": emb})
+    with eng.begin() as c:
+        c.execute(text("SET LOCAL enable_seqscan = off"))
+        plan = "\n".join(r[0] for r in c.execute(text(
+            "EXPLAIN SELECT id FROM documents WHERE context_id = :cid "
+            "AND metadata ? 'law_name' AND " + _LAW_NAME_NORM_SQL + " = :v"),
+            {"cid": str(cid), "v": "תקנון הכנסת"}))
+    # Verifies BOTH byte-identity (the WHERE expression matches the index expression)
+    # AND that the partial predicate `metadata ? 'law_name'` is in the query — without
+    # it PostgreSQL cannot prove the partial-index predicate and won't use the index.
+    assert "documents_law_name_norm" in plan, plan

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -102,6 +102,13 @@ def _seed_law_doc(database_url, context_id, content, metadata, embedding):
         conn.commit()
 
 
+def _refresh_law_catalog(database_url):
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        c.execute(text("REFRESH MATERIALIZED VIEW law_name_catalog"))
+
+
 def test_filter_miss_falls_back_to_unfiltered(aurora_db_filter, database_url, monkeypatch):
     from botnim.vector_store.vector_store_aurora import VectorStoreAurora
     from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
@@ -342,10 +349,32 @@ def test_resolve_law_name_bridges_colloquial(aurora_db_filter, database_url):
                 "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
                 "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
                 {"cid": str(cid), "h": "resh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    _refresh_law_catalog(database_url)
     with eng.begin() as c:
         assert _resolve_law_name(c, str(cid), "חוק המכרזים", _LAW_NAME_RESOLVE_THRESHOLD) == "חוק חובת המכרזים"
         assert _resolve_law_name(c, str(cid), "תקנון הכנסת") == "תקנון הכנסת"
         assert _resolve_law_name(c, str(cid), "כביש חוצה ישראל זזזזז בטטה") is None
+
+
+def test_best_law_match_returns_name_and_score(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    from botnim.vector_store.vector_store_aurora import _best_law_match, _LAW_NAME_RESOLVE_THRESHOLD
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'bestctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "חוק האזנת סתר"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "bh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    _refresh_law_catalog(database_url)
+    with eng.begin() as c:
+        m = _best_law_match(c, str(cid), "חוק המכרזים", _LAW_NAME_RESOLVE_THRESHOLD)
+        assert m is not None and m[0] == "חוק חובת המכרזים" and 0.0 < m[1] <= 1.0
+        assert _best_law_match(c, str(cid), "כביש חוצה ישראל זזזז בטטה") is None
 
 
 def test_absent_law_name_resolves_and_rescopes(aurora_db_filter, database_url, monkeypatch):
@@ -359,6 +388,7 @@ def test_absent_law_name_resolves_and_rescopes(aurora_db_filter, database_url, m
                   {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
     _seed_law_doc(database_url, cid, "unrelated law content",
                   {"law_name": "חוק אחר לגמרי", "DocumentTitle": "חוק אחר לגמרי"}, emb)
+    _refresh_law_catalog(database_url)
     # colloquial sole law_name -> exact-miss -> resolve -> re-scope to חוק חובת המכרזים, tagged
     res = store.search(context_name="reslaw", query_text="מהו חוק המכרזים",
                        search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
@@ -377,6 +407,7 @@ def test_unresolvable_law_name_falls_back_unfiltered(aurora_db_filter, database_
     cid = store.get_or_create_vector_store({"slug": "noreslaw"}, "noreslaw", False)
     emb = [1.0] * 1536
     _seed_law_doc(database_url, cid, "some law content", {"law_name": "חוק חובת המכרזים", "DocumentTitle": "חוק חובת המכרזים"}, emb)
+    _refresh_law_catalog(database_url)
     # a mention similar to NOTHING -> resolver returns None -> existing unfiltered fallback
     res = store.search(context_name="noreslaw", query_text="some law content",
                        search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -278,3 +278,51 @@ def test_recency_search_normalizes_law_name(aurora_db_filter, database_url, monk
     res = store.search(context_name="recctx", query_text="x", search_mode=recency, embedding=emb,
                        num_results=5, metadata_filter={"law_name": "חוק-יסוד: הכנסת"})
     assert res["hits"]["hits"], "RECENCY_BROWSE must match a normalized (maqaf/colon) law_name"
+
+
+def test_law_name_trgm_index_is_used(aurora_db_filter, database_url):
+    """Proves migration 0017 creates a usable GIN trigram index on law_name.
+
+    Primary assertion: pg_indexes confirms the index exists with gin_trgm_ops.
+    EXPLAIN assertion: with seqscan off and the competing B-tree norm index
+    temporarily dropped (it's a per-test DB, so safe), the GIN index is the
+    only path left for the trigram condition and must appear in the plan.
+    """
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+
+    # --- part 1: index DDL exists (primary proof) ---
+    with eng.begin() as c:
+        row = c.execute(text(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE tablename='documents' AND indexname='documents_law_name_trgm'"
+        )).fetchone()
+    assert row is not None, "migration 0017 did not create documents_law_name_trgm"
+    assert "gin_trgm_ops" in row[0], row[0]
+
+    # --- part 2: seed data ---
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'trgmctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "חוק האזנת סתר", "תקנון הכנסת"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "trgmh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+
+    # --- part 3: EXPLAIN after dropping competing B-tree index (safe: per-test DB) ---
+    # Drop documents_law_name_norm so it can't substitute for the trigram scan.
+    # Without seqscan and without a B-tree that covers metadata ? 'law_name',
+    # the planner's only index for the trigram condition is documents_law_name_trgm.
+    with eng.begin() as c:
+        c.execute(text("DROP INDEX IF EXISTS documents_law_name_norm"))
+    with eng.begin() as c:
+        c.execute(text("SET LOCAL enable_seqscan = off"))
+        c.execute(text("SET LOCAL pg_trgm.similarity_threshold = 0.3"))
+        plan = "\n".join(r[0] for r in c.execute(text(
+            "EXPLAIN SELECT metadata->>'law_name' FROM documents "
+            "WHERE metadata ? 'law_name' AND (metadata->>'law_name') % :m"),
+            {"m": "חוק המכרזים"}))
+    assert "documents_law_name_trgm" in plan, plan


### PR DESCRIPTION
Lands the full `israeli_laws` law-retrieval stack (43 commits, squash-merged), all validated on staging. Five workstreams, each spec'd → planned → implemented TDD → per-task + whole-branch reviewed:

**1. Law-book / israeli_laws consolidation** — Wikisource law-book ingestion, `israeli_laws` context, `legal_text` retired (single source), `law_name` metadata filtering.

**2. Scoped-first retrieval** — `_normalize_law_name` (maqaf/colon/gershayim parity), `_scoped_vector_knn` MATERIALIZED-CTE, scoped-first fork in `search()`, existence-gated sole-`law_name` fallback. Migration **0016** (normalized-law_name expression index).

**3. Law-name resolution** — colloquial/partial→formal law resolution (`_resolve_law_name` via pg_trgm), resolve-then-rescope on a scoped exact-miss, tool-description nudge. Migration **0017** (trigram index on `law_name`).

**4. Query-side law detection** — detect a legal-prefix span in an unfiltered query, resolve it, and re-scope (fixes "מהו חוק המכרזים?" → חוק חובת המכרזים without the model passing `law_name`). `law_name_catalog` matview + `_best_law_match` + `_detect_law_in_query`. Migrations **0018** (matview) and **0019** (matview owner→`botnim_app`). Fixes a stale-matview recursion in the gate_fired guard.

**5. Decision-complete retrieval** — for the interpretive corpora (ethics_decisions, legal_advisor_opinions/letters, house_committee_decisions), expand a retrieved chunk to the whole decision (same `DocumentTitle`), capped per-decision and by an aggregate budget. Fixes the bot reasoning from a fragment (row 2: ethics "not consecutive" qualifier).

**Staging validation (prod vs staging gold-set, LLM-judged):** row 10 fixed (חוק חובת המכרזים via query-side detection), row 2 fixed (לא from the complete ethics decision), no regressions; resolver ~60 ms (matview), decision expansion bounded ~9k tok.

**Prod-carry before a prod deploy:** migration 0018 needs `CREATE ON SCHEMA public` for the app role (or apply as master); 0019 reassigns matview ownership idempotently. Deferred follow-ups: on-point ranking, METADATA_BROWSE expansion guard, prompt-side source weighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
