### PR TITLE
fix(retrieve): named-law retrieval — dominance gate + filter-mismatch guard + prefix-less resolution

### DIFF
--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -159,6 +159,10 @@ def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD)
 _QUERY_DETECT_THRESHOLD = 0.55
 _QUERY_DETECT_DOMINANCE = 0.5  # the resolved law-name span must cover at least this fraction of the
                                 # query's content tokens; below it the prefix is incidental -> abstain
+_QUERY_RESOLVE_THRESHOLD = 0.5  # prefix-less fallback: when the query names no law with a legal
+                                # prefix but the model supplied a law_name filter, resolve the WHOLE
+                                # query against the catalog; override the filter only if the best law
+                                # match clears this (gold-set-tunable; topical queries score <=0.3).
 
 # Legal-title prefix tokens (an optional single leading letter — ה article, ל/ב/כ prepositions — is stripped before matching).
 _LEGAL_PREFIXES = frozenset({
@@ -893,49 +897,65 @@ class VectorStoreAurora(VectorStoreBase):
             )
             ctx_strategy = _LEXICAL_STRATEGY_TSQUERY
 
-        # Query-side law detection + filter-mismatch guard. Runs on EVERY israeli_laws vector
-        # search (not just unfiltered ones): detect the law the QUERY names (X) and compare it to
-        # the model's law_name filter (Y). Re-scope to X when the model left it unfiltered (existing
-        # behavior) OR supplied a CONTRADICTORY filter (norm(X) != norm(Y) — the guard); honor Y when
-        # it agrees with X or when X is None. `_qd_skip` on the re-entrant (already-scoped) call
-        # prevents re-detection. The dominance gate inside _detect_law_in_query is the safety
-        # precondition: X is set only when it dominates the query, so an incidental mention can't
-        # override a correct filter.
+        # Query-side law detection + filter-mismatch guard (with prefix-less resolution). Runs on
+        # EVERY israeli_laws vector search. Two ways to find the law the QUERY is about:
+        #   (1) prefix-anchored — _detect_law_in_query (dominance-gated): the law named with a legal
+        #       prefix (חוק/תקנון/…). Authoritative; used with or without a model filter.
+        #   (2) prefix-less — ONLY when (1) finds nothing AND the model supplied a law_name filter:
+        #       resolve the WHOLE query against the catalog (_best_law_match). Catches a topical
+        #       query that is really the law name minus its prefix (e.g. "מינוי מזכיר הכנסת").
+        # Re-scope to that law (the override) when the model left it unfiltered, or when its filter Y
+        # CONTRADICTS the found law (norm != norm); honor Y when it agrees or when no law is found.
+        # `_qd_skip` on the re-entrant call prevents re-detection. The dominance gate and the 0.5
+        # resolve threshold keep an incidental span or a weak match from overriding a correct filter.
         _q_law = (metadata_filter or {}).get("law_name")
         _q_law_norm = _normalize_law_name(str(_q_law)) if _q_law is not None else None
         if context_name == "israeli_laws" and use_vector and not _qd_skip:
+            detected = None
+            resolved = None  # prefix-less whole-query match; only computed when detected is None & filter present
             with get_session() as ds:
                 _drow = ds.execute(text(
                     "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
                 ), {"bot": bot, "name": context_name}).fetchone()
-                detected = (_detect_law_in_query(ds, str(_drow[0]), query_text,
-                                                 _QUERY_DETECT_THRESHOLD) if _drow else None)
+                if _drow:
+                    _cid = str(_drow[0])
+                    detected = _detect_law_in_query(ds, _cid, query_text, _QUERY_DETECT_THRESHOLD)
+                    if detected is None and _q_law_norm:
+                        m = _best_law_match(ds, _cid, query_text, _QUERY_RESOLVE_THRESHOLD)
+                        if m is not None and m[1] >= _QUERY_RESOLVE_THRESHOLD:
+                            resolved = m[0]
+            override = None
             if detected:
                 det_norm = _normalize_law_name(detected)
                 if not _q_law_norm:
                     # No (usable) model filter — query-side detection scopes to the named law.
                     logger.info("search query-detected: query=%r resolved=%r (%s, %s)",
                                 query_text, detected, bot, context_name)
-                    _rescope = True
+                    override = detected
                 elif det_norm != _q_law_norm:
-                    # MISMATCH GUARD: the model's law_name filter contradicts the law the query
-                    # names. A model guess must not hide the law the user asked about.
+                    # MISMATCH GUARD: the model's law_name filter contradicts the law the query names.
                     logger.warning("search filter-mismatch guard: query=%r names %r but model "
                                    "filter law_name=%r — overriding to query-named law (%s, %s)",
                                    query_text, detected, _q_law, bot, context_name)
-                    _rescope = True
-                else:
-                    _rescope = False  # filter agrees with the detected law — honor it
-                if _rescope:
-                    _new_filter = {k: v for k, v in (metadata_filter or {}).items()
-                                   if k != "law_name"}
-                    _new_filter["law_name"] = detected
-                    df = self.search(context_name, query_text, search_mode, embedding,
-                                     num_results=num_results, explain=explain,
-                                     metadata_filter=_new_filter, _qd_skip=True)
-                    for hit in df["hits"]["hits"]:
-                        hit.setdefault("_source", {}).setdefault("metadata", {})["_query_detected_law"] = detected
-                    return df
+                    override = detected
+                # else: filter agrees with the detected law — honor it (override stays None)
+            elif resolved is not None and _normalize_law_name(resolved) != _q_law_norm:
+                # PREFIX-LESS GUARD: the query has no legal prefix but resolves to a law that the
+                # model's filter contradicts (Variant 3 — topical query + filter-to-a-guessed-law).
+                logger.warning("search filter-mismatch guard (query-resolved): query=%r resolves to "
+                               "%r but model filter law_name=%r — overriding (%s, %s)",
+                               query_text, resolved, _q_law, bot, context_name)
+                override = resolved
+            if override is not None:
+                _new_filter = {k: v for k, v in (metadata_filter or {}).items()
+                               if k != "law_name"}
+                _new_filter["law_name"] = override
+                df = self.search(context_name, query_text, search_mode, embedding,
+                                 num_results=num_results, explain=explain,
+                                 metadata_filter=_new_filter, _qd_skip=True)
+                for hit in df["hits"]["hits"]:
+                    hit.setdefault("_source", {}).setdefault("metadata", {})["_query_detected_law"] = override
+                return df
 
         # Resolve context_id from (bot, name) — small extra round-trip but
         # keeps the search call self-contained and resilient to context

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -893,13 +893,17 @@ class VectorStoreAurora(VectorStoreBase):
             )
             ctx_strategy = _LEXICAL_STRATEGY_TSQUERY
 
-        # Query-side law detection: when the model leaves israeli_laws unfiltered but
-        # the query names a specific law, detect+resolve it and re-scope (independent of
-        # the model's tool-selection). israeli_laws-only; one level deep — the re-entrant
-        # call carries law_name, so has_law_name is True there and this block is skipped.
+        # Query-side law detection + filter-mismatch guard. Runs on EVERY israeli_laws vector
+        # search (not just unfiltered ones): detect the law the QUERY names (X) and compare it to
+        # the model's law_name filter (Y). Re-scope to X when the model left it unfiltered (existing
+        # behavior) OR supplied a CONTRADICTORY filter (norm(X) != norm(Y) — the guard); honor Y when
+        # it agrees with X or when X is None. `_qd_skip` on the re-entrant (already-scoped) call
+        # prevents re-detection. The dominance gate inside _detect_law_in_query is the safety
+        # precondition: X is set only when it dominates the query, so an incidental mention can't
+        # override a correct filter.
         _q_law = (metadata_filter or {}).get("law_name")
-        _q_no_law = _q_law is None or not _normalize_law_name(str(_q_law))
-        if _q_no_law and context_name == "israeli_laws" and use_vector and not _qd_skip:
+        _q_law_norm = _normalize_law_name(str(_q_law)) if _q_law is not None else None
+        if context_name == "israeli_laws" and use_vector and not _qd_skip:
             with get_session() as ds:
                 _drow = ds.execute(text(
                     "SELECT id FROM contexts WHERE bot=:bot AND name=:name"
@@ -907,14 +911,31 @@ class VectorStoreAurora(VectorStoreBase):
                 detected = (_detect_law_in_query(ds, str(_drow[0]), query_text,
                                                  _QUERY_DETECT_THRESHOLD) if _drow else None)
             if detected:
-                logger.info("search query-detected: query=%r resolved=%r (%s, %s)",
-                            query_text, detected, bot, context_name)
-                df = self.search(context_name, query_text, search_mode, embedding,
-                                 num_results=num_results, explain=explain,
-                                 metadata_filter={"law_name": detected})
-                for hit in df["hits"]["hits"]:
-                    hit.setdefault("_source", {}).setdefault("metadata", {})["_query_detected_law"] = detected
-                return df
+                det_norm = _normalize_law_name(detected)
+                if not _q_law_norm:
+                    # No (usable) model filter — query-side detection scopes to the named law.
+                    logger.info("search query-detected: query=%r resolved=%r (%s, %s)",
+                                query_text, detected, bot, context_name)
+                    _rescope = True
+                elif det_norm != _q_law_norm:
+                    # MISMATCH GUARD: the model's law_name filter contradicts the law the query
+                    # names. A model guess must not hide the law the user asked about.
+                    logger.warning("search filter-mismatch guard: query=%r names %r but model "
+                                   "filter law_name=%r — overriding to query-named law (%s, %s)",
+                                   query_text, detected, _q_law, bot, context_name)
+                    _rescope = True
+                else:
+                    _rescope = False  # filter agrees with the detected law — honor it
+                if _rescope:
+                    _new_filter = {k: v for k, v in (metadata_filter or {}).items()
+                                   if k != "law_name"}
+                    _new_filter["law_name"] = detected
+                    df = self.search(context_name, query_text, search_mode, embedding,
+                                     num_results=num_results, explain=explain,
+                                     metadata_filter=_new_filter, _qd_skip=True)
+                    for hit in df["hits"]["hits"]:
+                        hit.setdefault("_source", {}).setdefault("metadata", {})["_query_detected_law"] = detected
+                    return df
 
         # Resolve context_id from (bot, name) — small extra round-trip but
         # keeps the search call self-contained and resilient to context

--- a/botnim/vector_store/vector_store_aurora.py
+++ b/botnim/vector_store/vector_store_aurora.py
@@ -157,6 +157,8 @@ def _resolve_law_name(sess, cid, mention, threshold=_LAW_NAME_RESOLVE_THRESHOLD)
 
 
 _QUERY_DETECT_THRESHOLD = 0.55
+_QUERY_DETECT_DOMINANCE = 0.5  # the resolved law-name span must cover at least this fraction of the
+                                # query's content tokens; below it the prefix is incidental -> abstain
 
 # Legal-title prefix tokens (an optional single leading letter — ה article, ל/ב/כ prepositions — is stripped before matching).
 _LEGAL_PREFIXES = frozenset({
@@ -194,7 +196,7 @@ def _detect_law_in_query(sess, cid, query_text, threshold=_QUERY_DETECT_THRESHOL
         return None
     i = prefix_idxs[0]
 
-    best = None  # (law_name, score)
+    best = None  # (law_name, score, span_len)
     for k in (1, 2, 3):
         end = i + k
         if end >= len(toks):
@@ -205,10 +207,18 @@ def _detect_law_in_query(sess, cid, query_text, threshold=_QUERY_DETECT_THRESHOL
         span = " ".join(toks[i:end + 1])
         m = _best_law_match(sess, cid, span, threshold)
         if m is not None and m[1] >= threshold and (best is None or m[1] > best[1]):
-            best = m
+            best = (m[0], m[1], end - i + 1)
         if had_punct[end]:  # this token ended a sentence clause — stop extending
             break
-    return best[0] if best is not None else None
+    if best is None:
+        return None
+    # Dominance gate: an incidental legal-prefix span (e.g. a trailing "תקנון הכנסת" while the
+    # query's subject is elsewhere) must NOT hijack the scope. Require the span to cover a
+    # dominant share of the query's content tokens; else abstain -> the unfiltered topical search.
+    content_len = sum(1 for t in toks if t and t not in _SPAN_BOUNDARY)
+    if content_len and best[2] / content_len < _QUERY_DETECT_DOMINANCE:
+        return None
+    return best[0]
 
 
 _SCOPED_OVERRIDE_VECTOR_WEIGHT = 0.5

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -575,3 +575,34 @@ def test_stale_matview_punctuated_name_does_not_recurse(aurora_db_filter, databa
     hits = res["hits"]["hits"]
     assert all(h["_source"]["metadata"].get("_fallback_reason") == "law_name_absent" for h in hits)
     assert not any(h["_source"]["metadata"].get("_resolved_from") for h in hits)
+
+
+def _seed_three_laws_and_refresh(database_url):
+    from sqlalchemy import create_engine, text
+    eng = create_engine(database_url)
+    with eng.begin() as c:
+        cid = c.execute(text(
+            "INSERT INTO contexts (id, bot, name) VALUES (gen_random_uuid(), 'b', 'domctx') "
+            "ON CONFLICT (bot, name) DO UPDATE SET updated_at=now() RETURNING id")).scalar()
+        emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        for i, ln in enumerate(["חוק חובת המכרזים", "תקנון הכנסת", "חוק האזנת סתר"]):
+            c.execute(text(
+                "INSERT INTO documents (id, context_id, content, content_hash, metadata, embedding) "
+                "VALUES (gen_random_uuid(), :cid, 'x', :h, CAST(:m AS jsonb), CAST(:e AS vector))"),
+                {"cid": str(cid), "h": "domh%d" % i, "m": '{"law_name": "%s"}' % ln, "e": emb})
+    _refresh_law_catalog(database_url)
+    return str(cid)
+
+
+def test_detect_dominance_gate(aurora_db_filter, database_url):
+    from sqlalchemy import create_engine, text
+    from botnim.vector_store.vector_store_aurora import _detect_law_in_query, _QUERY_DETECT_THRESHOLD
+    cid = _seed_three_laws_and_refresh(database_url)
+    eng = create_engine(database_url)
+    with eng.connect() as c:
+        # dominant: span is the whole substantive query -> scope
+        assert _detect_law_in_query(c, cid, "מהו חוק המכרזים?", _QUERY_DETECT_THRESHOLD) == "חוק חובת המכרזים"
+        # INCIDENTAL trailing 'תקנון הכנסת' (the production failure) -> dominance 2/6 -> abstain
+        assert _detect_law_in_query(c, cid, "מזכיר הכנסת בחירה מינוי תקנון הכנסת", _QUERY_DETECT_THRESHOLD) is None
+        # law is the subject (dominance 3/6 = 0.5 >= 0.5) -> scope
+        assert _detect_law_in_query(c, cid, "האם חוק האזנת סתר חל על אזרחים?", _QUERY_DETECT_THRESHOLD) == "חוק האזנת סתר"

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -606,3 +606,75 @@ def test_detect_dominance_gate(aurora_db_filter, database_url):
         assert _detect_law_in_query(c, cid, "מזכיר הכנסת בחירה מינוי תקנון הכנסת", _QUERY_DETECT_THRESHOLD) is None
         # law is the subject (dominance 3/6 = 0.5 >= 0.5) -> scope
         assert _detect_law_in_query(c, cid, "האם חוק האזנת סתר חל על אזרחים?", _QUERY_DETECT_THRESHOLD) == "חוק האזנת סתר"
+
+
+def test_filter_mismatch_guard_rescopes(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "מינוי מזכיר הכנסת על ידי יושב ראש הכנסת",
+                  {"law_name": "חוק מינוי מזכיר הכנסת", "DocumentTitle": "חוק מינוי מזכיר הכנסת"}, emb)
+    _seed_law_doc(database_url, cid, "סדרי הדיון בוועדה",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _refresh_law_catalog(database_url)
+    # Model typed the law name but filtered to a DIFFERENT law -> guard overrides to query-named law.
+    res = store.search(context_name="israeli_laws", query_text="חוק מינוי מזכיר הכנסת",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "תקנון הכנסת"})
+    hits = res["hits"]["hits"]
+    assert hits, "guard should re-scope to the query-named law and return it"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק מינוי מזכיר הכנסת"}
+    assert hits[0]["_source"]["metadata"].get("_query_detected_law") == "חוק מינוי מזכיר הכנסת"
+
+
+def test_filter_honored_when_query_names_no_law(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "סעיף כלשהו בתקנון",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _seed_law_doc(database_url, cid, "חוק אחר כלשהו",
+                  {"law_name": "חוק האזנת סתר", "DocumentTitle": "חוק האזנת סתר"}, emb)
+    _refresh_law_catalog(database_url)
+    # Query names NO law (no legal-prefix token) -> detection returns None -> filter honored, no override.
+    res = store.search(context_name="israeli_laws", query_text="מזכיר הכנסת",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "תקנון הכנסת"})
+    hits = res["hits"]["hits"]
+    assert hits, "honored filter should still return the scoped law's docs"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"תקנון הכנסת"}
+    assert all("_query_detected_law" not in h["_source"]["metadata"] for h in hits)
+
+
+def test_filter_honored_when_matches_query_law(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "האזנת סתר חלה על אזרחים",
+                  {"law_name": "חוק האזנת סתר", "DocumentTitle": "חוק האזנת סתר"}, emb)
+    _seed_law_doc(database_url, cid, "סעיף בתקנון",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _refresh_law_catalog(database_url)
+    # Query names X and filter is the SAME law (X == Y) -> honored, NOT re-scoped (no _query_detected_law tag).
+    res = store.search(context_name="israeli_laws", query_text="חוק האזנת סתר",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק האזנת סתר"})
+    hits = res["hits"]["hits"]
+    assert hits
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק האזנת סתר"}
+    assert all("_query_detected_law" not in h["_source"]["metadata"] for h in hits)

--- a/tests/test_law_name_filter.py
+++ b/tests/test_law_name_filter.py
@@ -678,3 +678,78 @@ def test_filter_honored_when_matches_query_law(aurora_db_filter, database_url, m
     assert hits
     assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק האזנת סתר"}
     assert all("_query_detected_law" not in h["_source"]["metadata"] for h in hits)
+
+
+def test_filter_prefixless_resolves_and_overrides(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "מינוי מזכיר הכנסת על ידי יושב ראש הכנסת",
+                  {"law_name": "חוק מינוי מזכיר הכנסת", "DocumentTitle": "חוק מינוי מזכיר הכנסת"}, emb)
+    _seed_law_doc(database_url, cid, "סדרי הדיון בוועדה",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _refresh_law_catalog(database_url)
+    # Variant 3: query has NO legal-prefix token but IS the law name minus 'חוק'; model filtered to
+    # a different law -> whole-query resolution overrides to the query-named law.
+    res = store.search(context_name="israeli_laws", query_text="מינוי מזכיר הכנסת",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "תקנון הכנסת"})
+    hits = res["hits"]["hits"]
+    assert hits, "prefix-less resolution should re-scope to the query-named law and return it"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק מינוי מזכיר הכנסת"}
+    assert hits[0]["_source"]["metadata"].get("_query_detected_law") == "חוק מינוי מזכיר הכנסת"
+
+
+def test_filter_prefixless_honored_when_topical(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "סעיף כלשהו בתקנון",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _seed_law_doc(database_url, cid, "מינוי מזכיר הכנסת",
+                  {"law_name": "חוק מינוי מזכיר הכנסת", "DocumentTitle": "חוק מינוי מזכיר הכנסת"}, emb)
+    _refresh_law_catalog(database_url)
+    # A genuinely topical query that shares no trigrams with either seeded law name -> _best_law_match
+    # returns nothing >= 0.5 -> the model's filter is honored, no override.
+    res = store.search(context_name="israeli_laws", query_text="כמה עולה דלק היום",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "תקנון הכנסת"})
+    hits = res["hits"]["hits"]
+    assert hits, "honored filter should still return the scoped law's docs"
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"תקנון הכנסת"}
+    assert all("_query_detected_law" not in h["_source"]["metadata"] for h in hits)
+
+
+def test_filter_prefixless_honored_when_matches(aurora_db_filter, database_url, monkeypatch):
+    from botnim.vector_store.vector_store_aurora import VectorStoreAurora
+    from botnim.vector_store.search_modes import DEFAULT_SEARCH_MODE
+    monkeypatch.setattr("botnim.vector_store.vector_store_aurora._get_embedding_client",
+                        lambda env: _FakeEmbed())
+    store = VectorStoreAurora(config={"slug": "unified", "name": "Unified"},
+                              config_dir=".", environment="staging")
+    cid = store.get_or_create_vector_store({"slug": "israeli_laws"}, "israeli_laws", False)
+    emb = [1.0] * 1536
+    _seed_law_doc(database_url, cid, "מינוי מזכיר הכנסת",
+                  {"law_name": "חוק מינוי מזכיר הכנסת", "DocumentTitle": "חוק מינוי מזכיר הכנסת"}, emb)
+    _seed_law_doc(database_url, cid, "סעיף בתקנון",
+                  {"law_name": "תקנון הכנסת", "DocumentTitle": "תקנון הכנסת"}, emb)
+    _refresh_law_catalog(database_url)
+    # Prefix-less query resolves to X, and the model's filter IS that same law (X == Y) -> honored,
+    # no override and no _query_detected_law tag.
+    res = store.search(context_name="israeli_laws", query_text="מינוי מזכיר הכנסת",
+                       search_mode=DEFAULT_SEARCH_MODE, embedding=emb, num_results=5,
+                       metadata_filter={"law_name": "חוק מינוי מזכיר הכנסת"})
+    hits = res["hits"]["hits"]
+    assert hits
+    assert {h["_source"]["metadata"]["law_name"] for h in hits} == {"חוק מינוי מזכיר הכנסת"}
+    assert all("_query_detected_law" not in h["_source"]["metadata"] for h in hits)


### PR DESCRIPTION
Three composing server-side fixes to the `israeli_laws` retrieval path, all targeting one production bug: the bot wrongly claimed **`חוק מינוי מזכיר הכנסת` doesn't exist**. Root cause — the model scopes searches to its *guessed* law (`תקנון הכנסת`) in three distinct ways; each fix closes one. Each was built via TDD (per-task spec + quality review) and cleared a final whole-branch review.

| Commit | Fix | Closes |
|---|---|---|
| dominance gate | `_detect_law_in_query` abstains when the resolved law-name span covers < 0.5 of the query's content tokens | an *incidental* trailing legal-prefix (e.g. a query ending in `…תקנון הכנסת`) hijacking the scope |
| filter-mismatch guard | when the query text *names* law X (prefix-anchored, dominance-gated) but the model's `metadata_filter.law_name = Y ≠ X`, override to X | model types the law name but filters to a different law |
| prefix-less resolution | when the prefix path finds nothing **and** a `law_name` filter is present, resolve the whole query via `_best_law_match`; if it clears `_QUERY_RESOLVE_THRESHOLD=0.5` and contradicts Y, override | topical query (no `חוק` prefix) + filter-to-a-guessed-law — the actual reproduction |

**How they compose:** the dominance gate is the safety precondition — it bounds what `detected` (X) can be, so the mismatch guard only overrides on a *dominant* X (an incidental mention can never override a correct filter). The prefix-less path is gated on `detected is None`, mutually exclusive with the prefix path. All three feed a single `override` → one re-scope tail (recursion carries `_qd_skip=True`, so no path recurses more than once). Change is confined to `_detect_law_in_query` + the `search()` guard block in `botnim/vector_store/vector_store_aurora.py`; two new module-level constants. No new SQL/query, no `_best_law_match`/matview change, **no migration, no re-embed**.

**Thresholds** grounded in a staging measurement: `_QUERY_RESOLVE_THRESHOLD=0.5` sits in a wide gap — topical queries score ≤0.29 against the catalog, law-name-like queries ≥0.57.

**Tests:** 7 new tests in `tests/test_law_name_filter.py` (dominance gate; mismatch override / honored-no-law / honored-match; prefix-less override / honored-topical / honored-match), each distinguishing override (tag present) from honored (tag absent). Full file green in both orderings.

**Validated on staging (image built from this branch):**
- End-to-end UI: the `חוק מינוי מזכיר הכנסת` question now answers *"כן. קיים חוק מינוי מזכיר הכנסת, תשכ״ח–1968"* and quotes §1. CloudWatch confirms the model searched topically + filtered to `תקנון`, the prefix-less guard fired (`filter-mismatch guard (query-resolved)`), and the search re-scoped to the real law.
- Full prod-vs-staging gold-set (LLM-judged): no regression attributable to the fixes (the prefix-less guard fired exactly once in the window — on the bug query — and never on a gold-set row); my-fix rows (`חוק חובת המכרזים`, `חוק האזנת סתר`) are wins.

**Prod-carry:** these fixes are code-only and live on **staging** — a prod deploy is separate (the migrations `0018`/`0019` prod-carry from the prior `#196` stack still apply). Deferred follow-up: on-point ranking (a retrieval-ranking sensitivity within the takanon, orthogonal to these fixes — see the design docs on the parlibot side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
